### PR TITLE
Circle Fix + CodeEditor Example

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.example.md
+++ b/src/Component/CodeEditor/CodeEditor.example.md
@@ -1,0 +1,80 @@
+<!--
+ * Released under the BSD 2-Clause License
+ *
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+-->
+
+This demonstrates the usage of the `CodeEditor` component.
+
+```jsx
+import * as React from 'react';
+import { CodeEditor } from 'geostyler';
+import SldStyleParser from 'geostyler-sld-parser';
+
+class CodeEditorExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      sldParser: new SldStyleParser({sldVersion: '1.1.0'}),
+      style: {
+        "name": "Demo Style",
+        "rules": [
+          {
+            "name": "Rule 1",
+            "symbolizers": [
+              {
+                "kind": "Mark",
+                "wellKnownName": "circle"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+
+  render() {
+    const {
+      style,
+      sldParser
+    } = this.state;
+
+    return (
+      <div style={{height: '300px'}}>
+        <CodeEditor
+          style={style}
+          parsers={[sldParser]}
+          defaultParser={sldParser}
+        />
+      </div>
+    );
+  }
+}
+
+<CodeEditorExample />
+```

--- a/src/Component/PreviewMap/PreviewMap.example.md
+++ b/src/Component/PreviewMap/PreviewMap.example.md
@@ -47,7 +47,7 @@ class PreviewMapExample extends React.Component {
             "symbolizers": [
               {
                 "kind": "Mark",
-                "wellKnownName": "Circle"
+                "wellKnownName": "circle"
               }
             ]
           }

--- a/src/Component/RuleTable/RuleTable.example.md
+++ b/src/Component/RuleTable/RuleTable.example.md
@@ -47,7 +47,7 @@ class RuleTableExample extends React.Component {
             "symbolizers": [
               {
                 "kind": "Mark",
-                "wellKnownName": "Circle"
+                "wellKnownName": "circle"
               }
             ]
           }

--- a/src/Component/Style/Style.example.md
+++ b/src/Component/Style/Style.example.md
@@ -50,7 +50,7 @@ class StyleExample extends React.Component {
             "symbolizers": [
               {
                 "kind": "Mark",
-                "wellKnownName": "Circle"
+                "wellKnownName": "circle"
               }
             ]
           }

--- a/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.example.md
+++ b/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.example.md
@@ -39,7 +39,7 @@ class WellKnownNameFieldExample extends React.Component {
     super(props);
 
     this.state = {
-      wellKnownName: 'Circle'
+      wellKnownName: 'circle'
     };
 
     this.onChange = this.onChange.bind(this);

--- a/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.spec.tsx
+++ b/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.spec.tsx
@@ -55,7 +55,7 @@ describe('WellKnownNameField', () => {
   it('can handle wellKnownNames property', () => {
     expect.assertions(2);
     wrapper.setProps({
-      wellKnownNames: ['Circle', 'Square']
+      wellKnownNames: ['circle', 'square']
     });
     expect(wrapper.instance().props.wellKnownNames).toHaveLength(2);
     expect(wrapper.instance().getWKNSelectOptions()).toHaveLength(2);
@@ -64,10 +64,10 @@ describe('WellKnownNameField', () => {
   it('can handle wellKnownName property', () => {
     expect.assertions(2);
     wrapper.setProps({
-      wellKnownName: 'Square'
+      wellKnownName: 'square'
     });
-    expect(wrapper.instance().props.wellKnownName).toEqual('Square');
+    expect(wrapper.instance().props.wellKnownName).toEqual('square');
     const selectValue = wrapper.props().value;
-    expect(selectValue).toEqual('Square');
+    expect(selectValue).toEqual('square');
   });
 });

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.example.md
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.example.md
@@ -41,7 +41,7 @@ class GraphicEditorExample extends React.Component {
     this.state = {
       graphic: {
         kind: 'Mark',
-        wellKnownName: 'Circle'
+        wellKnownName: 'circle'
       },
       graphicType: 'Mark'
     };

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.spec.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.spec.tsx
@@ -37,11 +37,11 @@ describe('Renderer', () => {
   let dummyOnSymbolizerChange: jest.Mock;
   const dummySymbolizers: Symbolizer[] = [{
     kind: 'Mark',
-    wellKnownName: 'Circle',
+    wellKnownName: 'circle',
     color: '#FF0000'
   }, {
     kind: 'Mark',
-    wellKnownName: 'Circle',
+    wellKnownName: 'circle',
     color: '#FF00FF'
   }];
 

--- a/src/Component/Symbolizer/Preview/Preview.spec.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.spec.tsx
@@ -37,7 +37,7 @@ describe('Preview', () => {
   let onSymbolizersChangeDummy: jest.Mock;
   const dummySymbolizers: Symbolizer[] = [{
     kind: 'Mark',
-    wellKnownName: 'Circle',
+    wellKnownName: 'circle',
     color: '#FF0000'
   }];
 

--- a/src/Component/Symbolizer/Renderer/Renderer.spec.tsx
+++ b/src/Component/Symbolizer/Renderer/Renderer.spec.tsx
@@ -36,7 +36,7 @@ describe('Renderer', () => {
   let onClickDummy: jest.Mock;
   const dummySymbolizers: Symbolizer[] = [{
     kind: 'Mark',
-    wellKnownName: 'Circle',
+    wellKnownName: 'circle',
     color: '#FF0000'
   }];
 

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.spec.tsx
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.spec.tsx
@@ -35,7 +35,7 @@ describe('SymbolizerEditorWindow', () => {
   let wrapper: any;
   const dummySymbolizers: Symbolizer[] = [{
     kind: 'Mark',
-    wellKnownName: 'Circle',
+    wellKnownName: 'circle',
     color: '#FF0000'
   }];
 

--- a/src/Util/FilterUtil.spec.ts
+++ b/src/Util/FilterUtil.spec.ts
@@ -115,7 +115,7 @@ describe('FilterUtil', () => {
           'symbolizers': [
             {
               'kind': 'Mark',
-              'wellKnownName': 'Circle'
+              'wellKnownName': 'circle'
             }
           ],
           'filter': [
@@ -133,7 +133,7 @@ describe('FilterUtil', () => {
           'symbolizers': [
             {
               'kind': 'Mark',
-              'wellKnownName': 'Circle',
+              'wellKnownName': 'circle',
               'color': '#0E1058'
             }
           ],
@@ -152,7 +152,7 @@ describe('FilterUtil', () => {
           'symbolizers': [
             {
               'kind': 'Mark',
-              'wellKnownName': 'Circle',
+              'wellKnownName': 'circle',
               'color': '#0E1058'
             }
           ],
@@ -171,7 +171,7 @@ describe('FilterUtil', () => {
           'symbolizers': [
             {
               'kind': 'Mark',
-              'wellKnownName': 'Circle',
+              'wellKnownName': 'circle',
               'color': '#0E1058'
             }
           ],


### PR DESCRIPTION
## Description

This renames some occurrences of wellKnownName `Circle` to `circle` and `Square` to `square` as this changed in geostylerStyle.

This also adds an example file for the `CodeEditor` component.

## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
