### PR TITLE
Fix broken comparison filter

### DIFF
--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -64,13 +64,14 @@ export interface AttributeComboProps extends Partial<AttributeComboDefaultProps>
 
 interface AttributeComboState {
   value: string | undefined;
+  inputSelectionStart: number;
+  inputSelectionEnd: number;
 }
 
 /**
  * Combobox offering the attributes to be filtered on.
  */
 export class AttributeCombo extends React.Component<AttributeComboProps, AttributeComboState> {
-
   public static defaultProps: AttributeComboDefaultProps = {
     label: 'Attribute',
     placeholder: 'Select Attribute',
@@ -81,11 +82,15 @@ export class AttributeCombo extends React.Component<AttributeComboProps, Attribu
     validateStatus: 'success',
     help: 'Please select an attribute.'
   };
+  private inputRef: React.RefObject<Input>;
 
   constructor(props: AttributeComboProps) {
     super(props);
+    this.inputRef = React.createRef();
     this.state = {
-      value: this.props.value
+      value: this.props.value,
+      inputSelectionStart: 0,
+      inputSelectionEnd: 0
     };
   }
 
@@ -95,6 +100,19 @@ export class AttributeCombo extends React.Component<AttributeComboProps, Attribu
     return {
       value: nextProps.value
     };
+  }
+
+  componentDidUpdate() {
+    // ensure we preserve the cursor position for the input field
+    const {
+      inputSelectionStart,
+      inputSelectionEnd,
+    } = this.state;
+
+    if (this.inputRef && this.inputRef.current && this.inputRef.current.input) {
+      this.inputRef.current.input.selectionStart = inputSelectionStart;
+      this.inputRef.current.input.selectionEnd = inputSelectionEnd;
+    }
   }
 
   render() {
@@ -156,6 +174,7 @@ export class AttributeCombo extends React.Component<AttributeComboProps, Attribu
               </Select>
               :
               <Input
+                ref={this.inputRef}
                 draggable={true}
                 onDragStart={(e) => e.preventDefault()}
                 value={this.state.value}
@@ -163,6 +182,15 @@ export class AttributeCombo extends React.Component<AttributeComboProps, Attribu
                 style={{ width: '100%' }}
                 onChange={(event) => {
                   onAttributeChange(event.target.value);
+
+                  // save the cursor position to restore it in
+                  // componentDidUpdate, otherwise it jumps to the end while typing
+                  const cursorStart = event.target.selectionStart;
+                  const cursorEnd = event.target.selectionEnd;
+                  this.setState({
+                    inputSelectionStart: cursorStart,
+                    inputSelectionEnd: cursorEnd
+                  });
                 }}
               />
           }

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -369,8 +369,9 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
       validators
     } = this.props;
 
-    let filter: GsComparisonFilter = this.state.filter;
+    let filter: GsComparisonFilter = _cloneDeep(this.state.filter);
     filter[1] = newAttrName;
+    this.setState({filter});
 
     const valueFieldVis = this.getValueFieldVis(newAttrName);
     this.setState(valueFieldVis);
@@ -400,7 +401,7 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
     };
 
     this.setState({
-      filter,
+      attribute: newAttrName,
       validateStatus: validationStateNew
     }, () => {
       if (onFilterChange) {
@@ -451,8 +452,10 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
     const {
       onFilterChange
     } = this.props;
-    let filter: GsComparisonFilter = this.state.filter;
+    // let filter: GsComparisonFilter = this.state.filter;
+    let filter: GsComparisonFilter = _cloneDeep(this.state.filter);
     filter[2] = newValue;
+    this.setState({filter});
 
     // validate value fields
     let validationRes = this.props.validators.value(newValue, this.props.internalDataDef, this.state.attribute);
@@ -465,7 +468,7 @@ export class ComparisonFilter extends React.Component<ComparisonFilterProps, Com
     this.setState(
       {
         validateStatus: validationStateNew,
-        filter,
+        value: newValue,
         valueValidationHelpString: validationRes.errorMsg
       },
       () => {


### PR DESCRIPTION
## Description

This fixes the broken comparison filter, so the state reflects the changes in the UI and the dependent components (e.g.) the `CodeEditor` and ensures that the cursor in the attribute- and value-field does not jump to the end while typing. Achieved by doing the following:

This reverts the changeset introduced in #1345, which solved the unwanted cursor jump (see linked PR for details) but also introduced the missing sync of the filter with dependant components e.g. the `CodeEditor` in the GeoStyler-Demo (compare https://github.com/geostyler/geostyler-demo/issues/180).
Additionally an alternative fix for preserving the cursor position and thus allowing to type in the middle of a word in the attribute- and value-field of the comparison filter is now possible. The fix is based on this thread: https://github.com/facebook/react/issues/955.

## Related issues or pull requests

  - #1345 
  - https://github.com/geostyler/geostyler-demo/issues/180
  - https://github.com/facebook/react/issues/955

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
