### PR TITLE
Collect coverage for ts-files of DataProvider

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -29,7 +29,7 @@
 module.exports = {
   "collectCoverageFrom": [
     "src/Component/**/*.{tsx,jsx}",
-    "src/DataProvider/**/*.{tsx,jsx}",
+    "src/DataProvider/**/*.{ts,tsx,jsx}",
     "src/Util/**/*.{ts,js}"
   ],
   "setupFilesAfterEnv": [


### PR DESCRIPTION
## Description

This PR suggests to collect overage from the `DataProvider` as well. I think it is fair to assume the current configuration an oversight / bug.

## Releated issues or pull requests

*none*

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): tests / coverage
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
