### PR TITLE
Changes to make build-dist and build-browser windows compatible

### DIFF
--- a/transform-less.js
+++ b/transform-less.js
@@ -29,7 +29,7 @@
 const fs = require('fs');
 const readdirp = require('readdirp');
 const childProcess = require('child_process');
-
+const path = require('path');
 const replace = require('replace-in-file');
 
 // Transform less
@@ -37,7 +37,7 @@ const replace = require('replace-in-file');
   const files = await readdirp.promise('dist', { fileFilter: '*.less' });
   files.forEach(file => {
     const out = file.fullPath.replace('.less', '.css');
-    const less = childProcess.fork('./node_modules/.bin/lessc', [file.fullPath, out]);
+    const less = childProcess.exec(`${path.join('node_modules', '.bin', 'lessc')} ${file.fullPath} ${out}`);
     less.on('exit', function (code) {
       fs.unlink(file.fullPath, (err) => {
         if (err) throw err;

--- a/webpack.browser.config.js
+++ b/webpack.browser.config.js
@@ -3,6 +3,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin")
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 require("@babel/polyfill");
+const path = require('path');
 
 module.exports = {
   entry: [
@@ -12,7 +13,7 @@ module.exports = {
   ],
   output: {
     filename: "geostyler.js",
-    path: __dirname + "/browser",
+    path: path.join(__dirname, "browser"),
     library: "GeoStyler"
   },
   mode: 'production',
@@ -52,8 +53,8 @@ module.exports = {
       {
         test: /\.(ts|tsx)$/,
         include: [
-          __dirname + '/src',
-          __dirname + '/node_modules/geostyler-style'
+          path.join(__dirname, 'src'),
+          path.join(__dirname, 'node_modules', 'geostyler-style')
         ],
         use: [
           {


### PR DESCRIPTION
## Description

Introduces minor changes in build scripts so that it is possible to run `npm run build-dist` and `npm run build-browser` in windows dev environments.

Developer guide instructions remain unchanged.

With help from @KaiVolland and @dnlkoch

## Related issues or pull requests

#1726 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
