### PR TITLE
Fix vanishing filters when dropping

### DIFF
--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -301,7 +301,6 @@ export const FilterTree: React.FC<FilterTreeProps> = ({
   const onDrop = (dropObject: any) => {
     const {
       dragNode,
-      dropPosition,
       node
     } = dropObject;
 
@@ -348,7 +347,7 @@ export const FilterTree: React.FC<FilterTreeProps> = ({
 
     const removePosition = FilterUtil.positionArrayAsString(removePositionArray);
     // Insert into new position
-    newFilter = FilterUtil.insertAtPosition(newFilter, draggedFilter, dropTargetPosition, dropPosition);
+    newFilter = FilterUtil.insertAtPosition(newFilter, draggedFilter, dropTargetPosition);
     // Remove from old position
     newFilter = FilterUtil.removeAtPosition(newFilter, removePosition);
 

--- a/src/Util/FilterUtil.spec.ts
+++ b/src/Util/FilterUtil.spec.ts
@@ -360,31 +360,35 @@ describe('FilterUtil', () => {
     it('insterts a filter at the expected position', () => {
       const baseFilter: Filter = [
         '&&',
-        [
-          '!',
-          ['==', 'name', 'Schalke']
-        ]
+        ['==', 'state', 'germany']
       ];
       const got = [
         '&&',
         ['==', 'state', 'germany'],
         [
-          '!',
-          ['==', 'name', 'Schalke']
+          '||',
+          ['>=', 'population', 100000],
+          ['<', 'population', 200000]
         ]
       ];
-      const newFilter = FilterUtil.insertAtPosition(baseFilter, ['==', 'state', 'germany'], '[1]', 0);
-      expect(newFilter).toEqual(got);
-
-      const newFilter2 = FilterUtil.insertAtPosition(
-        newFilter,
+      const newFilter = FilterUtil.insertAtPosition(
+        baseFilter,
         [
           '||',
           ['>=', 'population', 100000],
           ['<', 'population', 200000]
         ],
-        '[1]',
-        2
+        '[1]'
+      );
+      expect(newFilter).toEqual(got);
+
+      const newFilter2 = FilterUtil.insertAtPosition(
+        newFilter,
+        [
+          '!',
+          ['==', 'name', 'Schalke']
+        ],
+        '[1]'
       );
       expect(newFilter2).toEqual(filter);
     });

--- a/src/Util/FilterUtil.ts
+++ b/src/Util/FilterUtil.ts
@@ -286,42 +286,28 @@ class FilterUtil {
   static insertAtPosition(
     baseFilter: Filter,
     insertFilter: Filter,
-    position: string,
-    dropPosition: number
+    position: string
   ): Filter {
     const dropTargetParentPosition = position.substring(0, position.length - 3);
-    const dropTargetSubPosition = position.substr(position.length - 3);
-    const dropTargetSubIndex = dropTargetParentPosition === ''
-      ? 1
-      : parseInt(dropTargetSubPosition.slice(1, 2), 10);
-    const dropTargetIsComparison = !['&', '||', '!'].includes(insertFilter[0]);
+    const dropTargetSubPosition = position.substring(position.length - 3);
+    const dropTargetSubIndex = parseInt(dropTargetSubPosition.slice(1, 2), 10);
+    const dropTargetIsComparison = !['&&', '||', '!'].includes(insertFilter[0]);
     let newFilter: Filter = [...baseFilter];
 
     const newSubFilter = dropTargetParentPosition === ''
       ? newFilter
       : _get(newFilter, dropTargetParentPosition);
 
-    // Add to new position
-    switch (dropPosition) {
-      // before
-      case 0:
+    if (dropTargetIsComparison) {
+      if (newFilter.length - 1 === dropTargetSubIndex) {
+        newSubFilter.push(insertFilter);
+      } else {
         newSubFilter.splice(dropTargetSubIndex, 0, insertFilter);
-        break;
-        // on
-      case 1:
-        if (dropTargetIsComparison) {
-          newSubFilter.splice(dropTargetSubIndex + 1, 0, insertFilter);
-        } else {
-          newSubFilter.push(insertFilter);
-        }
-        break;
-        // after
-      case 2:
-        newSubFilter.splice(dropTargetSubIndex + 1, 0, insertFilter);
-        break;
-      default:
-        break;
+      }
+    } else {
+      newSubFilter.push(insertFilter);
     }
+
     return newFilter;
   }
 


### PR DESCRIPTION
## Description

When using drag'n'drop to change the filter order, dropping filters in lists with more than three filters, dropping a filter on the last ones will lead to the dropped filter being deleted.

This fixes that bug, though drag'n'drop still feels a bit flaky and should be looked at again.

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
