### PR TITLE
Introduces `nullToUndefined` modificator

### DIFF
--- a/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.tsx
+++ b/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.tsx
@@ -29,12 +29,13 @@
 import * as React from 'react';
 
 import {
-  InputNumber
+  InputNumber, InputNumberProps
 } from 'antd';
+import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface BrightnessFieldProps {
-  onChange?: (opacity: number) => void;
+export interface BrightnessFieldProps extends InputNumberProps {
+  onChange?: (opacity: number | undefined) => void;
   brightness?: number;
 }
 
@@ -43,7 +44,8 @@ export interface BrightnessFieldProps {
  */
 export const BrightnessField: React.FC<BrightnessFieldProps> = ({
   onChange,
-  brightness
+  brightness,
+  ...inputProps
 }) => {
 
   return (
@@ -53,7 +55,8 @@ export const BrightnessField: React.FC<BrightnessFieldProps> = ({
       max={1}
       step={0.1}
       value={brightness}
-      onChange={onChange}
+      onChange={FieldUtil.nullToUndefined(onChange)}
+      {...inputProps}
     />
   );
 };

--- a/src/Component/Symbolizer/Field/ContrastField/ContrastField.tsx
+++ b/src/Component/Symbolizer/Field/ContrastField/ContrastField.tsx
@@ -29,12 +29,13 @@
 import * as React from 'react';
 
 import {
-  InputNumber
+  InputNumber, InputNumberProps
 } from 'antd';
+import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface ContrastFieldProps {
-  onChange?: (opacity: number) => void;
+export interface ContrastFieldProps extends InputNumberProps {
+  onChange?: (opacity: number | undefined) => void;
   contrast?: number;
 }
 
@@ -43,7 +44,8 @@ export interface ContrastFieldProps {
  */
 export const ContrastField: React.FC<ContrastFieldProps> = ({
   onChange,
-  contrast
+  contrast,
+  ...inputProps
 }) => {
 
   return (
@@ -53,7 +55,8 @@ export const ContrastField: React.FC<ContrastFieldProps> = ({
       max={1}
       step={0.1}
       value={contrast}
-      onChange={onChange}
+      onChange={FieldUtil.nullToUndefined(onChange)}
+      {...inputProps}
     />
   );
 };

--- a/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.tsx
+++ b/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.tsx
@@ -29,12 +29,13 @@
 import * as React from 'react';
 
 import {
-  InputNumber
+  InputNumber, InputNumberProps
 } from 'antd';
+import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface FadeDurationFieldProps {
-  onChange?: (opacity: number) => void;
+export interface FadeDurationFieldProps extends InputNumberProps {
+  onChange?: (opacity: number | undefined) => void;
   fadeDuration?: number;
 }
 
@@ -43,7 +44,8 @@ export interface FadeDurationFieldProps {
  */
 export const FadeDurationField: React.FC<FadeDurationFieldProps> = ({
   onChange,
-  fadeDuration
+  fadeDuration,
+  ...inputProps
 }) => {
 
   return (
@@ -52,7 +54,8 @@ export const FadeDurationField: React.FC<FadeDurationFieldProps> = ({
       min={0}
       step={10}
       value={fadeDuration}
-      onChange={onChange}
+      onChange={FieldUtil.nullToUndefined(onChange)}
+      {...inputProps}
     />
   );
 };

--- a/src/Component/Symbolizer/Field/GammaField/GammaField.tsx
+++ b/src/Component/Symbolizer/Field/GammaField/GammaField.tsx
@@ -29,12 +29,13 @@
 import * as React from 'react';
 
 import {
-  InputNumber
+  InputNumber, InputNumberProps
 } from 'antd';
+import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface GammaFieldProps {
-  onChange?: (opacity: number) => void;
+export interface GammaFieldProps extends InputNumberProps {
+  onChange?: (gamma: number | undefined) => void;
   gamma?: number;
 }
 
@@ -43,7 +44,8 @@ export interface GammaFieldProps {
  */
 export const GammaField: React.FC<GammaFieldProps> = ({
   onChange,
-  gamma
+  gamma,
+  ...inputProps
 }) => {
 
   return (
@@ -52,7 +54,8 @@ export const GammaField: React.FC<GammaFieldProps> = ({
       min={0}
       step={0.1}
       value={gamma}
-      onChange={onChange}
+      onChange={FieldUtil.nullToUndefined(onChange)}
+      {...inputProps}
     />
   );
 };

--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
@@ -30,9 +30,10 @@ import * as React from 'react';
 
 import { InputNumber } from 'antd';
 import { InputNumberProps } from 'antd/lib/input-number';
+import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface OffsetFieldProps extends Partial<InputNumberProps> {
+export interface OffsetFieldProps extends InputNumberProps {
   offset?: number;
 }
 
@@ -50,7 +51,7 @@ export const OffsetField: React.FC<OffsetFieldProps> = ({
       className="editor-field offset-field"
       value={offset}
       step={1}
-      onChange={onChange}
+      onChange={FieldUtil.nullToUndefined(onChange)}
       {...inputProps}
     />
   );

--- a/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
+++ b/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
@@ -32,6 +32,7 @@ import {
   InputNumber
 } from 'antd';
 import { InputNumberProps } from 'antd/lib/input-number';
+import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
 export interface OpacityFieldProps extends Partial<InputNumberProps> {
@@ -55,7 +56,7 @@ export const OpacityField: React.FC<OpacityFieldProps> = ({
       max={1}
       step={0.01}
       value={opacity}
-      onChange={onChange}
+      onChange={FieldUtil.nullToUndefined(onChange)}
       {...inputProps}
     />
   );

--- a/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
+++ b/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
@@ -29,11 +29,12 @@
 import * as React from 'react';
 
 import {
-  InputNumber
+  InputNumber, InputNumberProps
 } from 'antd';
+import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface RadiusFieldProps {
+export interface RadiusFieldProps extends InputNumberProps {
   onChange?: (radius: number) => void;
   radius?: number;
 }
@@ -43,7 +44,8 @@ export interface RadiusFieldProps {
  */
 export const RadiusField: React.FC<RadiusFieldProps> = ({
   onChange,
-  radius
+  radius,
+  ...inputProps
 }) => {
 
   return (
@@ -51,7 +53,8 @@ export const RadiusField: React.FC<RadiusFieldProps> = ({
       className="editor-field radius-field"
       min={0}
       value={radius}
-      onChange={onChange}
+      onChange={FieldUtil.nullToUndefined(onChange)}
+      {...inputProps}
     />
   );
 };

--- a/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
+++ b/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
@@ -29,11 +29,12 @@
 import * as React from 'react';
 
 import {
-  InputNumber
+  InputNumber, InputNumberProps
 } from 'antd';
+import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface RotateFieldProps {
+export interface RotateFieldProps extends InputNumberProps {
   onChange?: (radius: number) => void;
   rotate?: number;
 }
@@ -43,7 +44,8 @@ export interface RotateFieldProps {
  */
 export const RotateField: React.FC<RotateFieldProps> = ({
   onChange,
-  rotate
+  rotate,
+  ...inputProps
 }) => {
 
   return (
@@ -52,7 +54,8 @@ export const RotateField: React.FC<RotateFieldProps> = ({
       min={-360}
       max={360}
       value={rotate}
-      onChange={onChange}
+      onChange={FieldUtil.nullToUndefined(onChange)}
+      {...inputProps}
     />
   );
 };

--- a/src/Component/Symbolizer/Field/SaturationField/SaturationField.tsx
+++ b/src/Component/Symbolizer/Field/SaturationField/SaturationField.tsx
@@ -29,11 +29,12 @@
 import * as React from 'react';
 
 import {
-  InputNumber
+  InputNumber, InputNumberProps
 } from 'antd';
+import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface SaturationFieldProps {
+export interface SaturationFieldProps extends InputNumberProps {
   onChange?: (opacity: number) => void;
   saturation?: number;
 }
@@ -43,7 +44,8 @@ export interface SaturationFieldProps {
  */
 export const SaturationField: React.FC<SaturationFieldProps> = ({
   onChange,
-  saturation
+  saturation,
+  ...inputProps
 }) => {
 
   return (
@@ -53,7 +55,8 @@ export const SaturationField: React.FC<SaturationFieldProps> = ({
       max={1}
       step={0.1}
       value={saturation}
-      onChange={onChange}
+      onChange={FieldUtil.nullToUndefined(onChange)}
+      {...inputProps}
     />
   );
 };

--- a/src/Component/Symbolizer/Field/SizeField/SizeField.tsx
+++ b/src/Component/Symbolizer/Field/SizeField/SizeField.tsx
@@ -31,6 +31,7 @@ import * as React from 'react';
 import {
   InputNumber
 } from 'antd';
+import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
 export interface SizeFieldProps {
@@ -51,7 +52,7 @@ export const SizeField: React.FC<SizeFieldProps> = ({
       className="editor-field size-field"
       step={0.1}
       value={size}
-      onChange={onChange}
+      onChange={FieldUtil.nullToUndefined(onChange)}
     />
   );
 };

--- a/src/Component/Symbolizer/Field/WidthField/WidthField.tsx
+++ b/src/Component/Symbolizer/Field/WidthField/WidthField.tsx
@@ -27,9 +27,10 @@
  */
 
 import * as React from 'react';
-import { InputNumber } from 'antd';
+import { InputNumber, InputNumberProps } from 'antd';
+import FieldUtil from '../../../../Util/FieldUtil';
 
-export interface WidthFieldProps {
+export interface WidthFieldProps extends InputNumberProps {
   onChange?: (radius: number) => void;
   width?: number;
 }
@@ -39,7 +40,8 @@ export interface WidthFieldProps {
  */
 export const WidthField: React.FC<WidthFieldProps> = ({
   onChange,
-  width
+  width,
+  ...inputNumberProps
 }) => {
 
   return (
@@ -47,7 +49,8 @@ export const WidthField: React.FC<WidthFieldProps> = ({
       className="editor-field width-field"
       min={0}
       value={width}
-      onChange={onChange}
+      onChange={FieldUtil.nullToUndefined(onChange)}
+      {...inputNumberProps}
     />
   );
 };

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -191,7 +191,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
                     composition,
                     path: 'FillEditor.fillOpacityField',
                     onChange: onFillOpacityChange,
-                    propName: 'opacity',
+                    propName: 'fillOpacity',
                     propValue: fillOpacity,
                     defaultValue: defaultValues?.FillEditor?.defaultFillOpacity,
                     defaultElement: <OpacityField />
@@ -199,7 +199,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
                 }
               </Form.Item>
               <Form.Item
-                label={locale.fillOpacityLabel}
+                label={locale.opacityLabel}
                 {...formItemLayout}
               >
                 {

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -191,7 +191,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
                     composition,
                     path: 'FillEditor.fillOpacityField',
                     onChange: onFillOpacityChange,
-                    propName: 'fillOpacity',
+                    propName: 'opacity',
                     propValue: fillOpacity,
                     defaultValue: defaultValues?.FillEditor?.defaultFillOpacity,
                     defaultElement: <OpacityField />

--- a/src/Util/FieldUtil.spec.ts
+++ b/src/Util/FieldUtil.spec.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * Copyright © 2022-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/FieldUtil.spec.ts
+++ b/src/Util/FieldUtil.spec.ts
@@ -1,0 +1,60 @@
+/* Released under the BSD 2-Clause License
+ *
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import FieldUtil from './FieldUtil';
+
+describe('FieldUtil', () => {
+
+  const listener = jest.fn();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('nullToUndefined', () => {
+    it('calls the listener with the passed value if value is not null', async() => {
+      const modifiedListener = FieldUtil.nullToUndefined(listener);
+      modifiedListener(12);
+      expect(listener).toHaveBeenLastCalledWith(12);
+      modifiedListener('Peter');
+      expect(listener).toHaveBeenLastCalledWith('Peter');
+      modifiedListener('');
+      expect(listener).toHaveBeenLastCalledWith('');
+      modifiedListener(0);
+      expect(listener).toHaveBeenLastCalledWith(0);
+      modifiedListener(undefined);
+      expect(listener).toHaveBeenLastCalledWith(undefined);
+    });
+    it('calls the listener with `undefined` if value is null', async() => {
+      const modifiedListener = FieldUtil.nullToUndefined(listener);
+      modifiedListener(null);
+      expect(listener).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+});

--- a/src/Util/FieldUtil.ts
+++ b/src/Util/FieldUtil.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * Copyright © 2022-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/FieldUtil.ts
+++ b/src/Util/FieldUtil.ts
@@ -1,0 +1,47 @@
+/* Released under the BSD 2-Clause License
+ *
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @class FieldUtil
+ */
+class FieldUtil {
+
+  /**
+   * Transforms any changeListener to return undefined instead of null;
+   */
+  static nullToUndefined = (listener: any) => {
+    return (value: any) => {
+      if (value === null) {
+        value = undefined;
+      }
+      listener(value);
+    };
+  };
+}
+
+export default FieldUtil;

--- a/src/context/DefaultValueContext/DefaultValueContext.example.md
+++ b/src/context/DefaultValueContext/DefaultValueContext.example.md
@@ -39,7 +39,7 @@ Provide some default values.
 ```jsx
 import * as React from 'react';
 import { DefaultValueContext, IconEditor } from 'geostyler';
-import { Switch, InputNumber } from 'antd';
+import { Switch } from 'antd';
 
 class DefaultValueExample extends React.Component {
 


### PR DESCRIPTION
## Description

This introduces the `FileUtil.nullToUndefined` modificator. It is used to wrap the `onChange` listeners of the `InputNumberFields`.

Why is this introduced?

Previously when deleting the content of an inputfield the `onChange` listener was called with `null`. In the following a style with `null` was generated instead of removing the unused / resettet property from the style.

As this changes the signature of the properties this is a **BREAKING CHANGE** :exclamation:

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
