### PR TITLE
Fix Editing in ComparisonFilter

### DIFF
--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -368,7 +368,7 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
       validators
     } = this.props;
 
-    let filter: GsComparisonFilter = _cloneDeep(this.state.filter);
+    let filter: GsComparisonFilter = this.state.filter;
     filter[1] = newAttrName;
 
     const valueFieldVis = this.getValueFieldVis(newAttrName);
@@ -450,7 +450,7 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
     const {
       onFilterChange
     } = this.props;
-    let filter: GsComparisonFilter = _cloneDeep(this.state.filter);
+    let filter: GsComparisonFilter = this.state.filter;
     filter[2] = newValue;
 
     // validate value fields


### PR DESCRIPTION
## Description

The input fields of the  `ComparisonFilter` have a bug. It is not possible to make edits in the middle or the beginning of the text. After one character is typed, the cursor instantly jumps to the end of the text. See GIF below. The idea was to type "123" in the middle of the text, but the cursor jumps to end after typing the character "1".

![Peek 2021-02-23 12-00](https://user-images.githubusercontent.com/15704517/108834691-c3958180-75ce-11eb-84a7-03a34fd8c75f.gif)

I guess the reason for the bug is that the app creates completely new values of the changed input fields. This happens because of the use of `_cloneDeep()`. This causes the app to forget the previous position of the cursor. This Pull Request removes `_cloneDeep()` and re-creates the component state with changed values (not new ones). Afterwords the input works like expected.

## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
