### PR TITLE
Style cards rulename state fix

### DIFF
--- a/src/Component/CardStyle/CardStyle.tsx
+++ b/src/Component/CardStyle/CardStyle.tsx
@@ -190,10 +190,29 @@ export const CardStyle: React.FC<CardStyleProps> = ({
     setCurrentView(view);
   };
 
+  /**
+   * Update the title for all path elements with view RULEVIEW.
+   *
+   * @param ruleName The new name of the rule that should be used as title.
+   * @param path The path list to search for RULEVIEWs.
+   * @returns The path list with updated titles.
+   */
+  const updateRuleNameForPath = (ruleName: string, path: Crumb[]): Crumb[] => {
+    return path.map(pathItem => {
+      if (pathItem.view === RULEVIEW) {
+        pathItem.title = ruleName;
+      }
+      return pathItem;
+    });
+  };
+
   const onRuleChange = (newRule: GsRule) => {
     let styleClone = _cloneDeep(style);
     const ruleIdx = currentView.path[currentView.path.length - 1].indices[0];
     styleClone.rules[ruleIdx] = newRule;
+    const pathClone = _cloneDeep(currentView.path);
+    const newCurrentViewPath = updateRuleNameForPath(newRule.name, pathClone);
+    setCurrentView({...currentView, path: newCurrentViewPath});
     if (onStyleChange) {
       onStyleChange(styleClone);
     }


### PR DESCRIPTION
## Description

This fixes the broken state handling in the card layout breadcrumbs when changing the rule name.

![geostyler-card-layout-rulename-fix](https://user-images.githubusercontent.com/12186477/172624363-e38fd16a-dca8-4c6d-85cc-944f5c2a4f86.gif)


## Related issues or pull requests

None

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
