### PR TITLE
Use dataProjection in GeoJson Parser

### DIFF
--- a/src/Component/PreviewMap/PreviewMap.tsx
+++ b/src/Component/PreviewMap/PreviewMap.tsx
@@ -194,7 +194,7 @@ export class PreviewMap extends React.PureComponent<PreviewMapProps> {
     this.dataLayer.getSource().clear();
     if (data && data.exampleFeatures) {
       const format = new OlFormatGeoJSON({
-        defaultDataProjection: this.props.dataProjection,
+        dataProjection: this.props.dataProjection,
         featureProjection: this.map.getView().getProjection()
       });
       const olFeatures = format.readFeatures(data.exampleFeatures);


### PR DESCRIPTION
## Description

The code for the preview map uses a renamed option for the openlayers geojson format. The option `defaultDataProjection` is now `dataProjection`. See https://openlayers.org/en/v6.4.3/apidoc/module-ol_format_GeoJSON-GeoJSON.html

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
