### PR TITLE
Fix documentation workflows

### DIFF
--- a/.github/workflows/on-publish.yml
+++ b/.github/workflows/on-publish.yml
@@ -38,18 +38,18 @@ jobs:
       run: |
         echo "VERSION=$(node -pe "require('./package.json').version")" >> $GITHUB_ENV
 
-    - name: Deploy (to docs/v${{ env.VERSION }}) 🚀
+    - name: Deploy (to v${{ env.VERSION }}) 🚀
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
         FOLDER: build/styleguide
-        TARGET_FOLDER: docs/v${{ env.VERSION }}
+        TARGET_FOLDER: v${{ env.VERSION }}
 
-    - name: Deploy (to docs/latest) 🚀
+    - name: Deploy (to latest) 🚀
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
         FOLDER: build/styleguide
-        TARGET_FOLDER: docs/latest
+        TARGET_FOLDER: latest

--- a/.github/workflows/on-push-master.yml
+++ b/.github/workflows/on-push-master.yml
@@ -65,10 +65,10 @@ jobs:
     - name: Build styleguide 🏗️
       run: npm run build-styleguide
 
-    - name: Deploy (to docs/master) 🚀
+    - name: Deploy (to master) 🚀
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
         FOLDER: build/styleguide
-        TARGET_FOLDER: docs/master
+        TARGET_FOLDER: master


### PR DESCRIPTION
## Description

This fixes the workflow the deploys the documentation to gh-pages. Previously, the latest build were placed into a directory called `docs` which we did not use before.

## Related issues or pull requests


## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
