### PR TITLE
Add sample uscase of browser build

### DIFF
--- a/public/browser.html
+++ b/public/browser.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Document</title>
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="../browser/geostyler.js"></script>
+  <link rel="stylesheet" href="../browser/geostyler.css"/>
+  <link rel="stylesheet" href="../node_modules/antd/dist/antd.css"/>
+  <link rel="stylesheet" href="../node_modules/ol/ol.css"/>
+</head>
+<body>
+  <div id="root" ></div>
+  <div style="display: flex;">
+    <div id="preview" style="flex: 1;"></div>
+    <textarea id="textual_style" style="flex: 1; height: 300px;"></textarea>
+  </div>
+  <script defer>
+    const root = ReactDOM.createRoot(
+      document.getElementById('root')
+    );
+    const preview = ReactDOM.createRoot(
+      document.getElementById('preview')
+    );
+    let style = {
+      "name": "Demo Style",
+      "rules": [
+        {
+          "name": "Rule 1",
+          "symbolizers": [
+            {
+              "kind": "Mark",
+              "wellKnownName": "circle"
+            }
+          ]
+        }
+      ]
+    };
+    const renderPreview = () => {
+      const gsPreview = React.createElement(GeoStyler.PreviewMap, {
+          style: style,
+          mapHeight: 300
+        });
+      preview.render(gsPreview);
+    };
+    const geostyler = React.createElement(GeoStyler.Style, {
+      compact: true,
+      style: style,
+      onStyleChange: (gsStyle) => {
+        style = gsStyle;
+        document.getElementById('textual_style').value = JSON.stringify(style, null, 2);
+        renderPreview();
+      }
+    });
+    root.render(geostyler);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Description

This adds a very basic example for the usage of the browser build.

![localhost_8082_public_browser html](https://user-images.githubusercontent.com/1849416/179682427-dc5bc3e8-2a8f-4319-af90-16a29aa57fc1.png)

This is useful to verify that the browser build works as expected. A real test would be much better. So this might be replaced in the future. Maybe something @marcjansen want to have a look at if he is bored :wink: .

To test this the root directory has to be served. e.g:

```
npx http-server .
```

go to `http://127.0.0.1:8080/public/browser.html` (port may be different)

## Related issues or pull requests

Seems like #1804 can be closed,  as the browser-build works as expected.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
