### PR TITLE
Removes onSymbolizerChange from passThroughProps

### DIFF
--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 /* Released under the BSD 2-Clause License
  *
  * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
@@ -91,7 +92,7 @@ export class MultiEditor extends React.Component<MultiEditorProps> {
     if (onSymbolizersChange) {
       onSymbolizersChange([...symbolizers, newSymbolizer]);
     }
-  }
+  };
 
   removeSymbolizer = (key: number) => {
     const {
@@ -103,7 +104,7 @@ export class MultiEditor extends React.Component<MultiEditorProps> {
     if (onSymbolizersChange) {
       onSymbolizersChange(symbolizersClone);
     }
-  }
+  };
 
   onSymbolizerChange = (symbolizer: Symbolizer, key: number) => {
     const {
@@ -115,7 +116,7 @@ export class MultiEditor extends React.Component<MultiEditorProps> {
     if (onSymbolizersChange) {
       onSymbolizersChange(symbolizersClone);
     }
-  }
+  };
 
   render() {
     const {
@@ -124,38 +125,39 @@ export class MultiEditor extends React.Component<MultiEditorProps> {
       locale,
       internalDataDef,
       iconLibraries,
+      onSymbolizersChange,
       ...passThroughProps
     } = this.props;
 
     const tabs = symbolizers.map((symbolizer: Symbolizer, idx: number) => {
-        return (
-          <TabPane
-            className="gs-symbolizer-multi-editor-tab"
-            key={idx.toString()}
-            tab={idx}
-            closable={true}
-          >
-            <Editor
-              symbolizer={symbolizer}
-              onSymbolizerChange={(sym: Symbolizer) => {
-                this.onSymbolizerChange(sym, idx);
+      return (
+        <TabPane
+          className="gs-symbolizer-multi-editor-tab"
+          key={idx.toString()}
+          tab={idx}
+          closable={true}
+        >
+          <Editor
+            symbolizer={symbolizer}
+            onSymbolizerChange={(sym: Symbolizer) => {
+              this.onSymbolizerChange(sym, idx);
+            }}
+            internalDataDef={internalDataDef}
+            iconLibraries={iconLibraries}
+            {...editorProps}
+          />
+          {symbolizers.length === 1 ? null :
+            <Button
+              onClick={() => {
+                this.removeSymbolizer(idx);
               }}
-              internalDataDef={internalDataDef}
-              iconLibraries={iconLibraries}
-              {...editorProps}
-            />
-            {symbolizers.length === 1 ? null :
-              <Button
-                onClick={() => {
-                  this.removeSymbolizer(idx);
-                }}
-              >
-                {locale.remove}
-              </Button>
-            }
-          </TabPane>
-        );
-      });
+            >
+              {locale.remove}
+            </Button>
+          }
+        </TabPane>
+      );
+    });
 
     return (
       <Tabs


### PR DESCRIPTION
## Description

Removes `onSymbolizerChange` from `passThroughProps`. Includes some linting.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
