### PR TITLE
Allow editing even if document is temporarily invalid

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -136,7 +136,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           errors
         } = await activeParser.writeStyle(s);
         if (errors?.length > 0) {
-          setHasError(true);
+          setInvalidMessage(errors.map(e => e.message).join(', '));
         } else {
           setValue(parsedStyle);
         }


### PR DESCRIPTION
## Description

This prevents the code editor breaking the style if invalid text is inserted. Instead, the parse errors are shown in the editor so the user can fix the style.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
