### PR TITLE
Comparison filter refactoring

### DIFF
--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -132,7 +132,6 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
           internalDataDef ?
             <Select
               value={value}
-              style={{ width: '100%' }}
               onChange={onAttributeChange}
               placeholder={placeholder}
               size={size}
@@ -146,7 +145,6 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
               onDragStart={(e) => e.preventDefault()}
               value={value}
               placeholder={placeholder}
-              style={{ width: '100%' }}
               size={size}
               onChange={(event) => {
                 if (onAttributeChange) {

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.less
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.less
@@ -28,6 +28,7 @@
 
 .gs-comparison-filter-ui {
   padding-left: 5px;
+  display: flex;
 
   &.micro {
     .ant-form-item {

--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -134,7 +134,9 @@ export const FilterTree: React.FC<FilterTreeProps> = ({
       _set(newFilter, position, filter);
     }
 
-    onFilterChange(newFilter);
+    if (onFilterChange) {
+      onFilterChange(newFilter);
+    }
   };
 
   /**

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -82,9 +82,6 @@ export const NumberFilterField: React.FC<NumberFilterFieldProps> = ({
           size={size}
           defaultValue={value}
           value={value}
-          style={{
-            width: '100%'
-          }}
           onChange={onValueChange}
           placeholder={placeholder}
         />

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -42,7 +42,7 @@ interface OperatorComboDefaultProps {
   /** The default text to place into the empty field */
   placeholder: string;
   /** List of operators to show in this combo */
-  operators: string[];
+  operators: ComparisonOperator[];
   /** Mapping function for operator names in this combo */
   operatorNameMappingFunction: (originalOperatorName: string) => string;
   /** Mapping function for operator title in this combo */
@@ -69,7 +69,7 @@ export const OperatorCombo: React.FC<OperatorComboProps> = ({
   showTitles = true,
   placeholder = 'Select Operator',
   value,
-  operators = ['==', '*=', '!=', '<', '<=', '>', '>='],
+  operators = ['==', '*=', '!=', '<', '<=', '>', '>=', '<=x<='],
   operatorNameMappingFunction = n => n,
   operatorTitleMappingFunction = t => t,
   validateStatus = 'error',
@@ -112,7 +112,6 @@ export const OperatorCombo: React.FC<OperatorComboProps> = ({
         <Select
           size={size}
           value={value}
-          style={{ width: '100%' }}
           onChange={onOperatorChange}
           placeholder={placeholder}
         >

--- a/src/Component/Filter/TextFilterField/TextFilterField.less
+++ b/src/Component/Filter/TextFilterField/TextFilterField.less
@@ -1,0 +1,5 @@
+.gs-text-filter-field {
+  .ant-select {
+    min-width: 10rem;
+  }
+}

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -34,6 +34,8 @@ import { Data } from 'geostyler-data';
 import _get from 'lodash/get';
 import { Feature } from 'geojson';
 
+import './TextFilterField.less';
+
 // default props
 interface TextFilterFieldDefaultProps {
   /** Label for this field */
@@ -128,7 +130,6 @@ export const TextFilterField: React.FC<TextFilterFieldProps> = ({
             <AutoComplete
               size={size}
               value={value}
-              style={{ width: '100%' }}
               onChange={onAutoCompleteChange}
               placeholder={placeholder}
               dataSource={sampleValues}
@@ -143,7 +144,6 @@ export const TextFilterField: React.FC<TextFilterFieldProps> = ({
               draggable={true}
               onDragStart={(e) => e.preventDefault()}
               value={value}
-              style={{ width: '100%' }}
               onChange={(event) => {
                 onInputChange(event);
                 // save the cursor position to restore it in


### PR DESCRIPTION
## Description

This adds support for the `IsBetweenOperator` to the `ComparisonFilter`.
It also removes some inline styling and catches undefined `onFilterChange` in the `FilterTree`.

![localhost_8080_](https://user-images.githubusercontent.com/1849416/154978366-4af58f5e-ba68-4b5b-9991-cbace5f60408.png)

## Related issues or pull requests

https://github.com/geostyler/geostyler/pull/1556#discussion_r810996640

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [x] Feature
- [ ] Dependency updates
- [] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)
