### PR TITLE
Allows the windows to be closed on mobile devices

### DIFF
--- a/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
+++ b/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
@@ -120,7 +120,7 @@ export class FilterEditorWindow extends React.Component<FilterEditorWindowProps>
             topLeft: false,
             topRight: false
           }}
-          dragHandleClassName="filter-editor-window-header"
+          dragHandleClassName="title"
         >
           <div className="header filter-editor-window-header">
             <span className="title">

--- a/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
+++ b/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
@@ -127,7 +127,7 @@ export class RuleGeneratorWindow extends React.Component<RuleGeneratorWindowProp
             topRight: false
           }}
           bounds="window"
-          dragHandleClassName="rule-generator-window-header"
+          dragHandleClassName="title"
         >
           <div className="header rule-generator-window-header">
             <span className="title">

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
@@ -114,7 +114,7 @@ export class IconSelectorWindow extends React.Component<IconSelectorWindowProps>
             topRight: false
           }}
           bounds="window"
-          dragHandleClassName="gs-icon-selector-window-header"
+          dragHandleClassName="title"
         >
           <div className="header gs-icon-selector-window-header">
             <span className="title">

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
@@ -123,7 +123,7 @@ export class SymbolizerEditorWindow extends React.Component<SymbolizerEditorWind
             topLeft: false,
             topRight: false
           }}
-          dragHandleClassName="symbolizer-editor-window-header"
+          dragHandleClassName="title"
         >
           <div className="header symbolizer-editor-window-header">
             <span className="title">


### PR DESCRIPTION
## Description

Previously, it was not possible to close the individual windows via the corresponding button on mobile devices.

With this PR, the focus for the draggable element (`dragHandleClassName`) in the windows (`FilterEditorWindow`, `RuleGeneratorWindow`, `IconSelectorWindow` and `SymbolizerEditorWindow`) is moved from the whole header to the `title`.  
This keeps the components draggable, but also closable on mobile devices.

@jansule @KaiVolland please review

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] The test suite passes (run `npm test` locally)
