### PR TITLE
Speed up start of the styleguidist

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -28,23 +28,27 @@
 
 const path = require('path');
 const webpackConfig = require('./webpack.dev.config');
+const rdt = require('react-docgen-typescript');
 
 module.exports = {
   title: 'GeoStyler',
   styleguideDir: './build/styleguide',
   webpackConfig: {
     ...webpackConfig,
-    mode: 'production'
+    mode: process.env.NODE_ENV
   },
+  minimize: process.env.NODE_ENV === 'production',
   assetsDir: './docs',
-  propsParser: require('react-docgen-typescript')
-    .withCustomConfig('./tsconfig.json', {propFilter: (prop) => {
-      if (prop.parent) {
-        return !prop.parent.fileName.includes('node_modules');
-      }
-      return true;
-    }})
-    .parse,
+  propsParser: process.env.NODE_ENV === 'production' ?
+    rdt
+      .withCustomConfig('./tsconfig.json', {propFilter: (prop) => {
+        if (prop.parent) {
+          return !prop.parent.fileName.includes('node_modules');
+        }
+        return true;
+      }})
+      .parse :
+    undefined,
   components: 'src/Component/**/*.tsx',
   getExampleFilename(componentPath) {
     return componentPath.replace(/\.tsx?$/, '.example.md')

--- a/webpack.browser.config.js
+++ b/webpack.browser.config.js
@@ -1,25 +1,25 @@
 const TerserPlugin = require('terser-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const CssMinimizerPlugin = require("css-minimizer-webpack-plugin")
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-require("@babel/polyfill");
+require('@babel/polyfill');
 const path = require('path');
 
 module.exports = {
   entry: [
-    "@babel/polyfill",
-    "whatwg-fetch",
-    "./src/index.ts"
+    '@babel/polyfill',
+    'whatwg-fetch',
+    './src/index.ts'
   ],
   output: {
-    filename: "geostyler.js",
-    path: path.join(__dirname, "browser"),
-    library: "GeoStyler"
+    filename: 'geostyler.js',
+    path: path.join(__dirname, 'browser'),
+    library: 'GeoStyler'
   },
   mode: 'production',
   resolve: {
     // Add '.ts' and '.tsx' as resolvable extensions.
-    extensions: [".ts", ".tsx", ".js", ".json"]
+    extensions: ['.ts', '.tsx', '.js', '.json']
   },
   optimization: {
     minimizer: [
@@ -35,7 +35,7 @@ module.exports = {
           {
             loader: MiniCssExtractPlugin.loader,
           },
-          "css-loader"
+          'css-loader'
         ],
       },
       {
@@ -70,7 +70,7 @@ module.exports = {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: "geostyler.css"
+      filename: 'geostyler.css'
     }),
     new ForkTsCheckerWebpackPlugin({
       async: false,
@@ -84,7 +84,7 @@ module.exports = {
   // This is important because it allows us to avoid bundling all of our
   // dependencies, which allows browsers to cache those libraries between builds.
   externals: {
-    "react": "React",
-    "react-dom": "ReactDOM"
+    'react': 'React',
+    'react-dom': 'ReactDOM'
   }
 };

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -5,21 +5,21 @@ require('@babel/polyfill');
 
 module.exports = {
   entry: [
-    "@babel/polyfill",
-    "whatwg-fetch",
-    "./src/index.ts"
+    '@babel/polyfill',
+    'whatwg-fetch',
+    './src/index.ts'
   ],
   output: {
-    filename: "geostyler.js",
-    path: path.join(__dirname, "browser"),
-    library: "GeoStyler"
+    filename: 'geostyler.js',
+    path: path.join(__dirname, 'browser'),
+    library: 'GeoStyler'
   },
   mode: 'development',
   resolve: {
     // Add '.ts' and '.tsx' as resolvable extensions.
-    extensions: [".ts", ".tsx", ".js", ".json"],
+    extensions: ['.ts', '.tsx', '.js', '.json'],
     fallback: {
-      "buffer": false
+      'buffer': false
     }
   },
   module: {
@@ -30,7 +30,7 @@ module.exports = {
           {
             loader: MiniCssExtractPlugin.loader,
           },
-          "css-loader"
+          'css-loader'
         ],
       },
       {
@@ -58,7 +58,7 @@ module.exports = {
   },
   plugins: [
     new MiniCssExtractPlugin({
-      filename: "geostyler.css"
+      filename: 'geostyler.css'
     }),
     new ForkTsCheckerWebpackPlugin({
       async: false,
@@ -72,7 +72,7 @@ module.exports = {
   // This is important because it allows us to avoid bundling all of our
   // dependencies, which allows browsers to cache those libraries between builds.
   externals: {
-    "react": "React",
-    "react-dom": "ReactDOM"
+    'react': 'React',
+    'react-dom': 'ReactDOM'
   }
 };


### PR DESCRIPTION
## Description

After fiddling around with the current configuration, it looks like the `react-docgen-typescript` is slowing down the initial build of the styleguidist tremendously while checking the props/types of any parent component (e.g. the extended antd types).

This suggests to skip this check in `development` mode which will result in decent startup times (before: ~180s. after: ~20 s), **BUT** the list of props might not be complete. There seems to be a bug while detecting the props of function components as well, see [here](https://github.com/styleguidist/react-styleguidist/issues/1989).

## Related issues or pull requests

#1375.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
