### PR TITLE
Remove greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ![GeoStyler Logo](/docs/Geo_Styler_Logo_300_RGB.jpg)
 
-[![Build Status](https://travis-ci.org/geostyler/geostyler.svg?branch=master)](https://travis-ci.org/geostyler/geostyler)
-[![Greenkeeper badge](https://badges.greenkeeper.io/geostyler/geostyler.svg)](https://greenkeeper.io/)
-[![Coverage Status](https://coveralls.io/repos/github/geostyler/geostyler/badge.svg?branch=master)](https://coveralls.io/github/geostyler/geostyler?branch=master)
+[![Build Status](https://travis-ci.org/geostyler/geostyler.svg?branch=master)](https://travis-ci.org/geostyler/geostyler) [![Coverage Status](https://coveralls.io/repos/github/geostyler/geostyler/badge.svg?branch=master)](https://coveralls.io/github/geostyler/geostyler?branch=master)
 
 Code: [github](https://github.com/geostyler/geostyler)
 Package: [npm](https://www.npmjs.com/package/geostyler)


### PR DESCRIPTION
The title says it all; we no longer (can) use Greenkeeper, and the badge is broken anyhow.

A follow-up would be to have a dependabot badge there instead.