### PR TITLE
Fixes default wfs url for WfsParserInput

### DIFF
--- a/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
+++ b/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /* Released under the BSD 2-Clause License
  *
  * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
@@ -95,7 +96,7 @@ export class WfsParserInput extends React.Component<WfsParserInputProps, WfsPars
   constructor(props: any) {
     super(props);
     this.state = {
-      url: 'https://ows.terrestris.de/geoserver/terrestris/ows',
+      url: 'https://ows-demo.terrestris.de/geoserver/terrestris/ows',
       version: '1.1.0',
       typeName: 'terrestris:bundeslaender',
       maxFeatures: undefined,
@@ -127,7 +128,7 @@ export class WfsParserInput extends React.Component<WfsParserInputProps, WfsPars
         url: urlValidation
       }
     });
-  }
+  };
 
   onTypeNameChange = (event: any) => {
     const typeName = event.target.value;
@@ -146,7 +147,7 @@ export class WfsParserInput extends React.Component<WfsParserInputProps, WfsPars
       }
     });
     this.setState({typeName});
-  }
+  };
 
   onVersionChange = (version: string) => {
     let versionValidation = {};
@@ -164,24 +165,24 @@ export class WfsParserInput extends React.Component<WfsParserInputProps, WfsPars
       }
     });
     this.setState({version});
-  }
+  };
 
   onFeatureIDChange = (event: any) => {
     const featureID = event.target.value;
     this.setState({featureID});
-  }
+  };
 
   onPropertyNameChange = (propertyName: string[]) => {
     this.setState({propertyName});
-  }
+  };
 
   onMaxFeaturesChange = (maxFeatures: number) => {
     this.setState({maxFeatures});
-  }
+  };
 
   onClick = () => {
     this.props.onClick(this.state);
-  }
+  };
 
   render() {
     const {


### PR DESCRIPTION
## Description

Updates the default value for the `WfsParserInput`.
Includes some linting.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
