### PR TITLE
change testMatch expression (closes #1726)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -45,7 +45,7 @@ module.exports = {
   ],
   testMatch: [
     "<rootDir>/src/**/__tests__/**/*.(j|t)s?(x)",
-    "<rootDir>/src/**/?(*.)(spec|test).(j|t)s?(x)"
+    "<rootDir>/src/**/*(*.)(spec|test).(j|t)s?(x)"
   ],
   transform: {
     "^.+\\.jsx?$": "<rootDir>/node_modules/babel-jest",


### PR DESCRIPTION
## Description

This change in the testMatch expression for jest makes the tests pass in both linux and windows environment.

The previous expression did not match any test on windows.

## Related issues or pull requests

Issue #1726 

## Pull request type

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
