### PR TITLE
Add PreviewMap to Docs

### DIFF
--- a/src/Component/PreviewMap/PreviewMap.example.md
+++ b/src/Component/PreviewMap/PreviewMap.example.md
@@ -63,7 +63,7 @@ class PreviewMapExample extends React.Component {
 
     return (
       <PreviewMap
-        symbolizers={style}
+        style={style}
       />
     );
   }

--- a/src/Component/PreviewMap/PreviewMap.tsx
+++ b/src/Component/PreviewMap/PreviewMap.tsx
@@ -58,7 +58,7 @@ export interface PreviewMapDefaultProps {
   projection: string;
   /** The projection of the data to visualize */
   dataProjection: string;
-  /** Wheter an OSM basemap should be shown */
+  /** Whether an OSM basemap should be shown */
   showOsmBackground: boolean;
   /** The height of the map */
   mapHeight: number;

--- a/src/Component/PreviewMap/PreviewMap.tsx
+++ b/src/Component/PreviewMap/PreviewMap.tsx
@@ -54,25 +54,36 @@ import { localize } from '../LocaleWrapper/LocaleWrapper';
 
 // default props
 export interface PreviewMapDefaultProps {
+  /** The projection of the PreviewMap */
   projection: string;
+  /** The projection of the data to visualize */
   dataProjection: string;
+  /** Wheter an OSM basemap should be shown */
   showOsmBackground: boolean;
+  /** The height of the map */
   mapHeight: number;
 }
 
 // non default props
 export interface PreviewMapProps extends Partial<PreviewMapDefaultProps> {
+  /** The data to visualize */
   data?: Data;
+  /** The GeoStyler Style to preview */
   style: Style;
+  /** A custom map used for rendering */
   map?: any;
+  /** A list of layers to add to the map */
   layers?: any[];
+  /** A list of OpenLayers controls to add to the map */
   controls?: any[];
+  /** A list of OpenLayers interactions to add to the map */
   interactions?: any[];
+  /** Callback method that is triggered, when the map is mounted */
   onMapDidMount?: (map: any) => void;
 }
 
 /**
- * Symbolizer preview UI.
+ * Style preview UI.
  */
 export class PreviewMap extends React.PureComponent<PreviewMapProps> {
 

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -101,6 +101,9 @@ module.exports = {
     }, {
       name: 'UploadButton',
       components: 'src/Component/UploadButton/**/*.tsx'
+    }, {
+      name: 'PreviewMap',
+      components: 'src/Component/PreviewMap/**/*.tsx'
     }],
     sectionDepth: 2
   }, {


### PR DESCRIPTION
## Description

This adds the `PreviewMap` component to the docs.

## Releated issues or pull requests

Part of https://github.com/geostyler/geostyler/issues/1172

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
