### PR TITLE
Adds missing opacity field to WellKnownNameEditor

### DIFF
--- a/src/Component/DefaultValueContext/DefaultValueContext.tsx
+++ b/src/Component/DefaultValueContext/DefaultValueContext.tsx
@@ -79,6 +79,7 @@ export interface DefaultValues {
     defaultRadius?: string;
     defaultColor?: string;
     defaultOpacity?: number;
+    defaultFillOpacity?: number;
     defaultStrokeColor?: string;
     defaultStrokeWidth?: number;
     defaultStrokeOpacity?: number;

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.spec.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.spec.tsx
@@ -85,6 +85,16 @@ describe('WellKnownNameEditor', () => {
     });
   });
 
+  describe('onFillOpacityChange', () => {
+    it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
+      const onFillOpacityChange = wrapper.instance().onFillOpacityChange;
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.fillOpacity = 0.76;
+      onFillOpacityChange(0.76);
+      expect(onSymbolizerChangeDummy).toBeCalledWith(newSymbolizer);
+    });
+  });
+
   describe('onStrokeColorChange', () => {
     it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
       const onStrokeColorChange = wrapper.instance().onStrokeColorChange;

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -54,6 +54,7 @@ interface WellKnownNameEditorLocale {
   radiusLabel?: string;
   fillOpacityLabel?: string;
   fillColorLabel?: string;
+  opacityLabel?: string;
   strokeColorLabel?: string;
   strokeWidthLabel?: string;
   strokeOpacityLabel?: string;
@@ -114,6 +115,19 @@ export class WellKnownNameEditor extends React.Component<WellKnownNameEditorProp
     symbolizer.opacity = value;
     if (onSymbolizerChange) {
       onSymbolizerChange(symbolizer);
+    }
+  };
+
+  onFillOpacityChange = (fillOpacity: number) => {
+    const {
+      onSymbolizerChange,
+      symbolizer
+    } = this.props;
+    if (onSymbolizerChange) {
+      onSymbolizerChange({
+        ...symbolizer,
+        fillOpacity
+      });
     }
   };
 
@@ -188,13 +202,14 @@ export class WellKnownNameEditor extends React.Component<WellKnownNameEditorProp
     } = this.props;
 
     const {
-      radius,
       color,
+      fillOpacity,
       opacity,
+      radius,
       rotate,
       strokeColor,
-      strokeWidth,
-      strokeOpacity
+      strokeOpacity,
+      strokeWidth
     } = symbolizer;
 
     return (
@@ -231,14 +246,28 @@ export class WellKnownNameEditor extends React.Component<WellKnownNameEditorProp
             }
             {
               this.wrapFormItem(
-                locale.fillOpacityLabel,
+                locale.opacityLabel,
                 CompositionUtil.handleComposition({
                   composition,
-                  path: 'WellKnownNameEditor.fillOpacityField',
+                  path: 'WellKnownNameEditor.opacityField',
                   onChange: this.onOpacityChange,
                   propName: 'opacity',
                   propValue: opacity,
                   defaultValue: defaultValues?.WellKnownNameEditor?.defaultOpacity,
+                  defaultElement: <OpacityField />
+                })
+              )
+            }
+            {
+              this.wrapFormItem(
+                locale.fillOpacityLabel,
+                CompositionUtil.handleComposition({
+                  composition,
+                  path: 'WellKnownNameEditor.fillOpacityField',
+                  onChange: this.onFillOpacityChange,
+                  propName: 'opacity',
+                  propValue: fillOpacity,
+                  defaultValue: defaultValues?.WellKnownNameEditor?.defaultFillOpacity,
                   defaultElement: <OpacityField />
                 })
               )

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -90,6 +90,7 @@ export default {
     radiusLabel: 'Radius',
     fillOpacityLabel: 'Fülldeckkraft',
     fillColorLabel: 'Füllfarbe',
+    opacityLabel: 'Deckkraft',
     strokeColorLabel: 'Strichfarbe',
     strokeWidthLabel: 'Strichstärke',
     strokeOpacityLabel: 'Strichdeckkraft',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -91,6 +91,7 @@ export default {
     radiusLabel: 'Radius',
     fillOpacityLabel: 'Fill-Opacity',
     fillColorLabel: 'Fill-Color',
+    opacityLabel: 'Opacity',
     strokeColorLabel: 'Stroke-Color',
     strokeWidthLabel: 'Stroke-Width',
     strokeOpacityLabel: 'Stroke-Opacity',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -91,6 +91,7 @@ export default {
     radiusLabel: 'Radio',
     fillOpacityLabel: 'Relleno-Transparencia',
     fillColorLabel: 'Fondo-Color',
+    opacityLabel: 'Transparencia',
     strokeColorLabel: 'Trazo-Color',
     strokeWidthLabel: 'Trazo-Ancho',
     strokeOpacityLabel: 'Trazo-Transparencia',

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -91,6 +91,7 @@ export default {
     radiusLabel: '半径',
     fillOpacityLabel: '填充-不透明度',
     fillColorLabel: '填充-颜色',
+    opacityLabel: '不透明度',
     strokeColorLabel: '描边-颜色',
     strokeWidthLabel: '描边-宽度',
     strokeOpacityLabel: '描边-不透明度',


### PR DESCRIPTION
## Description

This adds the missing `opacity` field to the `WellKnownNameEditor`.

## Related issues or pull requests

It is related to https://github.com/geostyler/geostyler/issues/1359.

## Pull request type

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
