### PR TITLE
Introduces "all-distinct-values" button to RuleGenerator

### DIFF
--- a/src/Component/RuleGenerator/RuleGenerator.less
+++ b/src/Component/RuleGenerator/RuleGenerator.less
@@ -36,6 +36,10 @@
     .ant-form-item-control-wrapper {
       flex: 1;
     }
+
+    .all-distinct-values-button {
+      margin: 1px 0 0 5px;
+    }
   }
 
   .gs-rule-generator-submit-button {

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -308,7 +308,8 @@ export default {
     classification: 'Klassifizierungs Methode',
     classificationPlaceholder: 'Auswählen…',
     preview: 'Farb Vorschau',
-    numberOfRulesViaKmeans: '…betroffen durch k-Means Klassifizierung.'
+    numberOfRulesViaKmeans: '…betroffen durch k-Means Klassifizierung.',
+    allDistinctValues: 'Alle eindeutigen Werte verwenden'
   },
   GsColorRampCombo: {
     colorRampPlaceholder: 'Auswählen…'

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -313,7 +313,8 @@ export default {
     classificationPlaceholder: 'Select…',
     equalInterval: 'Equal Interval',
     preview: 'Color Preview',
-    numberOfRulesViaKmeans: '…affected by k-Means classification.'
+    numberOfRulesViaKmeans: '…affected by k-Means classification.',
+    allDistinctValues: 'Use all distinct values'
   },
   GsColorRampCombo: {
     colorRampPlaceholder: 'Select…'

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -250,7 +250,8 @@ export default {
     classification: 'Método de clasificación',
     classificationPlaceholder: 'Seleccionar…',
     preview: 'Avance de color',
-    numberOfRulesViaKmeans: '…afectados por la clasificación k-Means.'
+    numberOfRulesViaKmeans: '…afectados por la clasificación k-Means.',
+    allDistinctValues: 'Utilizar todos los valores distintos'
   },
   GsColorRampCombo: {
     colorRampPlaceholder: 'Seleccionar…'

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -313,7 +313,8 @@ export default {
     classificationPlaceholder: '选择……',
     equalInterval: '相等间隔',
     preview: '颜色预览',
-    numberOfRulesViaKmeans: '……被 k-Means 分类影响。'
+    numberOfRulesViaKmeans: '……被 k-Means 分类影响。',
+    allDistinctValues: '使用所有不同的值'
   },
   GsColorRampCombo: {
     colorRampPlaceholder: '选择……'


### PR DESCRIPTION
## Description

This adds a button which set the number of classes in the `RuleGenerator` to the amount of distinct values for the selected attribute.

![localhost_3000_ (2)](https://user-images.githubusercontent.com/1849416/134143899-d8cbbbbd-d747-464f-b075-74ef909bbf88.png)

## Pull request type

- [x] Feature

## Do you introduce a breaking change?

- [x] No
