### PR TITLE
Fix typing of mapHeight prop in PreviewMap

### DIFF
--- a/src/Component/PreviewMap/PreviewMap.tsx
+++ b/src/Component/PreviewMap/PreviewMap.tsx
@@ -44,13 +44,14 @@ import OlStyleParser from 'geostyler-openlayers-parser';
 import GeometryUtil from '../../Util/GeometryUtil';
 
 import './PreviewMap.less';
+import { StandardLonghandProperties } from 'csstype';
 
 // default props
 export interface PreviewMapDefaultProps {
   /** The projection of the data to visualize */
   dataProjection: ProjectionLike;
   /** The height of the map */
-  mapHeight: number;
+  mapHeight: StandardLonghandProperties['height'];
 }
 
 // non default props


### PR DESCRIPTION
## Description

This fixes the typing of the `mapHeight` property in the `PreviewMap`.
It was typed as `number` but actualy accepts all values the CSS height property accepts. Just like '100%', '100vh', …

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
