### PR TITLE
makes styleguidist config work on windows (refs #1726)

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,5 +1,6 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const path = require('path');
 require('@babel/polyfill');
 
 module.exports = {
@@ -10,7 +11,7 @@ module.exports = {
   ],
   output: {
     filename: "geostyler.js",
-    path: __dirname + "/browser",
+    path: path.join(__dirname, "browser"),
     library: "GeoStyler"
   },
   mode: 'development',
@@ -46,7 +47,7 @@ module.exports = {
       },
       {
         test: /\.(ts|tsx)$/,
-        include: __dirname + '/src',
+        include: path.join(__dirname, 'src'),
         use: [
           {
             loader: require.resolve('ts-loader'),


### PR DESCRIPTION
## Description

Uses `path` module to make styleguidist build work in both linux and windows environments.

## Related issues or pull requests

refs issue #1726 

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
