### PR TITLE
Allows nominal classification for all field types

### DIFF
--- a/src/Util/RuleGeneratorUtil.ts
+++ b/src/Util/RuleGeneratorUtil.ts
@@ -41,20 +41,14 @@ class RuleGeneratorUtil {
 
   static getDistinctValues(data: Data, attributeName: string): any[] {
     let distinctValues: any[] = [];
-    const attributeType = _get(data, `schema.properties[${attributeName}].type`);
     const features = _get(data, 'exampleFeatures.features');
     if (features) {
-      if (attributeType === 'string') {
-        features.forEach((feature: any) => {
-          const value = _get(feature, `properties[${attributeName}]`);
-          if (value && !distinctValues.includes(value)) {
-            distinctValues.push(value);
-          }
-        });
-        return distinctValues;
-      }
-      // TODO Implement logic for others than string. Maybe we don't even want to
-      // allow this
+      features.forEach((feature: any) => {
+        const value = _get(feature, `properties[${attributeName}]`);
+        if (value && !distinctValues.includes(value)) {
+          distinctValues.push(value);
+        }
+      });
       return distinctValues;
     }
     return distinctValues;


### PR DESCRIPTION
This removes the restriction of allowing nominal classification only for string fields. Perhaps this does not always make sense (e.g. for measure values), but in case of e.g. numeric codes such as zip codes it might be useful.

@KaiVolland Please review.