### PR TITLE
Rename default branch to main

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Thank you for considering giving code and/or documentation back to this project,
 
 ## Some guidelines for the proposed change
 
-Please review the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md) and the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md) of this repository. This makes it easy for you to give back and for us to accept your changes.
+Please review the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md) of this repository. This makes it easy for you to give back and for us to accept your changes.
 
 Please use the template below the line for the pull request description, and make sure to tick off the boxes in the checklists. In your final pull request everything above the next horizontal line can be removed to not distract reviewers or other readers.
 
@@ -46,8 +46,8 @@ Please check the type of change your PR introduces:
 
 ## Checklist
 
-- [ ] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
-- [ ] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
-- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
+- [ ] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
+- [ ] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
+- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
 - [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
 - [ ] I'm lost; why do I have to check so many boxes? Please help!

--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -1,9 +1,9 @@
-name: Test, Coverage & Docs (master)
+name: Test, Coverage & Docs (main)
 
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:
@@ -65,10 +65,10 @@ jobs:
     - name: Build styleguide 🏗️
       run: npm run build-styleguide
 
-    - name: Deploy (to master) 🚀
+    - name: Deploy (to main) 🚀
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH: gh-pages
         FOLDER: build/styleguide
-        TARGET_FOLDER: master
+        TARGET_FOLDER: main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ on GitHub.
 ## Changing code and documentation
 
 This guide covers contributing to the main version of GeoStyler source
-code which is the master branch.
+code which is the main branch.
 It assumes that you have some very basic knowledge of Git and GitHub,
 but if you don't just go through some tutorial online.
 
@@ -66,10 +66,10 @@ It is important that "origin" points to your fork.
 
 ### Update before creating a branch
 
-* Make sure your are using master branch:
+* Make sure your are using main branch:
 
 ```
-git checkout master
+git checkout main
 ```
 
 * Download updates from all branches from all remotes:
@@ -78,10 +78,10 @@ git checkout master
 git fetch upstream
 ```
 
-* Update your local master branch to match master in the main repository:
+* Update your local main branch to match main in the main repository:
 
 ```
-git rebase upstream/master
+git rebase upstream/main
 ```
 
 ### Update if you have local branches
@@ -96,7 +96,7 @@ git stash
 * Now you can rebase:
 
 ```
-git rebase upstream/master
+git rebase upstream/main
 ```
 
 * Apply your local changes on top:
@@ -113,7 +113,7 @@ git stash pop
 
 ### Creating a branch
 
-Now you have updated your local master branch, you can create a branch
+Now you have updated your local main branch, you can create a branch
 based on it.
 
 * Create a branch and switch to it:
@@ -168,7 +168,7 @@ the maintainers will decide if it is more appropriate to:
 
 * merge your branch,
 * squash all commit into one commit, or
-* rebase (i.e., replay) all commits on top of the master branch.
+* rebase (i.e., replay) all commits on top of the main branch.
 
 
 ### Legalese

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ![GeoStyler Logo](/docs/Geo_Styler_Logo_300_RGB.jpg)
 
-[![Test, Coverage & Docs (master)](https://github.com/geostyler/geostyler/actions/workflows/on-push-master.yml/badge.svg)](https://github.com/geostyler/geostyler/actions/workflows/on-push-master.yml) [![Create & publish versioned documentation](https://github.com/geostyler/geostyler/actions/workflows/on-publish.yml/badge.svg)](https://github.com/geostyler/geostyler/actions/workflows/on-publish.yml) [![Coverage Status](https://coveralls.io/repos/github/geostyler/geostyler/badge.svg?branch=master)](https://coveralls.io/github/geostyler/geostyler?branch=master) [![License](https://img.shields.io/github/license/geostyler/geostyler)](https://github.com/geostyler/geostyler/blob/master/LICENSE)
+[![Test, Coverage & Docs (main)](https://github.com/geostyler/geostyler/actions/workflows/on-push-main.yml/badge.svg)](https://github.com/geostyler/geostyler/actions/workflows/on-push-main.yml) [![Create & publish versioned documentation](https://github.com/geostyler/geostyler/actions/workflows/on-publish.yml/badge.svg)](https://github.com/geostyler/geostyler/actions/workflows/on-publish.yml) [![Coverage Status](https://coveralls.io/repos/github/geostyler/geostyler/badge.svg?branch=main)](https://coveralls.io/github/geostyler/geostyler?branch=main) [![License](https://img.shields.io/github/license/geostyler/geostyler)](https://github.com/geostyler/geostyler/blob/main/LICENSE)
 
 Code: [github](https://github.com/geostyler/geostyler)
 Package: [npm](https://www.npmjs.com/package/geostyler)
 
 Documentation:
-[master](https://geostyler.github.io/geostyler/master/index.html) /
+[main](https://geostyler.github.io/geostyler/main/index.html) /
 [latest](https://geostyler.github.io/geostyler/latest/index.html) /
 [4.3.0](https://geostyler.github.io/geostyler/v4.3.0/index.html)
 
@@ -228,5 +228,5 @@ Developing GeoStyler data parsers follows the same pattern as described in [Deve
 ## <a name="license"></a>License
 
 GeoStyler is released under the BSD 2-Clause license. Please see the file
-[`LICENSE`](https://github.com/geostyler/geostyler/blob/master/LICENSE) in the
+[`LICENSE`](https://github.com/geostyler/geostyler/blob/main/LICENSE) in the
 root of this repository.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,14 @@
 ![GeoStyler Logo](./Geo_Styler_Logo_300_RGB.jpg)
 
-[![Build Status](https://travis-ci.org/geostyler/geostyler.svg?branch=master)](https://travis-ci.org/geostyler/geostyler)
+[![Build Status](https://travis-ci.org/geostyler/geostyler.svg?branch=main)](https://travis-ci.org/geostyler/geostyler)
 [![Greenkeeper badge](https://badges.greenkeeper.io/geostyler/geostyler.svg)](https://greenkeeper.io/)
-[![Coverage Status](https://coveralls.io/repos/github/geostyler/geostyler/badge.svg?branch=master)](https://coveralls.io/github/geostyler/geostyler?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/geostyler/geostyler/badge.svg?branch=main)](https://coveralls.io/github/geostyler/geostyler?branch=main)
 
 Code: [github](https://github.com/geostyler/geostyler)
 Package: [npm](https://www.npmjs.com/package/geostyler)
 
 Documentation:
-[master](https://geostyler.github.io/geostyler/master/index.html) /
+[main](https://geostyler.github.io/geostyler/main/index.html) /
 [latest](https://geostyler.github.io/geostyler/latest/index.html) /
 [4.3.0](https://geostyler.github.io/geostyler/v4.3.0/index.html)
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint:test:cleanup:build": "npm run lint && npm run test && npm run cleanup && npm run build",
     "cleanup": "rimraf dist/** && rimraf build/**",
     "prepublishOnly": "npm run build-dist && npm run build-browser",
-    "release": "np --no-yarn && git push https://github.com/geostyler/geostyler.git master",
+    "release": "np --no-yarn && git push https://github.com/geostyler/geostyler.git main",
     "styleguide": "styleguidist server",
     "start-dev": "webpack --watch --config webpack.dev.config.js",
     "test": "jest --coverage",


### PR DESCRIPTION
## Description

This suggests to adjust several links to the updated name of the default branch.

## Related issues or pull requests

--

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
