### PR TITLE
Transforms lodash imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,8 +6,6 @@ module.exports = {
       {
         ignoreImports: true
       }
-    ],
-    "no-underscore-dangle": "off",
-
+    ]
   }
 };

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -55,7 +55,7 @@ import {
   StyleParser
 } from 'geostyler-style';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 import { localize } from '../LocaleWrapper/LocaleWrapper';
 import en_US from '../../locale/en_US';

--- a/src/Component/DataInput/DataLoader/DataLoader.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.tsx
@@ -32,7 +32,7 @@ import { Select, Modal } from 'antd';
 import { UploadRequestOption } from 'rc-upload/lib/interface';
 
 const Option = Select.Option;
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 import {
   VectorData,

--- a/src/Component/DataInput/StyleLoader/StyleLoader.tsx
+++ b/src/Component/DataInput/StyleLoader/StyleLoader.tsx
@@ -31,7 +31,7 @@ import * as React from 'react';
 import { Select } from 'antd';
 import { UploadRequestOption } from 'rc-upload/lib/interface';
 const Option = Select.Option;
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 import {
   Style as GsStyle,

--- a/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
+++ b/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
@@ -52,7 +52,7 @@ interface WfsParams {
 
 import en_US from '../../../locale/en_US';
 
-const _get = require('lodash/get');
+import _get from 'lodash/get';
 
 import './WfsParserInput.less';
 

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -52,11 +52,11 @@ import {
   Data as Data
 } from 'geostyler-data';
 
-const _get = require('lodash/get');
-const _cloneDeep = require('lodash/cloneDeep');
-const _isEqual = require('lodash/isEqual');
-const _isEmpty = require('lodash/isEmpty');
-const _isFunction = require('lodash/isFunction');
+import _get from 'lodash/get';
+import _cloneDeep from 'lodash/cloneDeep';
+import _isEqual from 'lodash/isEqual';
+import _isEmpty from 'lodash/isEmpty';
+import _isFunction from 'lodash/isFunction';
 
 // default props
 export interface ComparisonFilterDefaultProps {

--- a/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
+++ b/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
@@ -43,7 +43,7 @@ import { Filter } from 'geostyler-style';
 import FilterTree from '../FilterTree/FilterTree';
 import { ComparisonFilterProps } from '../ComparisonFilter/ComparisonFilter';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 // i18n
 export interface FilterEditorWindowLocale {
   filterEditor: string;

--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -42,10 +42,10 @@ import {
   PlusOutlined
 } from '@ant-design/icons';
 
-const _get = require('lodash/get');
-const _set = require('lodash/set');
-const _isEqual = require('lodash/isEqual');
-const _cloneDeep = require('lodash/cloneDeep');
+import _get from 'lodash/get';
+import _set from 'lodash/set';
+import _isEqual from 'lodash/isEqual';
+import _cloneDeep from 'lodash/cloneDeep';
 
 const TreeNode = Tree.TreeNode;
 

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -31,7 +31,7 @@ import * as React from 'react';
 import { ComparisonOperator } from 'geostyler-style';
 import { Select, Form } from 'antd';
 import { Data } from 'geostyler-data';
-const _indexOf = require('lodash/indexOf');
+import _indexOf from 'lodash/indexOf';
 const Option = Select.Option;
 
 // default props

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -31,7 +31,7 @@ import * as React from 'react';
 import { Input, Form, AutoComplete } from 'antd';
 import { Data } from 'geostyler-data';
 
-const _get = require('lodash/get');
+import _get from 'lodash/get';
 import { Feature } from 'geojson';
 
 // default props

--- a/src/Component/LocaleWrapper/LocaleWrapper.tsx
+++ b/src/Component/LocaleWrapper/LocaleWrapper.tsx
@@ -28,7 +28,7 @@
 
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
-const _get = require('lodash/get');
+import _get from 'lodash/get';
 
 export interface LocaleProps {
     locale?: object;

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -54,8 +54,8 @@ import Renderer, { RendererProps } from '../Symbolizer/Renderer/Renderer';
 import SymbolizerEditorWindow from '../Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow';
 import { IconLibrary } from '../Symbolizer/IconSelector/IconSelector';
 
-const _cloneDeep = require('lodash/cloneDeep');
-const _isEqual = require('lodash/isEqual');
+import _cloneDeep from 'lodash/cloneDeep';
+import _isEqual from 'lodash/isEqual';
 
 import './Rule.less';
 import en_US from '../../locale/en_US';

--- a/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.tsx
+++ b/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.tsx
@@ -33,7 +33,7 @@ import { Select } from 'antd';
 import en_US from '../../../locale/en_US';
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 export type ClassificationMethod = 'equalInterval' | 'quantile' | 'logarithmic' | 'kmeans';
 

--- a/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.tsx
+++ b/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.tsx
@@ -39,7 +39,7 @@ import { localize } from '../../LocaleWrapper/LocaleWrapper';
 
 import RuleGeneratorUtil from '../../../Util/RuleGeneratorUtil';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 // i18n
 export interface ColorRampComboLocale {

--- a/src/Component/RuleGenerator/ColorSpaceCombo/ColorSpaceCombo.tsx
+++ b/src/Component/RuleGenerator/ColorSpaceCombo/ColorSpaceCombo.tsx
@@ -34,7 +34,7 @@ import en_US from '../../../locale/en_US';
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import { InterpolationMode } from 'chroma-js';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 // i18n
 export interface ColorSpaceComboLocale {

--- a/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.tsx
+++ b/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.tsx
@@ -32,7 +32,7 @@ import './ColorsPreview.less';
 
 import RuleGeneratorUtil from '../../../Util/RuleGeneratorUtil';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 // non default props
 export interface ColorsPreviewProps {

--- a/src/Component/RuleGenerator/RuleGenerator.tsx
+++ b/src/Component/RuleGenerator/RuleGenerator.tsx
@@ -44,7 +44,7 @@ import { ColorRampCombo } from './ColorRampCombo/ColorRampCombo';
 import { ColorSpaceCombo } from './ColorSpaceCombo/ColorSpaceCombo';
 import ColorsPreview from './ColorsPreview/ColorsPreview';
 import { ClassificationMethod, ClassificationCombo } from './ClassificationCombo/ClassificationCombo';
-const _get = require('lodash/get');
+import _get from 'lodash/get';
 
 export type LevelOfMeasurement = 'nominal' | 'ordinal' | 'cardinal';
 

--- a/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
+++ b/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
@@ -47,8 +47,8 @@ import { localize } from '../LocaleWrapper/LocaleWrapper';
 import en_US from '../../locale/en_US';
 import RuleGenerator from './RuleGenerator';
 
-const _isEqual = require('lodash/isEqual');
-const _isFinite = require('lodash/isFinite');
+import _isEqual from 'lodash/isEqual';
+import _isFinite from 'lodash/isFinite';
 // i18n
 export interface RuleGeneratorWindowLocale {
   ruleGenerator: string;

--- a/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.spec.tsx
+++ b/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.spec.tsx
@@ -33,7 +33,7 @@ import {
   Rule as GsRule,
 } from 'geostyler-style';
 
-const _cloneDeep = require('lodash/cloneDeep');
+import _cloneDeep from 'lodash/cloneDeep';
 
 describe('ReorderButtonGroup', () => {
 

--- a/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.tsx
+++ b/src/Component/RuleTable/RuleReorderButtons/RuleReorderButtons.tsx
@@ -38,7 +38,7 @@ import en_US from '../../../locale/en_US';
 import { UpOutlined, DownOutlined } from '@ant-design/icons';
 
 const ButtonGroup = Button.Group;
-const _cloneDeep = require('lodash/cloneDeep');
+import _cloneDeep from 'lodash/cloneDeep';
 
 // i18n
 export interface RuleReorderButtonsLocale {

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -30,10 +30,10 @@
 import * as React from 'react';
 import { CqlParser } from 'geostyler-cql-parser';
 
-const _get = require('lodash/get');
-const _set = require('lodash/set');
-const _isEqual = require('lodash/isEqual');
-const _cloneDeep = require('lodash/cloneDeep');
+import _get from 'lodash/get';
+import _set from 'lodash/set';
+import _isEqual from 'lodash/isEqual';
+import _cloneDeep from 'lodash/cloneDeep';
 
 import {
   Table,

--- a/src/Component/ScaleDenominator/ScaleDenominator.tsx
+++ b/src/Component/ScaleDenominator/ScaleDenominator.tsx
@@ -31,8 +31,8 @@ import { Row, Col } from 'antd';
 import MinScaleDenominator from './MinScaleDenominator';
 import MaxScaleDenominator from './MaxScaleDenominator';
 
-const _get = require('lodash/get');
-const _cloneDeep = require('lodash/cloneDeep');
+import _get from 'lodash/get';
+import _cloneDeep from 'lodash/cloneDeep';
 
 import {
   ScaleDenominator as GsScaleDenominator

--- a/src/Component/Style/Style.spec.tsx
+++ b/src/Component/Style/Style.spec.tsx
@@ -29,7 +29,7 @@
 import { Style, StyleProps } from './Style';
 import TestUtil from '../../Util/TestUtil';
 import en_US from '../../locale/en_US';
-const _cloneDeep = require('lodash/cloneDeep');
+import _cloneDeep from 'lodash/cloneDeep';
 
 describe('Style', () => {
 

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -28,9 +28,9 @@
 
 import * as React from 'react';
 
-const _get = require('lodash/get');
-const _isEqual = require('lodash/isEqual');
-const _cloneDeep = require('lodash/cloneDeep');
+import _get from 'lodash/get';
+import _isEqual from 'lodash/isEqual';
+import _cloneDeep from 'lodash/cloneDeep';
 
 import { InterpolationMode } from 'chroma-js';
 

--- a/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
+++ b/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
@@ -28,7 +28,7 @@
 
 import * as React from 'react';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 import {
   Modal

--- a/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
+++ b/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
@@ -50,8 +50,8 @@ import { brewer } from 'chroma-js';
 
 import './ColorMapEditor.less';
 
-const _get = require('lodash/get');
-const _cloneDeep = require('lodash/cloneDeep');
+import _get from 'lodash/get';
+import _cloneDeep from 'lodash/cloneDeep';
 
 // i18n
 export interface ColorMapEditorLocale {

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -43,7 +43,7 @@ import './Editor.less';
 import 'ol/ol.css';
 import { Data } from 'geostyler-data';
 
-const _cloneDeep = require('lodash/cloneDeep');
+import _cloneDeep from 'lodash/cloneDeep';
 
 import KindField from '../Field/KindField/KindField';
 import IconEditor, { IconEditorProps } from '../IconEditor/IconEditor';

--- a/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
+++ b/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
@@ -39,8 +39,8 @@ import en_US from '../../../../locale/en_US';
 import ContrastEnhancementField from '../ContrastEnhancementField/ContrastEnhancementField';
 import GammaField from '../GammaField/GammaField';
 
-const _get = require('lodash/get');
-const _cloneDeep = require('lodash/cloneDeep');
+import _get from 'lodash/get';
+import _cloneDeep from 'lodash/cloneDeep';
 
 // i18n
 export interface ChannelFieldLocale {

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
@@ -43,7 +43,7 @@ import './ColorField.less';
 import { localize } from '../../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../../locale/en_US';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 // i18n
 export interface ColorFieldLocale {

--- a/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.tsx
+++ b/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.tsx
@@ -36,7 +36,7 @@ import OpacityField from '../OpacityField/OpacityField';
 import { localize } from '../../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../../locale/en_US';
 
-const _get = require('lodash/get');
+import _get from 'lodash/get';
 
 // i18n
 export interface ColorMapEntryFieldLocale {

--- a/src/Component/Symbolizer/Field/ColorMapTypeField/ColorMapTypeField.tsx
+++ b/src/Component/Symbolizer/Field/ColorMapTypeField/ColorMapTypeField.tsx
@@ -37,7 +37,7 @@ import { localize } from '../../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../../locale/en_US';
 import { RadioChangeEvent } from 'antd/lib/radio';
 
-const _get = require('lodash/get');
+import _get from 'lodash/get';
 
 // i18n
 export interface ColorMapTypeFieldLocale {

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
@@ -34,8 +34,8 @@ import { GraphicType } from 'geostyler-style';
 import { localize } from '../../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../../locale/en_US';
 
-const _get = require('lodash/get');
-const _isEqual = require('lodash/isEqual');
+import _get from 'lodash/get';
+import _isEqual from 'lodash/isEqual';
 
 const Option = Select.Option;
 

--- a/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.tsx
+++ b/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.tsx
@@ -37,8 +37,8 @@ import en_US from '../../../../locale/en_US';
 import SourceChannelNameField from '../SourceChannelNameField/SourceChannelNameField';
 import { ChannelSelection, GrayChannel } from 'geostyler-style';
 
-const _get = require('lodash/get');
-const _cloneDeep = require('lodash/cloneDeep');
+import _get from 'lodash/get';
+import _cloneDeep from 'lodash/cloneDeep';
 
 // i18n
 export interface GrayChannelFieldLocale {

--- a/src/Component/Symbolizer/Field/KindField/KindField.tsx
+++ b/src/Component/Symbolizer/Field/KindField/KindField.tsx
@@ -36,7 +36,7 @@ import { SymbolizerKind } from 'geostyler-style';
 import { localize } from '../../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../../locale/en_US';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 const Option = Select.Option;
 

--- a/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.tsx
+++ b/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.tsx
@@ -37,8 +37,8 @@ import en_US from '../../../../locale/en_US';
 import SourceChannelNameField from '../SourceChannelNameField/SourceChannelNameField';
 import { ChannelSelection, RGBChannel } from 'geostyler-style';
 
-const _get = require('lodash/get');
-const _cloneDeep = require('lodash/cloneDeep');
+import _get from 'lodash/get';
+import _cloneDeep from 'lodash/cloneDeep';
 
 // i18n
 export interface RgbChannelFieldLocale {

--- a/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
+++ b/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
@@ -36,8 +36,8 @@ import { WellKnownName } from 'geostyler-style';
 import { localize } from '../../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../../locale/en_US';
 
-const _get = require('lodash/get');
-const _isEqual = require('lodash/isEqual');
+import _get from 'lodash/get';
+import _isEqual from 'lodash/isEqual';
 const Option = Select.Option;
 
 // i18n

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -44,9 +44,9 @@ import OpacityField from '../Field/OpacityField/OpacityField';
 import GraphicEditor from '../GraphicEditor/GraphicEditor';
 import WidthField from '../Field/WidthField/WidthField';
 
-const _cloneDeep = require('lodash/cloneDeep');
-const _get = require('lodash/get');
-const _isEqual = require('lodash/isEqual');
+import _cloneDeep from 'lodash/cloneDeep';
+import _get from 'lodash/get';
+import _isEqual from 'lodash/isEqual';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -40,7 +40,7 @@ import SymbolizerUtil from '../../../Util/SymbolizerUtil';
 import { IconLibrary } from '../IconSelector/IconSelector';
 import { Form } from 'antd';
 
-const _get = require('lodash/get');
+import _get from 'lodash/get';
 
 export interface GraphicEditorDefaultProps {
   /** Label being used on TypeField */

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -37,9 +37,9 @@ import OpacityField from '../Field/OpacityField/OpacityField';
 import ImageField from '../Field/ImageField/ImageField';
 import { IconLibrary } from '../IconSelector/IconSelector';
 
-const _cloneDeep = require('lodash/cloneDeep');
-const _isEmpty = require('lodash/isEmpty');
-const _isEqual = require('lodash/isEqual');
+import _cloneDeep from 'lodash/cloneDeep';
+import _isEmpty from 'lodash/isEmpty';
+import _isEqual from 'lodash/isEqual';
 import RotateField from '../Field/RotateField/RotateField';
 import SizeField from '../Field/SizeField/SizeField';
 

--- a/src/Component/Symbolizer/IconSelector/IconSelector.tsx
+++ b/src/Component/Symbolizer/IconSelector/IconSelector.tsx
@@ -40,7 +40,7 @@ import en_US from '../../../locale/en_US';
 
 import './IconSelector.less';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 // i18n
 export interface IconSelectorLocale {

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
@@ -43,7 +43,7 @@ import en_US from '../../../locale/en_US';
 import IconSelector, { IconLibrary } from '../IconSelector/IconSelector';
 import './IconSelectorWindow.less';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 // i18n
 export interface IconSelectorWindowLocale {

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -49,9 +49,9 @@ import LineJoinField from '../Field/LineJoinField/LineJoinField';
 import OffsetField from '../Field/OffsetField/OffsetField';
 import GraphicEditor from '../GraphicEditor/GraphicEditor';
 
-const _cloneDeep = require('lodash/cloneDeep');
-const _get = require('lodash/get');
-const _isEqual = require('lodash/isEqual');
+import _cloneDeep from 'lodash/cloneDeep';
+import _get from 'lodash/get';
+import _isEqual from 'lodash/isEqual';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -42,7 +42,7 @@ import { CompositionContext, Compositions } from '../../CompositionContext/Compo
 import CompositionUtil from '../../../Util/CompositionUtil';
 import { Form } from 'antd';
 
-const _cloneDeep = require('lodash/cloneDeep');
+import _cloneDeep from 'lodash/cloneDeep';
 
 // i18n
 export interface MarkEditorLocale {

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -47,7 +47,7 @@ import en_US from '../../../locale/en_US';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
 import { IconLibrary } from '../IconSelector/IconSelector';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 // i18n
 export interface MultiEditorLocale {

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -54,8 +54,8 @@ import 'ol/ol.css';
 
 import OlStyleParser from 'geostyler-openlayers-parser';
 
-const _get = require('lodash/get');
-const _isEqual = require('lodash/isEqual');
+import _get from 'lodash/get';
+import _isEqual from 'lodash/isEqual';
 
 import { VectorData } from 'geostyler-data';
 import { IconEditorProps } from '../IconEditor/IconEditor';

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
@@ -37,8 +37,8 @@ import ColorField from '../Field/ColorField/ColorField';
 import OpacityField from '../Field/OpacityField/OpacityField';
 import WidthField from '../Field/WidthField/WidthField';
 
-const _cloneDeep = require('lodash/cloneDeep');
-const _isEqual = require('lodash/isEqual');
+import _cloneDeep from 'lodash/cloneDeep';
+import _isEqual from 'lodash/isEqual';
 import FontPicker from '../Field/FontPicker/FontPicker';
 import OffsetField from '../Field/OffsetField/OffsetField';
 import AttributeCombo from '../../Filter/AttributeCombo/AttributeCombo';

--- a/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
+++ b/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
@@ -47,8 +47,8 @@ import {
 } from 'geostyler-style';
 import ChannelField from '../Field/ChannelField/ChannelField';
 
-const _get = require('lodash/get');
-const _cloneDeep = require('lodash/cloneDeep');
+import _get from 'lodash/get';
+import _cloneDeep from 'lodash/cloneDeep';
 
 // i18n
 export interface RasterChannelEditorLocale {

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -50,8 +50,8 @@ import { CompositionContext, Compositions } from '../../CompositionContext/Compo
 import CompositionUtil from '../../../Util/CompositionUtil';
 import './RasterEditor.less';
 
-const _cloneDeep = require('lodash/cloneDeep');
-const _get = require('lodash/get');
+import _cloneDeep from 'lodash/cloneDeep';
+import _get from 'lodash/get';
 
 // i18n
 export interface RasterEditorLocale {

--- a/src/Component/Symbolizer/Renderer/Renderer.tsx
+++ b/src/Component/Symbolizer/Renderer/Renderer.tsx
@@ -46,9 +46,9 @@ import './Renderer.less';
 import 'ol/ol.css';
 import { Data } from 'geostyler-data';
 
-const _isEqual = require('lodash/isEqual');
-const _get = require('lodash/get');
-const _uniqueId = require('lodash/uniqueId');
+import _isEqual from 'lodash/isEqual';
+import _get from 'lodash/get';
+import _uniqueId from 'lodash/uniqueId';
 
 // non default props
 export interface RendererProps {

--- a/src/Component/Symbolizer/SLDRenderer/SLDRenderer.tsx
+++ b/src/Component/Symbolizer/SLDRenderer/SLDRenderer.tsx
@@ -28,7 +28,7 @@
 
 import * as React from 'react';
 import SldStyleParser from 'geostyler-sld-parser';
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 
 import './SLDRenderer.less';
 import { Style, Symbolizer } from 'geostyler-style';

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
@@ -46,7 +46,7 @@ import { CloseOutlined } from '@ant-design/icons';
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 
-const _isEqual = require('lodash/isEqual');
+import _isEqual from 'lodash/isEqual';
 // i18n
 export interface SymbolizerEditorWindowLocale {
   symbolizersEditor: string;

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -50,8 +50,8 @@ import RotateField from '../Field/RotateField/RotateField';
 import { CompositionContext, Compositions } from '../../CompositionContext/CompositionContext';
 import CompositionUtil from '../../../Util/CompositionUtil';
 
-const _cloneDeep = require('lodash/cloneDeep');
-const _isEqual = require('lodash/isEqual');
+import _cloneDeep from 'lodash/cloneDeep';
+import _isEqual from 'lodash/isEqual';
 
 import './TextEditor.less';
 

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -43,8 +43,8 @@ import CompositionUtil from '../../../Util/CompositionUtil';
 import en_US from '../../../locale/en_US';
 import { Form } from 'antd';
 
-const _cloneDeep = require('lodash/cloneDeep');
-const _isEqual = require('lodash/isEqual');
+import _cloneDeep from 'lodash/cloneDeep';
+import _isEqual from 'lodash/isEqual';
 
 // i18n
 interface WellKnownNameEditorLocale {

--- a/src/Util/CompositionUtil.ts
+++ b/src/Util/CompositionUtil.ts
@@ -28,7 +28,7 @@
 
 import * as React from 'react';
 import { Compositions } from '../Component/CompositionContext/CompositionContext';
-const _get = require('lodash/get');
+import _get from 'lodash/get';
 
 export interface CompositionUtilOptions {
   composition: Compositions;

--- a/src/Util/FilterUtil.ts
+++ b/src/Util/FilterUtil.ts
@@ -36,7 +36,7 @@ import {
   VectorData
 } from 'geostyler-data';
 
-const _get = require('lodash/get');
+import _get from 'lodash/get';
 
 export type CountResult = {
   counts?: number[];

--- a/src/Util/RuleGeneratorUtil.spec.ts
+++ b/src/Util/RuleGeneratorUtil.spec.ts
@@ -28,7 +28,7 @@
 
 import RuleGeneratorUtil from './RuleGeneratorUtil';
 import TestUtil from './TestUtil';
-const _cloneDeep = require('lodash/cloneDeep');
+import _cloneDeep from 'lodash/cloneDeep';
 
 describe('RuleGeneratorUtil', () => {
   const dummyData = TestUtil.getComplexGsDummyData();

--- a/src/Util/RuleGeneratorUtil.ts
+++ b/src/Util/RuleGeneratorUtil.ts
@@ -47,9 +47,7 @@ import {
 }  from 'chroma-js';
 import { ClassificationMethod } from 'src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo';
 
-// Unsure if we can rely on this file in future releases
-
-const _get = require('lodash/get');
+import _get from 'lodash/get';
 
 export interface RuleGenerationParams {
   data: Data;


### PR DESCRIPTION
## Description

This transforms the import statement regarding the `lodash` package.

e.G.:

Previously: 
```javascript
const _isEqual = require('lodash/isEqual');
```
Afterwards: 
```javascript
import _isEqual from 'lodash/isEqual';
```

This does not affect the size of the browserbuild (3.5 MB).


## Related issues or pull requests

This poped up when fixing the linting via #1360 .

## Pull request type

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [ ] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [ ] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
