### PR TITLE
Add Renderer component to SYMBOLIZERVIEW

### DIFF
--- a/src/Component/CardStyle/CardStyle.less
+++ b/src/Component/CardStyle/CardStyle.less
@@ -1,0 +1,16 @@
+.gs-card-style {
+  > .gs-renderer {
+
+    .gs-symbolizer-renderer {
+      width: 50px;
+      height: 50px;
+      cursor: default;
+    }
+
+    .gs-symbolizer-sldrenderer {
+      width: 50px;
+      height: 50px;
+      cursor: default;
+    }
+  }
+}

--- a/src/Component/CardStyle/CardStyle.tsx
+++ b/src/Component/CardStyle/CardStyle.tsx
@@ -60,6 +60,7 @@ import { BulkEditor } from '../BulkEditor/BulkEditor';
 import IconSelector, { IconLibrary } from '../Symbolizer/IconSelector/IconSelector';
 import { ComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
 import { GeoStylerLocale } from '../../locale/locale';
+import Renderer from '../Renderer/Renderer';
 
 // default props
 interface CardStyleDefaultProps {
@@ -312,7 +313,9 @@ export const CardStyle: React.FC<CardStyleProps> = ({
   const mergedStyleOverviewProps = {...styleOverviewProps, ...styleOverviewPropsOverwrites};
 
   return (
-    <div>
+    <div
+      className='gs-card-style'
+    >
       <Breadcrumb
         crumbs={currentView.path}
         onClick={changeView}
@@ -342,23 +345,35 @@ export const CardStyle: React.FC<CardStyleProps> = ({
       }
       {
         currentView.view === SYMBOLIZERVIEW && (
-          <Editor
-            symbolizer={
-              style
-                .rules[currentView.path[currentView.path.length - 1].indices[0]]
-                .symbolizers[currentView.path[currentView.path.length - 1].indices[1]]
-            }
-            onSymbolizerChange={onSymbolizerChange}
-            iconEditorProps={{
-              imageFieldProps: {
-                windowless: true,
-                onIconLibrariesClick: onIconEditorChangeView
+          <>
+            <Renderer
+              symbolizers={[
+                style
+                  .rules[currentView.path[currentView.path.length - 1].indices[0]]
+                  .symbolizers[currentView.path[currentView.path.length - 1].indices[1]]
+              ]}
+              data={data}
+              rendererType={rendererType}
+              // TODO add sldRendererProps
+            />
+            <Editor
+              symbolizer={
+                style
+                  .rules[currentView.path[currentView.path.length - 1].indices[0]]
+                  .symbolizers[currentView.path[currentView.path.length - 1].indices[1]]
               }
-            }}
-            internalDataDef={data}
-            iconLibraries={iconLibraries}
-            {...editorProps}
-          />
+              onSymbolizerChange={onSymbolizerChange}
+              iconEditorProps={{
+                imageFieldProps: {
+                  windowless: true,
+                  onIconLibrariesClick: onIconEditorChangeView
+                }
+              }}
+              internalDataDef={data}
+              iconLibraries={iconLibraries}
+              {...editorProps}
+            />
+          </>
         )
       }
       {

--- a/src/Component/RuleFieldContainer/RuleFieldContainer.less
+++ b/src/Component/RuleFieldContainer/RuleFieldContainer.less
@@ -13,6 +13,12 @@
 
     .gs-symbolizer-renderer {
       height: 100%;
+      cursor: default;
+    }
+
+    .gs-symbolizer-sldrenderer {
+      height: 100%;
+      cursor: default;
     }
   }
 }


### PR DESCRIPTION
## Description

This adds `<Renderer />` to SYMBOLIZERVIEW to enable users to directly see the changes they are applying.

This also changes the cursor to `default` for the non-clickable `<Renderer />`s.

Please note that a proper styling will be part of a subsequent PR, where also the Editor styling will be changed.

![image](https://user-images.githubusercontent.com/12186477/173576847-b57a4c9e-c7b1-4fef-99f4-b979f1678953.png)


## Related issues or pull requests

https://github.com/geostyler/geostyler/issues/1748

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
