### PR TITLE
Fix visibility of minus icon inside of filter editor

### DIFF
--- a/src/Component/Filter/FilterTree/FilterTree.less
+++ b/src/Component/Filter/FilterTree/FilterTree.less
@@ -78,7 +78,7 @@
         }
 
         .anticon-minus {
-          font-size: 10px;
+          font-size: 12px;
         }
       }
 


### PR DESCRIPTION
## Description

Fix visibility of minus icon shown inside of filter editor.

The bug could not be observed in [demo](https://geostyler.github.io/geostyler-demo/) and appears only while geostyler UI integration into another application.

The change doesn't affect or breaks current demo, icon is shown as expected furthermore.


Before fix:
![image](https://user-images.githubusercontent.com/3939355/109516941-0d87d700-7aa9-11eb-99da-34fb1dd87bed.png)

After fix: 
![image](https://user-images.githubusercontent.com/3939355/109517030-22fd0100-7aa9-11eb-9c9b-70712efe916c.png)


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
