### PR TITLE
Pass icon nodes to the button icon prop

### DIFF
--- a/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
+++ b/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
@@ -35,6 +35,8 @@ import { VectorData } from 'geostyler-data';
 import './FilterEditorWindow.less';
 import { Button } from 'antd';
 
+import { CloseOutlined } from '@ant-design/icons';
+
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 import { Filter } from 'geostyler-style';
@@ -125,7 +127,7 @@ export class FilterEditorWindow extends React.Component<FilterEditorWindowProps>
               {locale.filterEditor}
             </span>
             <Button
-              icon="close"
+              icon={<CloseOutlined />}
               size="small"
               onClick={onClose}
             />

--- a/src/Component/Rule/RemoveButton/RemoveButton.tsx
+++ b/src/Component/Rule/RemoveButton/RemoveButton.tsx
@@ -29,6 +29,8 @@
 import * as React from 'react';
 import { Button } from 'antd';
 
+import { CloseCircleOutlined } from '@ant-design/icons';
+
 import './RemoveButton.less';
 
 // default props
@@ -59,7 +61,7 @@ export class RemoveButton extends React.Component<RemoveButtonProps> {
       <div className="gs-rule-removebutton" >
         <Button
           danger={true}
-          icon="close-circle-o"
+          icon={<CloseCircleOutlined />}
           size="large"
           onClick={() => this.props.onClick(this.props.ruleIdx)}
         > {this.props.text}

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -31,6 +31,9 @@ import * as React from 'react';
 import {
   Button
 } from 'antd';
+
+import { CloseCircleOutlined } from '@ant-design/icons';
+
 import {
   ComparisonFilter as GsComparisonFilter,
   Rule as GsRule,
@@ -380,7 +383,7 @@ export class Rule extends React.Component<RuleProps, RuleState> {
         <Button
           className="gs-rule-remove-button"
           danger={true}
-          icon="close-circle-o"
+          icon={<CloseCircleOutlined />}
           size="large"
           onClick={this.onRemoveButtonClick}
         >

--- a/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
+++ b/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
@@ -41,6 +41,8 @@ import { Data } from 'geostyler-data';
 import './RuleGeneratorWindow.less';
 import { Button } from 'antd';
 
+import { CloseOutlined } from '@ant-design/icons';
+
 import { localize } from '../LocaleWrapper/LocaleWrapper';
 import en_US from '../../locale/en_US';
 import RuleGenerator from './RuleGenerator';
@@ -132,7 +134,7 @@ export class RuleGeneratorWindow extends React.Component<RuleGeneratorWindowProp
               {locale.ruleGenerator}
             </span>
             <Button
-              icon="close"
+              icon={<CloseOutlined />}
               size="small"
               onClick={onClose}
             />

--- a/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.tsx
+++ b/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.tsx
@@ -35,6 +35,7 @@ import {
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
+import { UpOutlined, DownOutlined } from '@ant-design/icons';
 
 const ButtonGroup = Button.Group;
 const _cloneDeep = require('lodash/cloneDeep');
@@ -97,14 +98,16 @@ export class RuleReorderButtons extends React.Component<RuleReorderButtonsProps>
 
     return (
       <ButtonGroup>
-        <Button icon="up"
+        <Button
+          icon={<UpOutlined />}
           disabled={ruleIndex === 0}
           title={locale.ruleMoveUpTip}
           onClick={() => {
             this.onRuleOrderChange(false);
           }}
         />
-        <Button icon="down"
+        <Button
+          icon={<DownOutlined />}
           disabled={ruleIndex === rules.length - 1}
           title={locale.ruleMoveDownTip}
           onClick={() => {

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -611,7 +611,7 @@ export class Style extends React.Component<StyleProps, StyleState> {
           compact ? null :
           <Button
             style={{'marginBottom': '20px', 'marginTop': '20px'}}
-            icon="plus"
+            icon={<PlusOutlined />}
             size="large"
             onClick={this.addRule}
           >

--- a/src/Component/Symbolizer/Field/LineDashField/LineDashField.tsx
+++ b/src/Component/Symbolizer/Field/LineDashField/LineDashField.tsx
@@ -32,6 +32,8 @@ import {
   InputNumber, Button
 } from 'antd';
 
+import { MinusOutlined, PlusOutlined } from '@ant-design/icons';
+
 import './LineDashField.less';
 
 // default props
@@ -106,12 +108,12 @@ export class LineDashField extends React.Component<LineDashFieldProps> {
         }
         <Button
           className="gs-add-dash-button"
-          icon="plus"
+          icon={<PlusOutlined />}
           onClick={this.onAddDash}
         />
         <Button
           className="gs-rm-dash-button"
-          icon="minus"
+          icon={<MinusOutlined />}
           onClick={this.onRemoveDash}
         />
       </div>

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
@@ -33,6 +33,8 @@ import {
   Button
 } from 'antd';
 
+import { CloseOutlined } from '@ant-design/icons';
+
 import { Rnd } from 'react-rnd';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
@@ -119,7 +121,7 @@ export class IconSelectorWindow extends React.Component<IconSelectorWindowProps>
               {locale.windowLabel}
             </span>
             <Button
-              icon="close"
+              icon={<CloseOutlined />}
               size="small"
               onClick={onClose}
             />

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -48,6 +48,8 @@ import {
   Button
 } from 'antd';
 
+import { EditOutlined } from '@ant-design/icons';
+
 import 'ol/ol.css';
 
 import OlStyleParser from 'geostyler-openlayers-parser';
@@ -387,7 +389,7 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
           <Button
             id={editorId}
             className="gs-edit-preview-button"
-            icon="edit"
+            icon={<EditOutlined />}
             onClick={this.onEditButtonClicked}
           >
             {editorVisible ? locale.closeEditorText : locale.openEditorText}

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
@@ -41,6 +41,8 @@ import { Data } from 'geostyler-data';
 import './SymbolizerEditorWindow.less';
 import { Button } from 'antd';
 
+import { CloseOutlined } from '@ant-design/icons';
+
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 
@@ -128,7 +130,7 @@ export class SymbolizerEditorWindow extends React.Component<SymbolizerEditorWind
               {locale.symbolizersEditor}
             </span>
             <Button
-              icon="close"
+              icon={<CloseOutlined />}
               size="small"
               onClick={onClose}
             />


### PR DESCRIPTION
## Description

This PR suggests to pass `Icon` nodes to the `icon` prop of all `Button`s. This is required due to the update of antd to version 4.
 
## Related issues or pull requests

See #1327.

## Pull request type

- [x] Bugfix

## Do you introduce a breaking change?

- [x] No
