### PR TITLE
Simplify formatLine method

### DIFF
--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
@@ -95,10 +95,8 @@ export class PropTextEditor extends React.Component<PropTextEditorProps> {
   }
 
   formatLabel = (label: string): string => {
-    const prefix = '\\{\\{';
-    const suffix = '\\}\\}';
-    const regExp = new RegExp(prefix + '.*' + suffix, 'g');
-    return label.replace(regExp, (match: string) => match.slice(2, match.length - 2));
+    const regExp: RegExp = /\{\{(.*)\}\}/g;
+    return label.replace(regExp, '$1');
   }
 
   onLabelChange = (newAttrName: string) => {


### PR DESCRIPTION
## Description

See also #1267, the new approach does not use `new RegExp()` and looks
simpler to my eye. Please review. 

## Releated issues or pull requests

Fixes #1267

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
