### PR TITLE
Include GeoStyler contributors in copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2018, terrestris GmbH & Co. KG
+Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/config/paths.js
+++ b/config/paths.js
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jest/cssTransform.js
+++ b/jest/cssTransform.js
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/jest/setup.js
+++ b/jest/setup.js
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/CodeEditor/CodeEditor.less
+++ b/src/Component/CodeEditor/CodeEditor.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/CodeEditor/CodeEditor.spec.tsx
+++ b/src/Component/CodeEditor/CodeEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/CompositionContext/CompositionContext.example.md
+++ b/src/Component/CompositionContext/CompositionContext.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/CompositionContext/CompositionContext.tsx
+++ b/src/Component/CompositionContext/CompositionContext.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/DataInput/DataLoader/DataLoader.spec.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/DataInput/DataLoader/DataLoader.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/DataInput/StyleLoader/StyleLoader.spec.tsx
+++ b/src/Component/DataInput/StyleLoader/StyleLoader.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/DataInput/StyleLoader/StyleLoader.tsx
+++ b/src/Component/DataInput/StyleLoader/StyleLoader.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/DataInput/WfsParserInput/WfsParserInput.less
+++ b/src/Component/DataInput/WfsParserInput/WfsParserInput.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/DataInput/WfsParserInput/WfsParserInput.spec.tsx
+++ b/src/Component/DataInput/WfsParserInput/WfsParserInput.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
+++ b/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/FieldSet/FieldSet.less
+++ b/src/Component/FieldSet/FieldSet.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/FieldSet/FieldSet.spec.tsx
+++ b/src/Component/FieldSet/FieldSet.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/FieldSet/FieldSet.tsx
+++ b/src/Component/FieldSet/FieldSet.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.spec.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/BoolFilterField/BoolFilterField.spec.tsx
+++ b/src/Component/Filter/BoolFilterField/BoolFilterField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
+++ b/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.less
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.spec.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.less
+++ b/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
+++ b/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/FilterEditorWindow/FilterWindow.spec.tsx
+++ b/src/Component/Filter/FilterEditorWindow/FilterWindow.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/FilterTree/FilterTree.less
+++ b/src/Component/Filter/FilterTree/FilterTree.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/FilterTree/FilterTree.spec.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.spec.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.spec.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/LocaleWrapper/LocaleWrapper.spec.tsx
+++ b/src/Component/LocaleWrapper/LocaleWrapper.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/LocaleWrapper/LocaleWrapper.tsx
+++ b/src/Component/LocaleWrapper/LocaleWrapper.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/NameField/NameField.less
+++ b/src/Component/NameField/NameField.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/NameField/NameField.spec.tsx
+++ b/src/Component/NameField/NameField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/NameField/NameField.tsx
+++ b/src/Component/NameField/NameField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/PreviewMap/PreviewMap.example.md
+++ b/src/Component/PreviewMap/PreviewMap.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/PreviewMap/PreviewMap.less
+++ b/src/Component/PreviewMap/PreviewMap.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/PreviewMap/PreviewMap.spec.tsx
+++ b/src/Component/PreviewMap/PreviewMap.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/PreviewMap/PreviewMap.tsx
+++ b/src/Component/PreviewMap/PreviewMap.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Rule/RemoveButton/RemoveButton.less
+++ b/src/Component/Rule/RemoveButton/RemoveButton.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Rule/RemoveButton/RemoveButton.spec.tsx
+++ b/src/Component/Rule/RemoveButton/RemoveButton.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Rule/RemoveButton/RemoveButton.tsx
+++ b/src/Component/Rule/RemoveButton/RemoveButton.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Rule/Rule.less
+++ b/src/Component/Rule/Rule.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Rule/Rule.spec.tsx
+++ b/src/Component/Rule/Rule.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Rule/TitleField/TitleField.less
+++ b/src/Component/Rule/TitleField/TitleField.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Rule/TitleField/TitleField.spec.tsx
+++ b/src/Component/Rule/TitleField/TitleField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Rule/TitleField/TitleField.tsx
+++ b/src/Component/Rule/TitleField/TitleField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.spec.tsx
+++ b/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.tsx
+++ b/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.less
+++ b/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.spec.tsx
+++ b/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.tsx
+++ b/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/ColorSpaceCombo/ColorSpaceCombo.spec.tsx
+++ b/src/Component/RuleGenerator/ColorSpaceCombo/ColorSpaceCombo.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/ColorSpaceCombo/ColorSpaceCombo.tsx
+++ b/src/Component/RuleGenerator/ColorSpaceCombo/ColorSpaceCombo.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.less
+++ b/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.spec.tsx
+++ b/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.tsx
+++ b/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/RuleGenerator.example.md
+++ b/src/Component/RuleGenerator/RuleGenerator.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/RuleGenerator.less
+++ b/src/Component/RuleGenerator/RuleGenerator.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/RuleGenerator.spec.tsx
+++ b/src/Component/RuleGenerator/RuleGenerator.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/RuleGenerator.tsx
+++ b/src/Component/RuleGenerator/RuleGenerator.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/RuleGeneratorWindow.less
+++ b/src/Component/RuleGenerator/RuleGeneratorWindow.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/RuleGeneratorWindow.spec.tsx
+++ b/src/Component/RuleGenerator/RuleGeneratorWindow.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
+++ b/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.spec.tsx
+++ b/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.tsx
+++ b/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleTable/RuleTable.example.md
+++ b/src/Component/RuleTable/RuleTable.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleTable/RuleTable.less
+++ b/src/Component/RuleTable/RuleTable.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleTable/RuleTable.spec.tsx
+++ b/src/Component/RuleTable/RuleTable.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/ScaleDenominator/MaxScaleDenominator.less
+++ b/src/Component/ScaleDenominator/MaxScaleDenominator.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/ScaleDenominator/MaxScaleDenominator.spec.tsx
+++ b/src/Component/ScaleDenominator/MaxScaleDenominator.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/ScaleDenominator/MaxScaleDenominator.tsx
+++ b/src/Component/ScaleDenominator/MaxScaleDenominator.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/ScaleDenominator/MinScaleDenominator.less
+++ b/src/Component/ScaleDenominator/MinScaleDenominator.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/ScaleDenominator/MinScaleDenominator.spec.tsx
+++ b/src/Component/ScaleDenominator/MinScaleDenominator.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/ScaleDenominator/MinScaleDenominator.tsx
+++ b/src/Component/ScaleDenominator/MinScaleDenominator.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/ScaleDenominator/ScaleDenominator.spec.tsx
+++ b/src/Component/ScaleDenominator/ScaleDenominator.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/ScaleDenominator/ScaleDenominator.tsx
+++ b/src/Component/ScaleDenominator/ScaleDenominator.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Style/Style.example.md
+++ b/src/Component/Style/Style.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Style/Style.less
+++ b/src/Component/Style/Style.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Style/Style.spec.tsx
+++ b/src/Component/Style/Style.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/BulkEditModals/BulkEditModals.less
+++ b/src/Component/Symbolizer/BulkEditModals/BulkEditModals.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/BulkEditModals/BulkEditModals.spec.tsx
+++ b/src/Component/Symbolizer/BulkEditModals/BulkEditModals.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
+++ b/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.less
+++ b/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.spec.tsx
+++ b/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
+++ b/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Editor/Editor.example.md
+++ b/src/Component/Symbolizer/Editor/Editor.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Editor/Editor.less
+++ b/src/Component/Symbolizer/Editor/Editor.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Editor/Editor.spec.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.example.md
+++ b/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.spec.tsx
+++ b/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.tsx
+++ b/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ChannelField/ChannelField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ChannelField/ChannelField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
+++ b/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ChannelSelectionField/ChannelSelectionField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ChannelSelectionField/ChannelSelectionField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ChannelSelectionField/ChannelSelectionField.tsx
+++ b/src/Component/Symbolizer/Field/ChannelSelectionField/ChannelSelectionField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.example.md
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.less
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.tsx
+++ b/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ColorMapTypeField/ColorMapTypeField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ColorMapTypeField/ColorMapTypeField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ColorMapTypeField/ColorMapTypeField.tsx
+++ b/src/Component/Symbolizer/Field/ColorMapTypeField/ColorMapTypeField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ContrastEnhancementField/ContrastEnhancementField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ContrastEnhancementField/ContrastEnhancementField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ContrastEnhancementField/ContrastEnhancementField.tsx
+++ b/src/Component/Symbolizer/Field/ContrastEnhancementField/ContrastEnhancementField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ContrastField/ContrastField.example.md
+++ b/src/Component/Symbolizer/Field/ContrastField/ContrastField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ContrastField/ContrastField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ContrastField/ContrastField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ContrastField/ContrastField.tsx
+++ b/src/Component/Symbolizer/Field/ContrastField/ContrastField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ExtendedField/ExtendedField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ExtendedField/ExtendedField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ExtendedField/ExtendedField.tsx
+++ b/src/Component/Symbolizer/Field/ExtendedField/ExtendedField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.example.md
+++ b/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.spec.tsx
+++ b/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.tsx
+++ b/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/FontPicker/FontPicker.example.md
+++ b/src/Component/Symbolizer/Field/FontPicker/FontPicker.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/FontPicker/FontPicker.spec.tsx
+++ b/src/Component/Symbolizer/Field/FontPicker/FontPicker.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
+++ b/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/GammaField/GammaField.example.md
+++ b/src/Component/Symbolizer/Field/GammaField/GammaField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/GammaField/GammaField.spec.tsx
+++ b/src/Component/Symbolizer/Field/GammaField/GammaField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/GammaField/GammaField.tsx
+++ b/src/Component/Symbolizer/Field/GammaField/GammaField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.example.md
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.spec.tsx
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.spec.tsx
+++ b/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.tsx
+++ b/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.example.md
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.less
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/KindField/KindField.example.md
+++ b/src/Component/Symbolizer/Field/KindField/KindField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/KindField/KindField.spec.tsx
+++ b/src/Component/Symbolizer/Field/KindField/KindField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/KindField/KindField.tsx
+++ b/src/Component/Symbolizer/Field/KindField/KindField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/LineCapField/LineCapField.example.md
+++ b/src/Component/Symbolizer/Field/LineCapField/LineCapField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/LineCapField/LineCapField.spec.tsx
+++ b/src/Component/Symbolizer/Field/LineCapField/LineCapField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/LineCapField/LineCapField.tsx
+++ b/src/Component/Symbolizer/Field/LineCapField/LineCapField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/LineDashField/LineDashField.example.md
+++ b/src/Component/Symbolizer/Field/LineDashField/LineDashField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/LineDashField/LineDashField.less
+++ b/src/Component/Symbolizer/Field/LineDashField/LineDashField.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/LineDashField/LineDashField.spec.tsx
+++ b/src/Component/Symbolizer/Field/LineDashField/LineDashField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/LineDashField/LineDashField.tsx
+++ b/src/Component/Symbolizer/Field/LineDashField/LineDashField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.example.md
+++ b/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.spec.tsx
+++ b/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.tsx
+++ b/src/Component/Symbolizer/Field/LineJoinField/LineJoinField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.example.md
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.spec.tsx
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/OpacityField/OpacityField.example.md
+++ b/src/Component/Symbolizer/Field/OpacityField/OpacityField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/OpacityField/OpacityField.spec.tsx
+++ b/src/Component/Symbolizer/Field/OpacityField/OpacityField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
+++ b/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/RadiusField/RadiusField.example.md
+++ b/src/Component/Symbolizer/Field/RadiusField/RadiusField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/RadiusField/RadiusField.spec.tsx
+++ b/src/Component/Symbolizer/Field/RadiusField/RadiusField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
+++ b/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.example.md
+++ b/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.tsx
+++ b/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.spec.tsx
+++ b/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.tsx
+++ b/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/RotateField/RotateField.example.md
+++ b/src/Component/Symbolizer/Field/RotateField/RotateField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/RotateField/RotateField.spec.tsx
+++ b/src/Component/Symbolizer/Field/RotateField/RotateField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
+++ b/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/SaturationField/SaturationField.example.md
+++ b/src/Component/Symbolizer/Field/SaturationField/SaturationField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/SaturationField/SaturationField.spec.tsx
+++ b/src/Component/Symbolizer/Field/SaturationField/SaturationField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/SaturationField/SaturationField.tsx
+++ b/src/Component/Symbolizer/Field/SaturationField/SaturationField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/SizeField/SizeField.example.md
+++ b/src/Component/Symbolizer/Field/SizeField/SizeField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/SizeField/SizeField.spec.tsx
+++ b/src/Component/Symbolizer/Field/SizeField/SizeField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/SizeField/SizeField.tsx
+++ b/src/Component/Symbolizer/Field/SizeField/SizeField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/SourceChannelNameField/SourceChannelNameField.spec.tsx
+++ b/src/Component/Symbolizer/Field/SourceChannelNameField/SourceChannelNameField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/SourceChannelNameField/SourceChannelNameField.tsx
+++ b/src/Component/Symbolizer/Field/SourceChannelNameField/SourceChannelNameField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.example.md
+++ b/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.spec.tsx
+++ b/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
+++ b/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/WidthField/WidthField.example.md
+++ b/src/Component/Symbolizer/Field/WidthField/WidthField.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/WidthField/WidthField.spec.tsx
+++ b/src/Component/Symbolizer/Field/WidthField/WidthField.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Field/WidthField/WidthField.tsx
+++ b/src/Component/Symbolizer/Field/WidthField/WidthField.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/FillEditor/FillEditor.example.md
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/FillEditor/FillEditor.spec.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.example.md
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.spec.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/IconEditor/IconEditor.example.md
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/IconEditor/IconEditor.spec.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/IconSelector/IconSelector.less
+++ b/src/Component/Symbolizer/IconSelector/IconSelector.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/IconSelector/IconSelector.spec.tsx
+++ b/src/Component/Symbolizer/IconSelector/IconSelector.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/IconSelector/IconSelector.tsx
+++ b/src/Component/Symbolizer/IconSelector/IconSelector.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.less
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.spec.tsx
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/LineEditor/LineEditor.example.md
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/LineEditor/LineEditor.spec.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.example.md
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.spec.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.example.md
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.less
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.spec.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Preview/Preview.example.md
+++ b/src/Component/Symbolizer/Preview/Preview.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Preview/Preview.less
+++ b/src/Component/Symbolizer/Preview/Preview.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Preview/Preview.spec.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.example.md
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.less
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.spec.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.spec.tsx
+++ b/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
+++ b/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.example.md
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.less
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.spec.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Renderer/Renderer.example.md
+++ b/src/Component/Symbolizer/Renderer/Renderer.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Renderer/Renderer.less
+++ b/src/Component/Symbolizer/Renderer/Renderer.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Renderer/Renderer.spec.tsx
+++ b/src/Component/Symbolizer/Renderer/Renderer.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/Renderer/Renderer.tsx
+++ b/src/Component/Symbolizer/Renderer/Renderer.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/SLDRenderer/LoadingIcon.ts
+++ b/src/Component/Symbolizer/SLDRenderer/LoadingIcon.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/SLDRenderer/SLDRenderer.less
+++ b/src/Component/Symbolizer/SLDRenderer/SLDRenderer.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/SLDRenderer/SLDRenderer.spec.tsx
+++ b/src/Component/Symbolizer/SLDRenderer/SLDRenderer.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/SLDRenderer/SLDRenderer.tsx
+++ b/src/Component/Symbolizer/SLDRenderer/SLDRenderer.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.example.md
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.less
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.spec.tsx
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/TextEditor/TextEditor.example.md
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/TextEditor/TextEditor.less
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.less
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/TextEditor/TextEditor.spec.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.example.md
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.spec.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/UploadButton/UploadButton.spec.tsx
+++ b/src/Component/UploadButton/UploadButton.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Component/UploadButton/UploadButton.tsx
+++ b/src/Component/UploadButton/UploadButton.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/DataProvider/DataProvider.spec.ts
+++ b/src/DataProvider/DataProvider.spec.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/DataProvider/DataProvider.ts
+++ b/src/DataProvider/DataProvider.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/DataProvider/ParserDesc.ts
+++ b/src/DataProvider/ParserDesc.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/CompositionUtil.spec.tsx
+++ b/src/Util/CompositionUtil.spec.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/CompositionUtil.ts
+++ b/src/Util/CompositionUtil.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/DataUtil.ts
+++ b/src/Util/DataUtil.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/FilterUtil.spec.ts
+++ b/src/Util/FilterUtil.spec.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/FilterUtil.ts
+++ b/src/Util/FilterUtil.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/HTTPUtil.spec.ts
+++ b/src/Util/HTTPUtil.spec.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/HTTPUtil.ts
+++ b/src/Util/HTTPUtil.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/RasterUtil.ts
+++ b/src/Util/RasterUtil.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/RuleGeneratorUtil.spec.ts
+++ b/src/Util/RuleGeneratorUtil.spec.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/RuleGeneratorUtil.ts
+++ b/src/Util/RuleGeneratorUtil.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/SymbolizerUtil.spec.ts
+++ b/src/Util/SymbolizerUtil.spec.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/SymbolizerUtil.ts
+++ b/src/Util/SymbolizerUtil.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/TestUtil.tsx
+++ b/src/Util/TestUtil.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/transform-less.js
+++ b/transform-less.js
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright (c) 2018-present, terrestris GmbH & Co. KG
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
As discussed on the Incubator mailinglist, this changes

`Copyright (c) 2018-present, terrestris GmbH & Co. KG` 

to

`Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors`

in all files. Please note the copyright-sign `©` so the line isn't longer than 80 characters.

Please review. 