### PR TITLE
fix: Fill opacity cannot transform to sld cssParameter

### DIFF
--- a/src/Component/Symbolizer/FillEditor/FillEditor.spec.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.spec.tsx
@@ -69,7 +69,7 @@ describe('FillEditor', () => {
     it('calls the onOpacityChange prop with correct symbolizer ', () => {
       const onFillOpacityChange = wrapper.instance().onFillOpacityChange;
       const newSymbolizer = {...dummySymbolizer};
-      newSymbolizer.opacity = 0.7;
+      newSymbolizer.fillOpacity = 0.7;
       onFillOpacityChange(0.7);
       expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
     });

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -104,7 +104,7 @@ export class FillEditor extends React.Component<FillEditorProps> {
       onSymbolizerChange
     } = this.props;
     const symbolizer: FillSymbolizer = _cloneDeep(this.props.symbolizer);
-    symbolizer.opacity = value;
+    symbolizer.fillOpacity = value;
     if (onSymbolizerChange) {
       onSymbolizerChange(symbolizer);
     }
@@ -180,7 +180,7 @@ export class FillEditor extends React.Component<FillEditorProps> {
 
     const {
       color,
-      opacity,
+      fillOpacity,
       outlineColor,
       graphicFill,
       outlineWidth,
@@ -218,7 +218,7 @@ export class FillEditor extends React.Component<FillEditorProps> {
                       path: 'FillEditor.fillOpacityField',
                       onChange: this.onFillOpacityChange,
                       propName: 'opacity',
-                      propValue: opacity,
+                      propValue: fillOpacity,
                       defaultElement: <OpacityField />
                     })
                   )

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -217,7 +217,7 @@ export class FillEditor extends React.Component<FillEditorProps> {
                       composition,
                       path: 'FillEditor.fillOpacityField',
                       onChange: this.onFillOpacityChange,
-                      propName: 'opacity',
+                      propName: 'fillOpacity',
                       propValue: fillOpacity,
                       defaultElement: <OpacityField />
                     })


### PR DESCRIPTION
## Description

Fill opacity in FillEditor is invalid, because the property name 'opacity' does not same as geostyler style defination for [FillSymbolizer ](https://github.com/geostyler/geostyler-style/blob/master/index.d.ts#L419). SLD parse implementation only deals with [fillOpacity](https://github.com/geostyler/geostyler-sld-parser/blob/master/src/SldStyleParser.ts#L1527)  field, not  the base property `opacity`.
This PR fix this, so we can get correct SLD from the geostyler style object.

BTW, TextEditor has a `opacity` field too, and geostyler style has no corresponding property, e.g. textOpacity, I'm wondering we may offer a common method for symbolizers  having base property like property. 

## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
