### PR TITLE
Add Legalese Info To CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -170,3 +170,44 @@ the maintainers will decide if it is more appropriate to:
 * merge your branch,
 * squash all commit into one commit, or
 * rebase (i.e., replay) all commits on top of the master branch.
+
+
+### Legalese
+Committers are the front line gatekeepers to keep the code base clear of improperly contributed code.
+It is important to the GeoStyler users, developers and the community to avoid contributing any
+code to the project without it being clearly licensed under the project license.
+
+Generally speaking the key issues are that those providing code to be included in the repository
+understand that the code will be released under the BSD-2-Clause license, and that the person providing
+the code has the right to contribute the code. For the committer themselves understanding about
+the license is hopefully clear. For other contributors, the committer should verify the understanding
+unless the committer is very comfortable that the contributor understands the license (for
+instance frequent contributors).
+
+If the contribution was developed on behalf of an employer (on work time, as part of a work project,
+etc) then it is important that an appropriate representative of the employer understand that the
+code will be contributed under the BSD-2-Clause license. The arrangement should be cleared with an
+authorized supervisor/manager, etc.
+
+The code should be developed by the contributor, or the code should be from a source which can be
+rightfully contributed such as from the public domain, or from an open source project under a
+compatible license.
+
+All unusual situations need to be discussed and/or documented.
+
+Committer should adhere to the following guidelines, and may be personally legally liable for
+improperly contributing code to the source repository:
+
+* Make sure the contributor (and possibly employer) is aware of the contribution terms.
+* Code coming from a source other than the contributor (such as adapted from another project)
+  should be clearly marked as to the original source, copyright holders, license terms and so forth.
+  This information can be in the file headers, but should also be added to the project licensing
+  file if not exactly matching normal project licensing (LICENSE.txt).
+* Existing copyright headers and license text should never be stripped from a file. If a copyright
+  holder wishes to give up copyright they must do so in writing to the project steering committee
+  before copyright messages are removed. If license terms are changed it has to be by agreement
+  (written in email is ok) of the copyright holders.
+* When substantial contributions are added to a file (such as substantial patches) the
+  author/contributor should be added to the list of copyright holders for the file.
+* If there is uncertainty about whether a change is proper to contribute to the code base, please
+  seek more information from the project steering committee.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,10 +204,10 @@ improperly contributing code to the source repository:
   This information can be in the file headers, but should also be added to the project licensing
   file if not exactly matching normal project licensing (LICENSE.txt).
 * Existing copyright headers and license text should never be stripped from a file. If a copyright
-  holder wishes to give up copyright they must do so in writing to the project steering committee
-  before copyright messages are removed. If license terms are changed it has to be by agreement
-  (written in email is ok) of the copyright holders.
+  holder wishes to give up copyright they must do so in writing to the project core team (@geostyler/core)
+  via reports@geostyler.org before copyright messages are removed. If license terms are changed it has to
+  be by agreement (written in email is ok) of the copyright holders.
 * When substantial contributions are added to a file (such as substantial patches) the
   author/contributor should be added to the list of copyright holders for the file.
 * If there is uncertainty about whether a change is proper to contribute to the code base, please
-  seek more information from the project steering committee.
+  seek more information from the project core team (@geostyler/core).


### PR DESCRIPTION
Adds a legalese section to CONTRIBUTING.md to indicate that any contributions will be open source.

Section was adapted from the [actinia project](https://github.com/mundialis/actinia_core/blob/27788176dc05b7b148cad7f10c2ead8add89c40a/CONTRIBUTING.md)