### PR TITLE
Update geostyler-openlayers-parser to v3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "geostyler-cql-parser": "^1.1.0",
         "geostyler-data": "^1.0.0",
         "geostyler-geojson-parser": "^1.0.1",
-        "geostyler-openlayers-parser": "^3.0.1",
+        "geostyler-openlayers-parser": "^3.1.0",
         "geostyler-sld-parser": "^3.2.2",
         "geostyler-style": "^5.1.0",
         "geostyler-wfs-parser": "^1.0.1",
@@ -10295,16 +10295,22 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/geostyler-openlayers-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
-      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
       "dependencies": {
+        "color-name": "^1.1.4",
         "geostyler-style": "^5.0.2",
         "lodash": "^4.17.21"
       },
       "peerDependencies": {
         "ol": "^6.0.0"
       }
+    },
+    "node_modules/geostyler-openlayers-parser/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/geostyler-sld-parser": {
       "version": "3.2.2",
@@ -33241,12 +33247,20 @@
       }
     },
     "geostyler-openlayers-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.0.2.tgz",
-      "integrity": "sha512-HiEjaobWR/UU/1NoSyobV85OIdoX7gxQaaTVQaFIyo7+8zN+RWRMf99chmY9PSasX8b5khN1LJfVL1ySUKwcsQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-openlayers-parser/-/geostyler-openlayers-parser-3.1.0.tgz",
+      "integrity": "sha512-TidTBmvlM/yVUWuarjO5mb9uiBmRDeWxCkdnvktuUrezWUWsVZWUXk9faA9s9D8o3IQMKJtI5UzIcSGuCB6H0Q==",
       "requires": {
+        "color-name": "^1.1.4",
         "geostyler-style": "^5.0.2",
         "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
       }
     },
     "geostyler-sld-parser": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "geostyler-cql-parser": "^1.1.0",
     "geostyler-data": "^1.0.0",
     "geostyler-geojson-parser": "^1.0.1",
-    "geostyler-openlayers-parser": "^3.0.1",
+    "geostyler-openlayers-parser": "^3.1.0",
     "geostyler-sld-parser": "^3.2.2",
     "geostyler-style": "^5.1.0",
     "geostyler-wfs-parser": "^1.0.1",

--- a/src/Component/Symbolizer/Renderer/Renderer.tsx
+++ b/src/Component/Symbolizer/Renderer/Renderer.tsx
@@ -150,6 +150,9 @@ export const Renderer: React.FC<RendererProps> = ({
    * @param {Symbolizer[]} newSymbolizers The symbolizers holding the style to apply
    */
   const applySymbolizers = async(newSymbolizers: Symbolizer[]) => {
+    if (!newSymbolizers) {
+      return undefined;
+    }
     const styleParser = new OlStyleParser();
 
     // we have to wrap the symbolizer in a Style object since the writeStyle

--- a/src/Util/RuleGeneratorUtil.spec.ts
+++ b/src/Util/RuleGeneratorUtil.spec.ts
@@ -43,8 +43,8 @@ describe('RuleGeneratorUtil', () => {
       expect(distinctValues).toHaveLength(16);
 
       const dummyWithDuplicates = _cloneDeep(dummyData);
-      dummyWithDuplicates.exampleFeatures.features[0].properties.GEN = 'same';
-      dummyWithDuplicates.exampleFeatures.features[1].properties.GEN = 'same';
+      dummyWithDuplicates.exampleFeatures!.features[0]!.properties!.GEN = 'same';
+      dummyWithDuplicates.exampleFeatures!.features[1]!.properties!.GEN = 'same';
       const newDistinct = RuleGeneratorUtil.getDistinctValues(dummyWithDuplicates, 'GEN');
       expect(newDistinct).toHaveLength(15);
     });


### PR DESCRIPTION
## Description

This updates the `geostyler-openlayers-parser` to v3.1.0.
It also adds a check to the `Renderer` component to avoid the creation of an invalid geostyler-style.

## Related issues or pull requests

Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.

## Pull request type

Closes #1787 

- [x] Bugfix
- [ ] Feature
- [x] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
