### PR TITLE
Attempt to check watcher-scripts

### DIFF
--- a/.github/workflows/dev-setup-working.yml
+++ b/.github/workflows/dev-setup-working.yml
@@ -38,8 +38,21 @@ jobs:
     - name: Build artifacts 🏗️
       run: npm run build
 
-#    - name: Check webpack serving, how to test is unclear currently for me…
-#      run: npm run start-dev
+    - name: Check webpack serving
+      run: echo "::set-output name=start_dev_output::$(npm run start-dev)"
+      id: run_start_dev
+      timeout-minutes: 2
+      continue-on-error: true
+
+    - name: …did we compile successfully?
+      run: |
+        from sys import exit;
+        if "${{ steps.run_start_dev.outputs.start_dev_output }}".find("compiled successfully in") == -1:
+          exit(1)
+        else:
+          exit(0)
+      shell: python
+
 #
 #    - name: Check testsuite watching, how to test is unclear currently for me…
 #      run: npm run test-watch


### PR DESCRIPTION
## Description

A follow up of #1783, I think I can only test this once it is merged. Do you interpret the docs e.g. about [`outputs`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idoutputs), [`timeout-minutes`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepstimeout-minutes) and  [`continue-on-error`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error) the same way?

This is not tested right now.

## Related issues or pull requests

#1783

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
