### PR TITLE
Introduces PreviewMap component

### DIFF
--- a/src/Component/PreviewMap/PreviewMap.example.md
+++ b/src/Component/PreviewMap/PreviewMap.example.md
@@ -1,0 +1,43 @@
+This demonstrates the usage of the `PreviewMap` component.
+
+```jsx
+import * as React from 'react';
+import { PreviewMap } from 'geostyler';
+
+class PreviewMapExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      style: {
+        "name": "Demo Style",
+        "rules": [
+          {
+            "name": "Rule 1",
+            "symbolizers": [
+              {
+                "kind": "Mark",
+                "wellKnownName": "Circle"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+
+  render() {
+    const {
+      style
+    } = this.state;
+
+    return (
+      <PreviewMap
+        symbolizers={style}
+      />
+    );
+  }
+}
+
+<PreviewMapExample />
+```

--- a/src/Component/PreviewMap/PreviewMap.less
+++ b/src/Component/PreviewMap/PreviewMap.less
@@ -1,0 +1,5 @@
+.gs-symbolizer-previewmap {
+  position: relative;
+  border: 1px solid lightgrey;
+  border-radius: 4px;
+}

--- a/src/Component/PreviewMap/PreviewMap.spec.tsx
+++ b/src/Component/PreviewMap/PreviewMap.spec.tsx
@@ -1,0 +1,23 @@
+import { PreviewMap, PreviewMapProps } from './PreviewMap';
+import TestUtil from '../../Util/TestUtil';
+
+describe('PreviewMap', () => {
+
+  let wrapper: any;
+  const dummyStyle = TestUtil.getLineStyle();
+
+  beforeEach(() => {
+    const props: PreviewMapProps = {
+      style: dummyStyle
+    };
+    wrapper = TestUtil.shallowRenderComponent(PreviewMap, props);
+  });
+
+  it('is defined', () => {
+    expect(PreviewMap).toBeDefined();
+  });
+
+  it('renders correctly', () => {
+    expect(wrapper).not.toBeUndefined();
+  });
+});

--- a/src/Component/PreviewMap/PreviewMap.tsx
+++ b/src/Component/PreviewMap/PreviewMap.tsx
@@ -1,0 +1,250 @@
+import * as React from 'react';
+
+import OlMap from 'ol/Map';
+import OlLayerVector from 'ol/layer/Vector';
+import OlSourceVector from 'ol/source/Vector';
+import OlFormatGeoJSON from 'ol/format/GeoJSON';
+import OlGeomPoint from 'ol/geom/Point';
+import OlGeomLineString from 'ol/geom/LineString';
+import OlGeomPolygon from 'ol/geom/Polygon';
+import OlView from 'ol/View';
+import OlFeature from 'ol/Feature';
+import OlLayerTile from 'ol/layer/Tile';
+import OlSourceOSM from 'ol/source/OSM';
+
+import { Style } from 'geostyler-style';
+
+import './PreviewMap.less';
+
+import 'ol/ol.css';
+
+import OlStyleParser from 'geostyler-openlayers-parser';
+
+import { Data, VectorData } from 'geostyler-data';
+
+import { localize } from '../LocaleWrapper/LocaleWrapper';
+
+// default props
+export interface PreviewMapDefaultProps {
+  projection: string;
+  dataProjection: string;
+  showOsmBackground: boolean;
+  mapHeight: number;
+}
+
+// non default props
+export interface PreviewMapProps extends Partial<PreviewMapDefaultProps> {
+  data?: Data;
+  style: Style;
+  map?: any;
+  layers?: any[];
+  controls?: any[];
+  interactions?: any[];
+  onMapDidMount?: (map: any) => void;
+}
+
+/**
+ * Symbolizer preview UI.
+ */
+export class PreviewMap extends React.PureComponent<PreviewMapProps> {
+
+  /** Openlayers Style Parser instance */
+  _styleParser = new OlStyleParser();
+
+  /** reference to the underlying OpenLayers map */
+  map: any;
+
+  /** refrence to the vector layer for the passed in features  */
+  dataLayer: any;
+
+  /** id of the generated mapdiv */
+  _mapTargetId: string = `map_${Math.floor((1 + Math.random()) * 0x10000)}`;
+
+  public static defaultProps: PreviewMapDefaultProps = {
+    projection: 'EPSG:3857',
+    dataProjection: 'EPSG:4326',
+    showOsmBackground: true,
+    mapHeight: 267
+  };
+
+  static componentName: string = 'PreviewMap';
+
+  public componentDidUpdate() {
+    const {
+      style
+    } = this.props;
+
+    this._styleParser.writeStyle(style)
+      .then((olStyles: any) => {
+        this.dataLayer.setStyle(olStyles);
+      });
+    this.setFeatures();
+  }
+
+  public componentDidMount() {
+    const {
+      controls,
+      interactions,
+      layers,
+      onMapDidMount,
+      showOsmBackground,
+      style,
+      projection
+    } = this.props;
+
+    let map: any;
+    if (!this.props.map) {
+      // create a new OL map and bind it to this preview DIV
+      map = new OlMap({
+        layers: [],
+        controls: [],
+        interactions: [],
+        target: this._mapTargetId,
+        view: new OlView({
+          projection: projection
+        })
+      });
+    } else {
+      // use passed in OL map and bind it to this preview DIV
+      map = this.props.map;
+      map.setTarget(this._mapTargetId);
+    }
+
+    // show an OSM background layer if configured and no map was passed in
+    if (!this.props.map && showOsmBackground) {
+      const osmLayer = new OlLayerTile({
+        source: new OlSourceOSM()
+      });
+      map.addLayer(osmLayer);
+    }
+
+    // add configured OL control to map, when no map was passed in
+    if (!this.props.map && controls) {
+      this.props.controls.forEach((ctrl) => {
+        map.addControl(ctrl);
+      });
+    }
+
+    // add configured OL interaction to map, when no map was passed in
+    if (!this.props.map && interactions) {
+      this.props.interactions.forEach((iac) => {
+        map.addInteraction(iac);
+      });
+    }
+
+    // add configured additional layers
+    if (layers) {
+      layers.forEach((layer) => {
+        map.addLayer(layer);
+      });
+    }
+
+    const vectorLayer = new OlLayerVector({
+      source: new OlSourceVector()
+    });
+
+    map.addLayer(vectorLayer);
+    this.dataLayer = vectorLayer;
+
+    this._styleParser.writeStyle(style)
+      .then((olStyles: any) => {
+        this.dataLayer.setStyle(olStyles);
+      });
+
+    this.map = map;
+
+    if (onMapDidMount) {
+      onMapDidMount(map);
+    }
+
+    this.setFeatures();
+  }
+
+  setFeatures = () => {
+    const data = this.props.data as VectorData;
+
+    this.dataLayer.getSource().clear();
+    if (data && data.exampleFeatures) {
+      const format = new OlFormatGeoJSON({
+        defaultDataProjection: this.props.dataProjection,
+        featureProjection: this.map.getView().getProjection()
+      });
+      const olFeatures = format.readFeatures(data.exampleFeatures);
+      this.dataLayer.getSource().addFeatures(olFeatures);
+    } else {
+      const geoms = this.getSampleGeomFromStyle();
+      geoms.forEach((geometry: any) => {
+        const feature = new OlFeature({geometry});
+        this.dataLayer.getSource().addFeature(feature);
+      });
+    }
+    this.map.getView().fit(this.dataLayer.getSource().getExtent());
+  }
+
+  getSampleGeomFromStyle = () => {
+    const {
+      style
+    } = this.props;
+
+    const kinds: string[] = [];
+
+    style.rules.forEach(rule => {
+      rule.symbolizers.forEach(symbolizer => {
+        if (!kinds.includes(symbolizer.kind)) {
+          kinds.push(symbolizer.kind);
+        }
+      });
+    });
+
+    return kinds.map(kind => {
+      switch (kind) {
+        case 'Mark':
+        case 'Icon':
+        case 'Text':
+          return (new OlGeomPoint([7.10066, 50.735851]))
+            .transform('EPSG:4326', this.props.projection);
+        case 'Fill':
+          return (new OlGeomPolygon([[
+              [7.1031761169433585, 50.734268655851345],
+              [7.109270095825195, 50.734268655851345],
+              [7.109270095825195, 50.73824770380063],
+              [7.1031761169433585, 50.73824770380063],
+              [7.1031761169433585, 50.734268655851345]
+            ]]))
+              .transform('EPSG:4326', this.props.projection);
+        case 'Line':
+          return (new OlGeomLineString([
+            [7.062578201293945, 50.721786104206004],
+            [7.077512741088867, 50.729610159968296],
+            [7.082319259643555, 50.732435192351126],
+            [7.097940444946289, 50.73748722929948],
+            [7.106866836547852, 50.73775882875318],
+            [7.117509841918945, 50.73889952925885],
+            [7.129182815551758, 50.7504679214779]
+          ]))
+            .transform('EPSG:4326', this.props.projection);
+        default:
+          return (new OlGeomPoint([7.10066, 50.735851]))
+            .transform('EPSG:4326', this.props.projection);
+      }
+    });
+  }
+
+  render() {
+    const {
+      mapHeight,
+    } = this.props;
+
+    return (
+      <div
+        className="gs-symbolizer-previewmap map"
+        id={this._mapTargetId}
+        style={{
+          height: mapHeight
+        }}
+      />
+    );
+  }
+}
+
+export default localize(PreviewMap, PreviewMap.componentName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ import OffsetField from './Component/Symbolizer/Field/OffsetField/OffsetField';
 import OpacityField from './Component/Symbolizer/Field/OpacityField/OpacityField';
 import OperatorCombo from './Component/Filter/OperatorCombo/OperatorCombo';
 import Preview from './Component/Symbolizer/Preview/Preview';
+import PreviewMap from './Component/PreviewMap/PreviewMap';
 import PropTextEditor from './Component/Symbolizer/PropTextEditor/PropTextEditor';
 import RadiusField from './Component/Symbolizer/Field/RadiusField/RadiusField';
 import RasterChannelEditor from './Component/Symbolizer/RasterChannelEditor/RasterChannelEditor';
@@ -139,6 +140,7 @@ export {
   OpacityField,
   OperatorCombo,
   Preview,
+  PreviewMap,
   PropTextEditor,
   RadiusField,
   RasterChannelEditor,


### PR DESCRIPTION
This introduces the `PreviewMap` component.

Which shows the style on a map. The component works without GeoStlyer-Data but it is much more usefull when data is passed:

![localhost_3000_ (5)](https://user-images.githubusercontent.com/1849416/72355596-11f80180-36e8-11ea-930b-8041290f67bb.png)

