### PR TITLE
Highlighting the rule that is currently being edited via the checkbox

### DIFF
--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -197,8 +197,10 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
     const {
       rowSelection
     } = this.props;
-    const onChange = rowSelection.onChange;
-    onChange([record.key], null);
+    if(typeof(rowSelection) != 'undefined' && rowSelection != null) {
+      const onChange = rowSelection.onChange;
+      onChange([record.key], null);
+    }
 
     this.setState({
       ruleEditIndex: record.key,

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -197,7 +197,7 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
     const {
       rowSelection
     } = this.props;
-    if(typeof(rowSelection) != 'undefined' && rowSelection != null) {
+    if (typeof(rowSelection) !== 'undefined' && rowSelection !== null) {
       const onChange = rowSelection.onChange;
       onChange([record.key], null);
     }
@@ -435,7 +435,7 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
     const {
       rowSelection
     } = this.props;
-    if(typeof(rowSelection) != 'undefined' && rowSelection != null) {
+    if (typeof(rowSelection) !== 'undefined' && rowSelection !== null) {
       const onChange = rowSelection.onChange;
       onChange([], null);
     }

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -435,8 +435,10 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
     const {
       rowSelection
     } = this.props;
-    const onChange = rowSelection.onChange;
-    onChange([], null);
+    if(typeof(rowSelection) != 'undefined' && rowSelection != null) {
+      const onChange = rowSelection.onChange;
+      onChange([], null);
+    }
 
     this.setState({
       symbolizerEditorVisible: false

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -194,6 +194,12 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
   }
 
   onSymbolizerClick = (record: RuleRecord, symbolizerEditorPosition: DOMRect) => {
+    const {
+      rowSelection
+    } = this.props;
+    const onChange = rowSelection.onChange;
+    onChange([record.key], null);
+
     this.setState({
       ruleEditIndex: record.key,
       symbolizerEditorVisible: true,
@@ -424,6 +430,12 @@ export class RuleTable extends React.Component<RuleTableProps, RuleTableState> {
   }
 
   onSymbolizerEditorWindowClose = () => {
+    const {
+      rowSelection
+    } = this.props;
+    const onChange = rowSelection.onChange;
+    onChange([], null);
+
     this.setState({
       symbolizerEditorVisible: false
     });


### PR DESCRIPTION
Handles the request from Issue #831 

When opening the SymbolyzerEditorWindow the current rule is marked via the checkbox and is removed again when closing it.

