### PR TITLE
Sets color picker to fixed position

### DIFF
--- a/src/Component/Symbolizer/Field/ColorField/ColorField.less
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.less
@@ -27,7 +27,7 @@
  */
 
 .sketch-picker {
-  position: absolute;
+  position: fixed;
   z-index: 200;
 }
 


### PR DESCRIPTION
## Description

In the context of a project I came across the following problem when using GeoStyler:
Color pickers in the "Symbolizer Editor" are not displayed completely, especially if single components of the editor are hidden or in almost any display of the color picker for stroke color settings:

![cp_hidden](https://user-images.githubusercontent.com/43119593/100897503-09571800-34c0-11eb-9747-be3dc1d4719b.png)

By changing the CSS property of the position the color picker becomes accessible again at least for the user:

![cp_fixed](https://user-images.githubusercontent.com/43119593/100897759-54712b00-34c0-11eb-842b-bdc7de68792f.png)

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
