### PR TITLE
Transfer antd menu children to items

### DIFF
--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -69,6 +69,7 @@ import {
   isNegationFilter
 } from 'geostyler-style/dist/typeguards';
 import FilterUtil from '../../../Util/FilterUtil';
+import { ItemType } from 'antd/lib/menu/hooks/useItems';
 
 interface FilterTreeLocale {
   andDrpdwnLabel: string;
@@ -192,28 +193,53 @@ export const FilterTree: React.FC<FilterTreeProps> = ({
       }
     };
 
+    const items: ItemType[] = [];
+    if (isCombinationFilter(filter)) {
+      items.push({
+        label: 'Add filter',
+        key: 'add',
+        icon: <PlusOutlined />,
+        children: [{
+          label: locale.andDrpdwnLabel,
+          key: 'and'
+        }, {
+          label: locale.orDrpdwnLabel,
+          key: 'or'
+        }, {
+          label: locale.notDrpdwnLabel,
+          key: 'not'
+        },{
+          label: locale.comparisonDrpdwnLabel,
+          key: 'comparison'
+        }],
+      });
+    }
+    items.push({
+      label: 'Change filter',
+      key: 'change',
+      icon: <FilterOutlined />,
+      children: [{
+        label: locale.andDrpdwnLabel,
+        key: 'and'
+      }, {
+        label: locale.orDrpdwnLabel,
+        key: 'or'
+      }, {
+        label: locale.notDrpdwnLabel,
+        key: 'not'
+      },{
+        label: locale.comparisonDrpdwnLabel,
+        key: 'comparison'
+      }],
+    });
+    items.push({
+      key: 'remove',
+      icon: <MinusOutlined />
+    });
+
     const menu = (
       <Dropdown overlay={
-        <Menu onClick={onMenuClick}>
-          {
-            isCombinationFilter(filter) &&
-            <Menu.SubMenu key="add" title="Add filter" icon={<PlusOutlined />}>
-              <Menu.Item key="and">{locale.andDrpdwnLabel}</Menu.Item>
-              <Menu.Item key="or">{locale.orDrpdwnLabel}</Menu.Item>
-              <Menu.Item key="not">{locale.notDrpdwnLabel}</Menu.Item>
-              <Menu.Item key="comparison">{locale.comparisonDrpdwnLabel}</Menu.Item>
-            </Menu.SubMenu>
-          }
-          <Menu.SubMenu key="change" title="Change filter" icon={<FilterOutlined />}>
-            <Menu.Item key="and">{locale.andDrpdwnLabel}</Menu.Item>
-            <Menu.Item key="or">{locale.orDrpdwnLabel}</Menu.Item>
-            <Menu.Item key="not">{locale.notDrpdwnLabel}</Menu.Item>
-            <Menu.Item key="comparison">{locale.comparisonDrpdwnLabel}</Menu.Item>
-          </Menu.SubMenu>
-          <Menu.Item key="remove" icon={<MinusOutlined />}>
-            Remove Filter
-          </Menu.Item>
-        </Menu>
+        <Menu onClick={onMenuClick} items={items} />
       }>
         <Button
           className="filter-menu-button"

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -466,7 +466,7 @@ export class Style extends React.Component<StyleProps, StyleState> {
       icon: <CopyOutlined />
     }, {
       key: 'removeRule',
-      label: locale.addRuleBtnText,
+      label: locale.removeRulesBtnText,
       disabled: !allowRemove,
       icon: <MinusOutlined />
     }, {

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -67,6 +67,7 @@ import { IconLibrary } from '../Symbolizer/IconSelector/IconSelector';
 
 import './Style.less';
 import { CopyOutlined, MenuUnfoldOutlined, MinusOutlined, PlusOutlined } from '@ant-design/icons';
+import { ItemType } from 'antd/lib/menu/hooks/useItems';
 
 // i18n
 export interface StyleLocale {
@@ -440,6 +441,7 @@ export class Style extends React.Component<StyleProps, StyleState> {
         return !isValid;
     }
   };
+
   createFooter = () => {
     const {
       locale
@@ -453,47 +455,46 @@ export class Style extends React.Component<StyleProps, StyleState> {
     const allowRemove = selectedRowKeys.length > 0 && selectedRowKeys.length < style.rules.length;
     const allowClone = selectedRowKeys.length > 0;
 
+    const items: ItemType[] = [{
+      key: 'addRule',
+      label: locale.addRuleBtnText,
+      icon: <PlusOutlined />
+    }, {
+      key: 'cloneRules',
+      label: locale.addRuleBtnText,
+      disabled: !allowClone,
+      icon: <CopyOutlined />
+    }, {
+      key: 'removeRule',
+      label: locale.addRuleBtnText,
+      disabled: !allowRemove,
+      icon: <MinusOutlined />
+    }, {
+      key: 'multi-edit',
+      label: <span><MenuUnfoldOutlined /><span>{locale.multiEditLabel}</span></span>,
+      disabled: selectedRowKeys.length <= 1,
+      children:[{
+        key: 'color',
+        label: locale.colorLabel,
+        disabled: this.disableMenu('color', selectedRowKeys)
+      }, {
+        key: 'size',
+        label: locale.radiusLabel,
+        disabled: this.disableMenu('size', selectedRowKeys)
+      }, {
+        key: 'symbol',
+        label: locale.symbolLabel,
+        disabled: this.disableMenu('symbol', selectedRowKeys)
+      }]
+    }];
+
     return (
       <Menu
         mode="horizontal"
         onClick={this.onTableMenuClick}
         selectable={false}
-      >
-        <Menu.Item key="addRule">
-          <PlusOutlined />
-          {locale.addRuleBtnText}
-        </Menu.Item>
-        <Menu.Item key="cloneRules"
-          disabled={!allowClone}
-        >
-          <CopyOutlined />
-          {locale.cloneRulesBtnText}
-        </Menu.Item>
-        <Menu.Item key="removeRule"
-          disabled={!allowRemove}
-        >
-          <MinusOutlined />
-          {locale.removeRulesBtnText}
-        </Menu.Item>
-        <Menu.SubMenu
-          title={<span><MenuUnfoldOutlined /><span>{locale.multiEditLabel}</span></span>}
-          disabled={selectedRowKeys.length <= 1}
-        >
-          <Menu.Item
-            key="color"
-            disabled={this.disableMenu('color', selectedRowKeys)}
-          >{locale.colorLabel}</Menu.Item>
-          <Menu.Item
-            key="size"
-            disabled={this.disableMenu('size', selectedRowKeys)}
-          >{locale.radiusLabel}</Menu.Item>
-          <Menu.Item key="opacity">{locale.opacityLabel}</Menu.Item>
-          <Menu.Item
-            key="symbol"
-            disabled={this.disableMenu('symbol', selectedRowKeys)}
-          >{locale.symbolLabel}</Menu.Item>
-        </Menu.SubMenu>
-      </Menu>
+        items={items}
+      />
     );
   };
 


### PR DESCRIPTION
## Description

This transforms the children of the antd Menus to `items` as the approach of using children is deprecated in the newer antd versions

## Related issues or pull requests

Closes #1645

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [x] I'm lost; why do I have to check so many boxes? Please help!
