### PR TITLE
Fixes FilterTree layout

### DIFF
--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -60,6 +60,7 @@ export interface AttributeComboProps extends Partial<AttributeComboDefaultProps>
   onAttributeChange?: ((newAttrName: string) => void);
   /** Value set to the field */
   value?: string | undefined;
+  size?: 'large' | 'middle' | 'small';
 }
 
 /**
@@ -75,7 +76,8 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
   validateStatus = 'success',
   help = 'Please select an attribute.',
   internalDataDef,
-  onAttributeChange
+  onAttributeChange,
+  size
 }) => {
 
   const [inputSelectionStart, setInputSelectionStart] = React.useState<number>();
@@ -131,6 +133,7 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
               style={{ width: '100%' }}
               onChange={onAttributeChange}
               placeholder={placeholder}
+              size={size}
             >
               {options}
             </Select>
@@ -142,6 +145,7 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
               value={value}
               placeholder={placeholder}
               style={{ width: '100%' }}
+              size={size}
               onChange={(event) => {
                 if (onAttributeChange) {
                   onAttributeChange(event.target.value);

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -84,10 +84,12 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
   const [inputSelectionEnd, setInputSelectionEnd] = React.useState<number>();
   const inputRef = React.useRef(null);
 
-  if (inputRef && inputRef.current && inputRef.current.input) {
-    inputRef.current.input.selectionStart = inputSelectionStart;
-    inputRef.current.input.selectionEnd = inputSelectionEnd;
-  }
+  React.useLayoutEffect(() => {
+    if (inputRef && inputRef.current && inputRef.current.input) {
+      inputRef.current.input.selectionStart = inputSelectionStart;
+      inputRef.current.input.selectionEnd = inputSelectionEnd;
+    }
+  }, [inputSelectionStart, inputSelectionEnd, value]);
 
   let options: Object[] = [];
 

--- a/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
+++ b/src/Component/Filter/BoolFilterField/BoolFilterField.tsx
@@ -42,6 +42,7 @@ interface BoolFilterFieldDefaultProps {
 export interface BoolFilterFieldProps extends Partial<BoolFilterFieldDefaultProps> {
   /** Callback function for onChange */
   onValueChange?: ((newValue: boolean) => void);
+  size?: 'large' | 'middle' | 'small';
 }
 
 /**
@@ -50,7 +51,8 @@ export interface BoolFilterFieldProps extends Partial<BoolFilterFieldDefaultProp
 export const BoolFilterField: React.FC<BoolFilterFieldProps> = ({
   label = 'Value',
   value = false,
-  onValueChange
+  onValueChange,
+  size
 }) => {
 
   /**
@@ -63,8 +65,14 @@ export const BoolFilterField: React.FC<BoolFilterFieldProps> = ({
     }
   };
 
+  let className = 'gs-bool-filter-field';
+  if (size === 'small') {
+    // TODO: make use of this for the checkbox
+    className += ' ant-input-sm';
+  }
+
   return (
-    <div className="gs-bool-filter-field">
+    <div className={className}>
       <Form.Item label={label} colon={false} >
         <Checkbox
           checked={value === true}

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.less
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.less
@@ -37,34 +37,5 @@
     .ant-form-item-label {
       display: none;
     }
-
-    input,
-    .ant-input,
-    .ant-input-number {
-      font-size: 0.9em;
-      padding: 0 4px;
-      height: 24px;
-    }
-
-    .ant-select-selection {
-      font-size: 0.9em;
-      height: 24px;
-    }
-
-    .ant-select-selection__rendered {
-      line-height: 24px;
-    }
-
-    .ant-select-selection__rendered ul {
-      padding: 0;
-    }
-
-    .ant-select-selection__rendered ul li {
-      padding: 0;
-    }
-
-    .gs-operator-combo .ant-select-arrow {
-      right: 2px;
-    }
   }
 }

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -270,6 +270,7 @@ export const ComparisonFilter: React.FC<ComparisonFilterProps> = ({
         <Row gutter={16} justify="center">
           <Col span={10} className="gs-small-col">
             <AttributeCombo
+              size={microUI ? 'small' : undefined}
               value={filter ? filter[1] as string : undefined}
               internalDataDef={internalDataDef}
               onAttributeChange={onAttributeChange}
@@ -284,6 +285,7 @@ export const ComparisonFilter: React.FC<ComparisonFilterProps> = ({
           </Col>
           <Col span={4} className="gs-small-col">
             <OperatorCombo
+              size={microUI ? 'small' : undefined}
               value={filter ? filter[0] : undefined}
               onOperatorChange={onOperatorChange}
               operators={allowedOperators}
@@ -300,6 +302,7 @@ export const ComparisonFilter: React.FC<ComparisonFilterProps> = ({
             textFieldVisible ?
               <Col span={10} className="gs-small-col">
                 <TextFilterField
+                  size={microUI ? 'small' : undefined}
                   value={filter ? filter[2] as string : undefined}
                   internalDataDef={internalDataDef}
                   selectedAttribute={attribute}
@@ -316,6 +319,7 @@ export const ComparisonFilter: React.FC<ComparisonFilterProps> = ({
             numberFieldVisible ?
               <Col span={10} className="gs-small-col">
                 <NumberFilterField
+                  size={microUI ? 'small' : undefined}
                   value={filter ? filter[2] as number : undefined}
                   onValueChange={onValueChange}
                   label={valueLabel}
@@ -330,6 +334,7 @@ export const ComparisonFilter: React.FC<ComparisonFilterProps> = ({
             boolFieldVisible ?
               <Col span={10} className="gs-small-col">
                 <BoolFilterField
+                  size={microUI ? 'small' : undefined}
                   value={filter ? filter[2] as boolean : undefined}
                   onValueChange={onValueChange}
                   label={valueLabel}

--- a/src/Component/Filter/FilterTree/FilterTree.less
+++ b/src/Component/Filter/FilterTree/FilterTree.less
@@ -34,8 +34,11 @@
     .style-filter-node.or-filter,
     .style-filter-node.not-filter {
       border-radius: 4px;
-      background-color: rgba(0, 0, 0, 0.05);
       margin-bottom: 5px;
+
+      .ant-tree-node-content-wrapper {
+        background-color: rgba(0, 0, 0, 0.05)
+      }
     }
 
     .style-filter-node {

--- a/src/Component/Filter/FilterTree/FilterTree.less
+++ b/src/Component/Filter/FilterTree/FilterTree.less
@@ -38,12 +38,6 @@
       margin-bottom: 5px;
     }
 
-    .ant-tree-node-content-wrapper,
-    .ant-tree-node-content-wrapper,
-    .ant-tree-node-content-wrapper {
-      width: calc(100% - 24px);
-    }
-
     .style-filter-node {
       &.comparison-filter {
         .ant-tree-switcher {
@@ -67,29 +61,11 @@
 
     .node-title {
       display: flex;
-      align-items: center;
+      align-items: baseline;
       justify-content: space-between;
 
-      .filter-tools {
-        visibility: hidden;
-
-        .anticon {
-          color: black;
-        }
-
-        .anticon-minus {
-          font-size: 12px;
-        }
-      }
-
-      &:hover {
-        .filter-tools {
-          visibility: visible;
-        }
-      }
-
-      .filter-tools:hover {
-        visibility: visible;
+      .filter-menu-button {
+        margin-left: 5px;
       }
     }
   }

--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -200,7 +200,7 @@ export const FilterTree: React.FC<FilterTreeProps> = ({
 
     if (isCombinationFilter(filter)) {
       const text = filter[0] === '&&' ? locale.andFilterText : locale.orFilterText;
-      extraClassName = `${text}-filter`;
+      extraClassName = `${filter[0] === '&&' ? 'and' : 'or'}-filter`;
       title = (
         <span className="node-title">
           <span className="filter-text">{text}</span>

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -46,6 +46,7 @@ interface NumberFilterFieldDefaultProps {
 export interface NumberFilterFieldProps extends Partial<NumberFilterFieldDefaultProps> {
   /** Callback for onChange */
   onValueChange?: ((newValue: number) => void);
+  size?: 'large' | 'middle' | 'small';
 }
 
 /**
@@ -58,7 +59,8 @@ export const NumberFilterField: React.FC<NumberFilterFieldProps> = ({
   value,
   validateStatus = 'success',
   help = 'Please enter a number.',
-  onValueChange
+  onValueChange,
+  size
 }) => {
 
   const helpTxt = validateStatus !== 'success' ? help : null;
@@ -77,6 +79,7 @@ export const NumberFilterField: React.FC<NumberFilterFieldProps> = ({
         hasFeedback={true}
       >
         <InputNumber
+          size={size}
           defaultValue={value}
           value={value}
           style={{

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -57,7 +57,8 @@ export interface OperatorComboProps extends Partial<OperatorComboDefaultProps> {
   /** Callback function for onChange */
   onOperatorChange?: ((newOperator: ComparisonOperator) => void);
   /** Initial value set to the field */
-  value: ComparisonOperator | undefined;
+  value?: ComparisonOperator | undefined;
+  size?: 'large' | 'middle' | 'small';
 }
 
 /**
@@ -73,7 +74,8 @@ export const OperatorCombo: React.FC<OperatorComboProps> = ({
   operatorTitleMappingFunction = t => t,
   validateStatus = 'error',
   help = 'Please select an operator.',
-  onOperatorChange
+  onOperatorChange,
+  size
 }) => {
 
   // create an option per attribute
@@ -108,6 +110,7 @@ export const OperatorCombo: React.FC<OperatorComboProps> = ({
         help={helpText}
       >
         <Select
+          size={size}
           value={value}
           style={{ width: '100%' }}
           onChange={onOperatorChange}

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -75,13 +75,15 @@ export const TextFilterField: React.FC<TextFilterFieldProps> = ({
 }) => {
 
   const inputRef = React.useRef<Input>();
-  const [inputSelectionStart, setinputSelectionStart] = React.useState<number>(0);
+  const [inputSelectionStart, setInputSelectionStart] = React.useState<number>(0);
   const [inputSelectionEnd, setInputSelectionEnd] = React.useState<number>(0);
 
-  if (inputRef && inputRef.current && inputRef.current.input) {
-    inputRef.current.input.selectionStart = inputSelectionStart;
-    inputRef.current.input.selectionEnd = inputSelectionEnd;
-  }
+  React.useLayoutEffect(() => {
+    if (inputRef && inputRef.current && inputRef.current.input) {
+      inputRef.current.input.selectionStart = inputSelectionStart;
+      inputRef.current.input.selectionEnd = inputSelectionEnd;
+    }
+  }, [inputSelectionStart, inputSelectionEnd, value]);
 
   /**
    * Extracts the text value of the event object of 'onChange'
@@ -148,7 +150,7 @@ export const TextFilterField: React.FC<TextFilterFieldProps> = ({
                 // componentDidUpdate, otherwise it jumps to the end while typing
                 const cursorStart = event.target.selectionStart;
                 const cursorEnd = event.target.selectionEnd;
-                setinputSelectionStart(cursorStart);
+                setInputSelectionStart(cursorStart);
                 setInputSelectionEnd(cursorEnd);
               }}
               placeholder={placeholder}

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -55,6 +55,7 @@ export interface TextFilterFieldProps extends Partial<TextFilterFieldDefaultProp
   onValueChange?: (newValue: string) => void;
   /** The selected attribute name */
   selectedAttribute?: string;
+  size?: 'large' | 'middle' | 'small';
 }
 
 /**
@@ -69,7 +70,8 @@ export const TextFilterField: React.FC<TextFilterFieldProps> = ({
   help = 'Please enter a text.',
   internalDataDef,
   onValueChange,
-  selectedAttribute
+  selectedAttribute,
+  size
 }) => {
 
   const inputRef = React.useRef<Input>();
@@ -122,6 +124,7 @@ export const TextFilterField: React.FC<TextFilterFieldProps> = ({
         {
           sampleValues.length > 0 ?
             <AutoComplete
+              size={size}
               value={value}
               style={{ width: '100%' }}
               onChange={onAutoCompleteChange}
@@ -133,6 +136,7 @@ export const TextFilterField: React.FC<TextFilterFieldProps> = ({
             />
             :
             <Input
+              size={size}
               ref={inputRef}
               draggable={true}
               onDragStart={(e) => e.preventDefault()}


### PR DESCRIPTION
## Description

This fixes the layout of the `FilterTree` which was kind of broken (field height, margins, …) due to several antd updates.

It also simplifies the code of the `FilterTree`.

The menu (add, change, remove) is now accesible via a button which is alwas visible.

Before:

![geostyler github io_geostyler-demo_](https://user-images.githubusercontent.com/1849416/135277782-22ffdea9-8343-4249-9869-6a54c059bc14.png)

After:

![localhost_3000_ (4)](https://user-images.githubusercontent.com/1849416/135280284-3339274d-ac00-485f-aca7-b6ca1e2d3a73.png)



## Pull request type

- [x] Bugfix
- [x] Code style update (formatting, renaming)

## Do you introduce a breaking change?

- [x] No

