### PR TITLE
Verify that dev setup works on various OS

### DIFF
--- a/.github/workflows/dev-setup-working.yml
+++ b/.github/workflows/dev-setup-working.yml
@@ -1,0 +1,45 @@
+name: Verify dev setup works on various OS
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Cache Node.js modules 💾
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.OS }}-node-
+          ${{ runner.OS }}-
+
+    - name: Install dependencies ⏬
+      run: npm install
+
+    - name: Lint code 💄
+      run: npm run lint
+
+    - name: Test code ✅
+      run: npm run test-ci
+
+    - name: Build artifacts 🏗️
+      run: npm run build
+
+#    - name: Check webpack serving, how to test is unclear currently for me…
+#      run: npm run start-dev
+#
+#    - name: Check testsuite watching, how to test is unclear currently for me…
+#      run: npm run test-watch

--- a/.github/workflows/dev-setup-working.yml
+++ b/.github/workflows/dev-setup-working.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Checkout sources


### PR DESCRIPTION
## Description

This PR suggests to add a new workflow that can be [manually triggered from the GitHub website](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow). It tries to execute some steps a developer would usually run, and we verify these all give expected results (i.e. do not err).

In order to test this / execute this, I think it first must be merged:

> To trigger the workflow_dispatch event, your workflow must be in the default branch.

This workflow runs on Windows, macOS and Ubuntu, and ensures that developers with different OS still can work on GeoStyler.

## Related issues or pull requests

This came up for some devs during the latest Codesprint.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
