### PR TITLE
Introduces UnsupportedPropertiesContext, Utill and use it in Symbolizer Editors

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -23,16 +23,6 @@
       "always",
       100
     ],
-    "subject-case": [
-      1,
-      "never",
-      [
-        "sentence-case",
-        "start-case",
-        "pascal-case",
-        "upper-case"
-      ]
-    ],
     "subject-empty": [
       1,
       "never"

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,23 +1,5 @@
 {
   "rules": {
-    "body-leading-blank": [
-      1,
-      "always"
-    ],
-    "body-max-line-length": [
-      1,
-      "always",
-      100
-    ],
-    "footer-leading-blank": [
-      1,
-      "always"
-    ],
-    "footer-max-line-length": [
-      1,
-      "always",
-      100
-    ],
     "header-max-length": [
       1,
       "always",

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -219,7 +219,8 @@ export const FillEditor: React.FC<FillEditorProps> = ({
                 }
               </Form.Item>
               <Form.Item
-                label={locale.fillOpacityLabel}
+                label={locale.opacityLabel}
+                {...getSupportProps('opacity')}
                 {...formItemLayout}
               >
                 {

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -83,7 +83,10 @@ export const FillEditor: React.FC<FillEditorProps> = ({
   defaultValues
 }) => {
 
-  const unsupportedProperties = useContext(UnsupportedPropertiesContext);
+  const {
+    unsupportedProperties,
+    options
+  } = useContext(UnsupportedPropertiesContext);
 
   const onFillColorChange = (value: string) => {
     const symbolizerClone: FillSymbolizer = _cloneDeep(symbolizer);
@@ -166,9 +169,13 @@ export const FillEditor: React.FC<FillEditorProps> = ({
     outlineOpacity
   } = symbolizer;
 
-  const getSupportProps = (fieldName: keyof FillSymbolizer) => {
-    return UnsupportedPropertiesUtil
-      .getSupportProps<FillSymbolizer>(fieldName, 'FillSymbolizer', unsupportedProperties);
+  const getSupportProps = (propName: keyof FillSymbolizer) => {
+    return UnsupportedPropertiesUtil.getSupportProps<FillSymbolizer>({
+      propName,
+      symbolizerName: 'FillSymbolizer',
+      unsupportedProperties,
+      hideUnsupported: options?.hideUnsupported
+    });
   };
 
   return (

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -174,7 +174,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
       propName,
       symbolizerName: 'FillSymbolizer',
       unsupportedProperties,
-      hideUnsupported: options?.hideUnsupported
+      ...options
     });
   };
 

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
+import React, { useContext } from 'react';
 import {
   Collapse,
   Form
@@ -56,6 +56,10 @@ import CompositionUtil from '../../../Util/CompositionUtil';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
 import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 import { GeoStylerLocale } from '../../../locale/locale';
+import {
+  UnsupportedPropertiesContext
+} from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
+import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
 
 const Panel = Collapse.Panel;
 
@@ -78,6 +82,8 @@ export const FillEditor: React.FC<FillEditorProps> = ({
   onSymbolizerChange,
   defaultValues
 }) => {
+
+  const unsupportedProperties = useContext(UnsupportedPropertiesContext);
 
   const onFillColorChange = (value: string) => {
     const symbolizerClone: FillSymbolizer = _cloneDeep(symbolizer);
@@ -160,6 +166,11 @@ export const FillEditor: React.FC<FillEditorProps> = ({
     outlineOpacity
   } = symbolizer;
 
+  const getSupportProps = (fieldName: keyof FillSymbolizer) => {
+    return UnsupportedPropertiesUtil
+      .getSupportProps<FillSymbolizer>(fieldName, 'FillSymbolizer', unsupportedProperties);
+  };
+
   return (
     <CompositionContext.Consumer>
       {(composition: Compositions) => (
@@ -168,6 +179,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
             <Panel header="General" key="1">
               <Form.Item
                 label={locale.fillColorLabel}
+                {...getSupportProps('color')}
                 {...formItemLayout}
               >
                 {
@@ -184,6 +196,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               </Form.Item>
               <Form.Item
                 label={locale.fillOpacityLabel}
+                {...getSupportProps('fillOpacity')}
                 {...formItemLayout}
               >
                 {
@@ -191,7 +204,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
                     composition,
                     path: 'FillEditor.fillOpacityField',
                     onChange: onFillOpacityChange,
-                    propName: 'opacity',
+                    propName: 'fillOpacity',
                     propValue: fillOpacity,
                     defaultValue: defaultValues?.FillEditor?.defaultFillOpacity,
                     defaultElement: <OpacityField />
@@ -199,7 +212,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
                 }
               </Form.Item>
               <Form.Item
-                label={locale.opacityLabel}
+                label={locale.fillOpacityLabel}
                 {...formItemLayout}
               >
                 {
@@ -216,6 +229,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               </Form.Item>
               <Form.Item
                 label={locale.outlineOpacityLabel}
+                {...getSupportProps('outlineOpacity')}
                 {...formItemLayout}
               >
                 {
@@ -232,6 +246,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               </Form.Item>
               <Form.Item
                 label={locale.outlineColorLabel}
+                {...getSupportProps('outlineColor')}
                 {...formItemLayout}
               >
                 {
@@ -248,6 +263,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               </Form.Item>
               <Form.Item
                 label={locale.outlineWidthLabel}
+                {...getSupportProps('outlineWidth')}
                 {...formItemLayout}
               >
                 {
@@ -264,6 +280,7 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               </Form.Item>
               <Form.Item
                 label={locale.outlineDasharrayLabel}
+                {...getSupportProps('outlineDasharray')}
                 {...formItemLayout}
               >
                 {

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
+import React, { useContext } from 'react';
 
 import {
   Symbolizer,
@@ -52,6 +52,8 @@ import CompositionUtil from '../../../Util/CompositionUtil';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
 import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 import { GeoStylerLocale } from '../../../locale/locale';
+import { UnsupportedPropertiesContext } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
+import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
 
 // default props
 export interface IconEditorDefaultProps {
@@ -83,6 +85,12 @@ export const IconEditor: React.FC<IconEditorProps> = ({
   defaultValues,
   imageFieldProps
 }) => {
+
+  const {
+    unsupportedProperties,
+    options
+  } = useContext(UnsupportedPropertiesContext);
+
 
   const onImageSrcChange = (value: string) => {
     const symbolizerClone = _cloneDeep(symbolizer);
@@ -130,12 +138,22 @@ export const IconEditor: React.FC<IconEditorProps> = ({
 
   const imageSrc = !_isEmpty(image) ? image : locale.imagePlaceholder;
 
+  const getSupportProps = (propName: keyof IconSymbolizer) => {
+    return UnsupportedPropertiesUtil.getSupportProps<IconSymbolizer>({
+      propName,
+      symbolizerName: 'IconSymbolizer',
+      unsupportedProperties,
+      hideUnsupported: options?.hideUnsupported
+    });
+  };
+
   return (
     <CompositionContext.Consumer>
       {(composition: Compositions) => (
         <div className="gs-icon-symbolizer-editor" >
           <Form.Item
             label={locale.imageLabel}
+            {...getSupportProps('image')}
             {...formItemLayout}
           >
             {
@@ -161,6 +179,7 @@ export const IconEditor: React.FC<IconEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.sizeLabel}
+            {...getSupportProps('size')}
             {...formItemLayout}
           >
             {
@@ -177,6 +196,7 @@ export const IconEditor: React.FC<IconEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.rotateLabel}
+            {...getSupportProps('rotate')}
             {...formItemLayout}
           >
             {
@@ -193,6 +213,7 @@ export const IconEditor: React.FC<IconEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.opacityLabel}
+            {...getSupportProps('opacity')}
             {...formItemLayout}
           >
             {

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -52,7 +52,9 @@ import CompositionUtil from '../../../Util/CompositionUtil';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
 import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 import { GeoStylerLocale } from '../../../locale/locale';
-import { UnsupportedPropertiesContext } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
+import {
+  UnsupportedPropertiesContext
+} from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
 import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
 
 // default props
@@ -143,7 +145,7 @@ export const IconEditor: React.FC<IconEditorProps> = ({
       propName,
       symbolizerName: 'IconSymbolizer',
       unsupportedProperties,
-      hideUnsupported: options?.hideUnsupported
+      ...options
     });
   };
 

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
+import React, { useContext } from 'react';
 
 import {
   Collapse,
@@ -60,6 +60,8 @@ import CompositionUtil from '../../../Util/CompositionUtil';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
 import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 import { GeoStylerLocale } from '../../../locale/locale';
+import { UnsupportedPropertiesContext } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
+import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
 
 const Panel = Collapse.Panel;
 
@@ -84,6 +86,11 @@ export const LineEditor: React.FC<LineEditorProps> = ({
   onSymbolizerChange,
   defaultValues
 }) => {
+
+  const {
+    unsupportedProperties,
+    options
+  } = useContext(UnsupportedPropertiesContext);
 
   const onColorChange = (value: LineSymbolizer['color']) => {
     const sybolizerClone = _cloneDeep(symbolizer);
@@ -174,6 +181,15 @@ export const LineEditor: React.FC<LineEditorProps> = ({
     graphicFill
   } = _cloneDeep(symbolizer);
 
+  const getSupportProps = (propName: keyof LineSymbolizer) => {
+    return UnsupportedPropertiesUtil.getSupportProps<LineSymbolizer>({
+      propName,
+      symbolizerName: 'LineSymbolizer',
+      unsupportedProperties,
+      hideUnsupported: options?.hideUnsupported
+    });
+  };
+
   return (
     <CompositionContext.Consumer>
       {(composition: Compositions) => (
@@ -182,6 +198,7 @@ export const LineEditor: React.FC<LineEditorProps> = ({
             <Panel header="General" key="1">
               <Form.Item
                 label={locale.colorLabel}
+                {...getSupportProps('color')}
                 {...formItemLayout}
               >
                 {
@@ -198,6 +215,7 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               </Form.Item>
               <Form.Item
                 label={locale.widthLabel}
+                {...getSupportProps('width')}
                 {...formItemLayout}
               >
                 {
@@ -214,6 +232,7 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               </Form.Item>
               <Form.Item
                 label={locale.opacityLabel}
+                {...getSupportProps('opacity')}
                 {...formItemLayout}
               >
                 {
@@ -230,6 +249,7 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               </Form.Item>
               <Form.Item
                 label={locale.dashLabel}
+                {...getSupportProps('dasharray')}
                 {...formItemLayout}
               >
                 {
@@ -245,6 +265,7 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               </Form.Item>
               <Form.Item
                 label={locale.dashOffsetLabel}
+                {...getSupportProps('dashOffset')}
                 {...formItemLayout}
               >
                 {
@@ -266,6 +287,7 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               </Form.Item>
               <Form.Item
                 label={locale.capLabel}
+                {...getSupportProps('cap')}
                 {...formItemLayout}
               >
                 {
@@ -282,6 +304,7 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               </Form.Item>
               <Form.Item
                 label={locale.joinLabel}
+                {...getSupportProps('join')}
                 {...formItemLayout}
               >
                 {

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -60,7 +60,9 @@ import CompositionUtil from '../../../Util/CompositionUtil';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
 import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 import { GeoStylerLocale } from '../../../locale/locale';
-import { UnsupportedPropertiesContext } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
+import {
+  UnsupportedPropertiesContext
+} from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
 import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
 
 const Panel = Collapse.Panel;
@@ -186,7 +188,7 @@ export const LineEditor: React.FC<LineEditorProps> = ({
       propName,
       symbolizerName: 'LineSymbolizer',
       unsupportedProperties,
-      hideUnsupported: options?.hideUnsupported
+      ...options
     });
   };
 

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
+import React, { useContext } from 'react';
 
 import {
   Symbolizer,
@@ -46,6 +46,10 @@ import { Form } from 'antd';
 
 import _cloneDeep from 'lodash/cloneDeep';
 import { GeoStylerLocale } from '../../../locale/locale';
+import {
+  UnsupportedPropertiesContext
+} from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
+import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
 
 // default props
 interface MarkEditorDefaultProps {
@@ -68,6 +72,11 @@ export const MarkEditor: React.FC<MarkEditorProps> = ({
   defaultValues
 }) => {
 
+  const {
+    unsupportedProperties,
+    options
+  } = useContext(UnsupportedPropertiesContext);
+
   const onWellKnownNameChange = (wellKnownName: WellKnownName) => {
     const clonedSymbolizer = _cloneDeep(symbolizer);
     clonedSymbolizer.wellKnownName = wellKnownName;
@@ -81,12 +90,22 @@ export const MarkEditor: React.FC<MarkEditorProps> = ({
     wrapperCol: { span: 16 }
   };
 
+  const getSupportProps = (propName: keyof MarkSymbolizer) => {
+    return UnsupportedPropertiesUtil.getSupportProps<MarkSymbolizer>({
+      propName,
+      symbolizerName: 'MarkSymbolizer',
+      unsupportedProperties,
+      hideUnsupported: options?.hideUnsupported
+    });
+  };
+
   return (
     <CompositionContext.Consumer>
       {(composition: Compositions) => (
         <div className="gs-mark-symbolizer-editor" >
           <Form.Item
             label={locale.wellKnownNameFieldLabel}
+            {...getSupportProps('wellKnownName')}
             {...formItemLayout}
           >
             {

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -95,7 +95,7 @@ export const MarkEditor: React.FC<MarkEditorProps> = ({
       propName,
       symbolizerName: 'MarkSymbolizer',
       unsupportedProperties,
-      hideUnsupported: options?.hideUnsupported
+      ...options
     });
   };
 

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.spec.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.spec.tsx
@@ -38,8 +38,7 @@ describe('RasterEditor', () => {
   const props: RasterEditorProps = {
     symbolizer: dummySymbolizer,
     locale: en_US.RasterEditor,
-    onSymbolizerChange: jest.fn(),
-    defaultValues: undefined
+    onSymbolizerChange: jest.fn()
   };
 
   it('is defined', () => {

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -179,7 +179,7 @@ export const RasterEditor: React.FC<RasterEditorProps> = ({
       propName,
       symbolizerName: 'RasterSymbolizer',
       unsupportedProperties,
-      hideUnsupported: options?.hideUnsupported
+      ...options
     });
   };
 

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 
 import {
   Symbolizer,
@@ -56,6 +56,10 @@ import './RasterEditor.less';
 import _cloneDeep from 'lodash/cloneDeep';
 import _get from 'lodash/get';
 import { GeoStylerLocale } from '../../../locale/locale';
+import {
+  UnsupportedPropertiesContext
+} from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
+import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
 
 // default props
 interface RasterEditorDefaultProps {
@@ -71,7 +75,7 @@ export interface RasterEditorProps extends Partial<RasterEditorDefaultProps> {
   colorRamps?: {
     [name: string]: string[];
   };
-  defaultValues: DefaultValues;
+  defaultValues?: DefaultValues;
 }
 
 type ShowDisplay = 'symbolizer' | 'colorMap' | 'contrastEnhancement';
@@ -89,6 +93,11 @@ export const RasterEditor: React.FC<RasterEditorProps> = ({
   colorRamps,
   defaultValues
 }) => {
+
+  const {
+    unsupportedProperties,
+    options
+  } = useContext(UnsupportedPropertiesContext);
 
   const [showDisplay, setShowDisplay] = useState('symbolizer');
 
@@ -144,25 +153,6 @@ export const RasterEditor: React.FC<RasterEditorProps> = ({
     }
   };
 
-  /**
-   * Wraps a Form Item around a given element and adds its locale
-   * to the From Item label.
-   */
-  const wrapFormItem = (label: string, element: React.ReactElement): React.ReactElement => {
-    const formItemLayout = {
-      labelCol: { span: 8 },
-      wrapperCol: { span: 16 }
-    };
-    return element == null ? null : (
-      <Form.Item
-        label={label}
-        {...formItemLayout}
-      >
-        {element}
-      </Form.Item>
-    );
-  };
-
   const {
     opacity,
     contrastEnhancement,
@@ -179,47 +169,79 @@ export const RasterEditor: React.FC<RasterEditorProps> = ({
     wrapperCol: {span: 24}
   };
 
+  const formItemLayout = {
+    labelCol: { span: 8 },
+    wrapperCol: { span: 16 }
+  };
+
+  const getSupportProps = (propName: keyof RasterSymbolizer) => {
+    return UnsupportedPropertiesUtil.getSupportProps<RasterSymbolizer>({
+      propName,
+      symbolizerName: 'RasterSymbolizer',
+      unsupportedProperties,
+      hideUnsupported: options?.hideUnsupported
+    });
+  };
+
   return (
     <CompositionContext.Consumer>
       {(composition: Compositions) => (
         <div className="gs-raster-symbolizer-editor" >
           {
             showDisplay !== 'symbolizer' ? null : ([
-              wrapFormItem(
-                locale.opacityLabel,
-                CompositionUtil.handleComposition({
-                  composition,
-                  path: 'RasterEditor.opacityField',
-                  onChange: onOpacityChange,
-                  propName: 'opacity',
-                  propValue: opacity,
-                  defaultValue: defaultValues?.RasterEditor?.defaultOpacity,
-                  defaultElement: <OpacityField />
-                })
-              ),
-              wrapFormItem(
-                locale.contrastEnhancementLabel,
-                CompositionUtil.handleComposition({
-                  composition,
-                  path: 'RasterEditor.contrastEnhancementField',
-                  onChange: onContrastEnhancementChange,
-                  propName: 'contrastEnhancement',
-                  propValue: _get(contrastEnhancement, 'enhancementType'),
-                  defaultElement: <ContrastEnhancementField />
-                })
-              ),
-              wrapFormItem(
-                locale.gammaValueLabel,
-                CompositionUtil.handleComposition({
-                  composition,
-                  path: 'RasterEditor.gammaValueField',
-                  onChange: onGammaValueChange,
-                  propName: 'gamma',
-                  propValue: _get(contrastEnhancement, 'gammaValue'),
-                  defaultValue: defaultValues?.RasterEditor?.defaultGammaValue,
-                  defaultElement: <GammaField />
-                })
-              ),
+              <Form.Item
+                key='opacity'
+                label={locale.opacityLabel}
+                {...getSupportProps('opacity')}
+                {...formItemLayout}
+              >
+                {
+                  CompositionUtil.handleComposition({
+                    composition,
+                    path: 'RasterEditor.opacityField',
+                    onChange: onOpacityChange,
+                    propName: 'opacity',
+                    propValue: opacity,
+                    defaultValue: defaultValues?.RasterEditor?.defaultOpacity,
+                    defaultElement: <OpacityField />
+                  })
+                }
+              </Form.Item>,
+              <Form.Item
+                key='contrastEnhancement'
+                label={locale.contrastEnhancementLabel}
+                {...getSupportProps('contrastEnhancement')}
+                {...formItemLayout}
+              >
+                {
+                  CompositionUtil.handleComposition({
+                    composition,
+                    path: 'RasterEditor.contrastEnhancementField',
+                    onChange: onContrastEnhancementChange,
+                    propName: 'contrastEnhancement',
+                    propValue: _get(contrastEnhancement, 'enhancementType'),
+                    defaultElement: <ContrastEnhancementField />
+                  })
+                }
+              </Form.Item>,
+              <Form.Item
+                key='gamma'
+                label={locale.gammaValueLabel}
+                {...getSupportProps('contrastEnhancement')}
+                {...formItemLayout}
+              >
+                {
+                  CompositionUtil.handleComposition({
+                    composition,
+                    path: 'RasterEditor.gammaValueField',
+                    onChange: onGammaValueChange,
+                    propName: 'gamma',
+                    propValue: _get(contrastEnhancement, 'gammaValue'),
+                    defaultValue: defaultValues?.RasterEditor?.defaultGammaValue,
+                    defaultElement: <GammaField />
+                  })
+                }
+              </Form.Item>,
               <Form.Item
                 className="gs-raster-editor-view-toggle"
                 key="toggleColorMap"

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
+import React, { useContext } from 'react';
 import {
   Mentions,
   Form
@@ -61,6 +61,8 @@ import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 import { VectorData } from 'geostyler-data';
 import { GeoStylerLocale } from '../../../locale/locale';
+import { UnsupportedPropertiesContext } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
+import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
 
 interface TextEditorDefaultProps {
   locale: GeoStylerLocale['TextEditor'];
@@ -88,6 +90,11 @@ export const TextEditor: React.FC<TextEditorProps> = ({
   internalDataDef,
   defaultValues
 }) => {
+
+  const {
+    unsupportedProperties,
+    options
+  } = useContext(UnsupportedPropertiesContext);
 
   const onLabelChange = (value: any) => {
     const symbolizerClone = _cloneDeep(symbolizer);
@@ -198,12 +205,22 @@ export const TextEditor: React.FC<TextEditorProps> = ({
     wrapperCol: { span: 16 }
   };
 
+  const getSupportProps = (propName: keyof TextSymbolizer) => {
+    return UnsupportedPropertiesUtil.getSupportProps<TextSymbolizer>({
+      propName,
+      symbolizerName: 'TextSymbolizer',
+      unsupportedProperties,
+      hideUnsupported: options?.hideUnsupported
+    });
+  };
+
   return (
     <CompositionContext.Consumer>
       {(composition: Compositions) => (
         <div className="gs-text-symbolizer-editor" >
           <Form.Item
             label={locale.templateFieldLabel}
+            {...getSupportProps('label')}
             {...formItemLayout}
           >
             {
@@ -228,6 +245,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.colorLabel}
+            {...getSupportProps('color')}
             {...formItemLayout}
           >
             {
@@ -244,6 +262,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.fontLabel}
+            {...getSupportProps('font')}
             {...formItemLayout}
           >
             {
@@ -260,6 +279,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.opacityLabel}
+            {...getSupportProps('opacity')}
             {...formItemLayout}
           >
             {
@@ -276,6 +296,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.sizeLabel}
+            {...getSupportProps('size')}
             {...formItemLayout}
           >
             {
@@ -292,6 +313,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.offsetXLabel}
+            {...getSupportProps('offset')}
             {...formItemLayout}
           >
             {
@@ -308,6 +330,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.offsetYLabel}
+            {...getSupportProps('offset')}
             {...formItemLayout}
           >
             {
@@ -324,6 +347,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.rotateLabel}
+            {...getSupportProps('rotate')}
             {...formItemLayout}
           >
             {
@@ -340,6 +364,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.haloColorLabel}
+            {...getSupportProps('haloColor')}
             {...formItemLayout}
           >
             {
@@ -356,6 +381,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           </Form.Item>
           <Form.Item
             label={locale.haloWidthLabel}
+            {...getSupportProps('haloWidth')}
             {...formItemLayout}
           >
             {

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -61,7 +61,9 @@ import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 import { VectorData } from 'geostyler-data';
 import { GeoStylerLocale } from '../../../locale/locale';
-import { UnsupportedPropertiesContext } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
+import {
+  UnsupportedPropertiesContext
+} from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
 import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
 
 interface TextEditorDefaultProps {
@@ -210,7 +212,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
       propName,
       symbolizerName: 'TextSymbolizer',
       unsupportedProperties,
-      hideUnsupported: options?.hideUnsupported
+      ...options
     });
   };
 

--- a/src/Util/UnsupportedPropertiesUtil.ts
+++ b/src/Util/UnsupportedPropertiesUtil.ts
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * Copyright © 2022-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/Util/UnsupportedPropertiesUtil.ts
+++ b/src/Util/UnsupportedPropertiesUtil.ts
@@ -41,25 +41,42 @@ type UnsupportedSymbolizerProps<T extends Symbolizer> = SupportDef | {
  */
 class UnsupportedPropertiesUtil {
 
-  static getSupportProps = <T extends Symbolizer>(
-    propName: keyof T,
-    symbolizerName: SymbolizerName,
-    unsupportedProperties: UnsupportedProperties
-  ): Partial<FormItemProps> => {
+  static getSupportProps = <T extends Symbolizer>({
+    propName,
+    symbolizerName,
+    unsupportedProperties,
+    hideUnsupported = false
+  }: {
+    propName: keyof T;
+    symbolizerName: SymbolizerName;
+    unsupportedProperties: UnsupportedProperties;
+    hideUnsupported?: boolean;
+  }): Partial<FormItemProps> => {
+
+    if (!unsupportedProperties) {
+      return {};
+    }
+
     const props: Partial<FormItemProps> = {};
     const unsupportedSymbolizerProps = UnsupportedPropertiesUtil
       .getUnsupportedPropsForSymbolizer<T>(unsupportedProperties, symbolizerName);
 
-    const val = unsupportedSymbolizerProps[(propName as string)];
+    const val: SupportDef = unsupportedSymbolizerProps[(propName as string)];
     if (val) {
       props.hasFeedback = true;
       if (val === 'none') {
         props.help = 'Not supported by selected parser.'; // TODO: i18n
+        if (hideUnsupported) {
+          props.hidden = true;
+        }
       } else if (val === 'partial') {
         props.help = 'Only partialy supported by selected parser.'; // TODO: i18n
       } else {
         props.help = val.info;
         props.validateStatus = 'warning';
+        if (val.support === 'none' && hideUnsupported) {
+          props.hidden = true;
+        }
       }
     }
 

--- a/src/Util/UnsupportedPropertiesUtil.ts
+++ b/src/Util/UnsupportedPropertiesUtil.ts
@@ -28,6 +28,8 @@
 
 import { FormItemProps } from 'antd';
 import { SupportDef, Symbolizer, UnsupportedProperties } from 'geostyler-style';
+import en_US from '../locale/en_US';
+import { GeoStylerLocale } from '../locale/locale';
 
 type SymbolizerName = 'LineSymbolizer' |
 'FillSymbolizer' | 'MarkSymbolizer' | 'IconSymbolizer' | 'TextSymbolizer' | 'RasterSymbolizer';
@@ -45,12 +47,14 @@ class UnsupportedPropertiesUtil {
     propName,
     symbolizerName,
     unsupportedProperties,
-    hideUnsupported = false
+    hideUnsupported = false,
+    locale = en_US.UnsupportedPropertiesUtil
   }: {
     propName: keyof T;
     symbolizerName: SymbolizerName;
     unsupportedProperties: UnsupportedProperties;
     hideUnsupported?: boolean;
+    locale?: GeoStylerLocale['UnsupportedPropertiesUtil'];
   }): Partial<FormItemProps> => {
 
     if (!unsupportedProperties || Object.keys(unsupportedProperties).length < 1) {
@@ -65,12 +69,12 @@ class UnsupportedPropertiesUtil {
     if (val) {
       props.hasFeedback = true;
       if (val === 'none') {
-        props.help = 'Not supported by selected parser.'; // TODO: i18n
+        props.help = locale.notSupported;
         if (hideUnsupported) {
           props.hidden = true;
         }
       } else if (val === 'partial') {
-        props.help = 'Only partialy supported by selected parser.'; // TODO: i18n
+        props.help = locale.partiallySupported;
       } else {
         props.help = val.info;
         props.validateStatus = 'warning';

--- a/src/Util/UnsupportedPropertiesUtil.ts
+++ b/src/Util/UnsupportedPropertiesUtil.ts
@@ -53,7 +53,7 @@ class UnsupportedPropertiesUtil {
     hideUnsupported?: boolean;
   }): Partial<FormItemProps> => {
 
-    if (!unsupportedProperties) {
+    if (!unsupportedProperties || Object.keys(unsupportedProperties).length < 1) {
       return {};
     }
 
@@ -61,7 +61,7 @@ class UnsupportedPropertiesUtil {
     const unsupportedSymbolizerProps = UnsupportedPropertiesUtil
       .getUnsupportedPropsForSymbolizer<T>(unsupportedProperties, symbolizerName);
 
-    const val: SupportDef = unsupportedSymbolizerProps[(propName as string)];
+    const val: SupportDef = unsupportedSymbolizerProps?.[(propName as string)];
     if (val) {
       props.hasFeedback = true;
       if (val === 'none') {
@@ -87,7 +87,7 @@ class UnsupportedPropertiesUtil {
     unsupportedProperties: UnsupportedProperties,
     symbolizerName: SymbolizerName
   ): UnsupportedSymbolizerProps<T> => {
-    return unsupportedProperties.Symbolizer[symbolizerName];
+    return unsupportedProperties?.Symbolizer?.[symbolizerName];
   };
 }
 

--- a/src/Util/UnsupportedPropertiesUtil.ts
+++ b/src/Util/UnsupportedPropertiesUtil.ts
@@ -1,0 +1,77 @@
+/* Released under the BSD 2-Clause License
+ *
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { FormItemProps } from 'antd';
+import { SupportDef, Symbolizer, UnsupportedProperties } from 'geostyler-style';
+
+type SymbolizerName = 'LineSymbolizer' |
+'FillSymbolizer' | 'MarkSymbolizer' | 'IconSymbolizer' | 'TextSymbolizer' | 'RasterSymbolizer';
+
+type UnsupportedSymbolizerProps<T extends Symbolizer> = SupportDef | {
+  [key in keyof Required<T>]?: SupportDef
+};
+
+/**
+ * @class UnsupportedPropertiesUtil
+ */
+class UnsupportedPropertiesUtil {
+
+  static getSupportProps = <T extends Symbolizer>(
+    propName: keyof T,
+    symbolizerName: SymbolizerName,
+    unsupportedProperties: UnsupportedProperties
+  ): Partial<FormItemProps> => {
+    const props: Partial<FormItemProps> = {};
+    const unsupportedSymbolizerProps = UnsupportedPropertiesUtil
+      .getUnsupportedPropsForSymbolizer<T>(unsupportedProperties, symbolizerName);
+
+    const val = unsupportedSymbolizerProps[(propName as string)];
+    if (val) {
+      props.hasFeedback = true;
+      if (val === 'none') {
+        props.help = 'Not supported by selected parser.'; // TODO: i18n
+      } else if (val === 'partial') {
+        props.help = 'Only partialy supported by selected parser.'; // TODO: i18n
+      } else {
+        props.help = val.info;
+        props.validateStatus = 'warning';
+      }
+    }
+
+    return props;
+  };
+
+  static getUnsupportedPropsForSymbolizer = <T extends Symbolizer>(
+    unsupportedProperties: UnsupportedProperties,
+    symbolizerName: SymbolizerName
+  ): UnsupportedSymbolizerProps<T> => {
+    return unsupportedProperties.Symbolizer[symbolizerName];
+  };
+}
+
+export default UnsupportedPropertiesUtil;

--- a/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.example.md
+++ b/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.example.md
@@ -1,0 +1,95 @@
+<!--
+ * Released under the BSD 2-Clause License
+ *
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+-->
+
+The `UnsupportedPropertiesContext` deploys unsuported properties to underlying components.
+The components themeselve will disable field that are marked as not supported and add notes
+for fields that are only partialy supported.
+
+#### Example
+
+Provide some default values.
+
+```jsx
+import * as React from 'react';
+import { UnsupportedPropertiesContext, FillEditor } from 'geostyler';
+import OlStyleParser from 'geostyler-openlayers-parser';
+import SldStyleParser from 'geostyler-sld-parser';
+import { Switch, InputNumber } from 'antd';
+
+class UnsupportedPropertiesContextExample extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      parser: new SldStyleParser()
+    }
+    this.switchParser = this.switchParser.bind(this);
+  }
+
+  switchParser(checked) {
+    this.setState({
+      parser: checked ? new SldStyleParser() : new OlStyleParser()
+    });
+  }
+
+  render() {
+    const {
+      parser
+    } = this.state;
+
+    return (
+      <div>
+        <Switch
+          checked={parser instanceof SldStyleParser}
+          onChange={this.switchParser}
+          checkedChildren="SLD"
+          unCheckedChildren="OpenLayers"
+        />
+        <hr/>
+        <UnsupportedPropertiesContext.Provider value={parser.unsupportedProperties}>
+          <FillEditor
+            symbolizer={{
+              kind: 'Fill',
+              color: '#0E1058',
+              fillOpacity: 0.14,
+              opacity: 0.09,
+              outlineOpacity: 0.06,
+              outlineColor: '#194d2b',
+              outlineWidth: 6
+            }}
+          />
+        </UnsupportedPropertiesContext.Provider>
+      </div>
+    );
+  }
+}
+
+<UnsupportedPropertiesContextExample />
+```

--- a/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.example.md
+++ b/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.example.md
@@ -41,16 +41,18 @@ import * as React from 'react';
 import { UnsupportedPropertiesContext, FillEditor } from 'geostyler';
 import OlStyleParser from 'geostyler-openlayers-parser';
 import SldStyleParser from 'geostyler-sld-parser';
-import { Switch, InputNumber } from 'antd';
+import { Checkbox, Switch, InputNumber } from 'antd';
 
 class UnsupportedPropertiesContextExample extends React.Component {
 
   constructor(props) {
     super(props);
     this.state = {
-      parser: new SldStyleParser()
+      parser: new SldStyleParser(),
+      hideUnsupported: false
     }
     this.switchParser = this.switchParser.bind(this);
+    this.onHideUnsupportedChange = this.onHideUnsupportedChange.bind(this);
   }
 
   switchParser(checked) {
@@ -59,21 +61,40 @@ class UnsupportedPropertiesContextExample extends React.Component {
     });
   }
 
+  onHideUnsupportedChange(e) {
+    this.setState({
+      hideUnsupported: e.target.checked
+    });
+  }
+
   render() {
     const {
-      parser
+      parser,
+      hideUnsupported
     } = this.state;
 
     return (
       <div>
         <Switch
+          style={{marginRight: 20}}
           checked={parser instanceof SldStyleParser}
           onChange={this.switchParser}
           checkedChildren="SLD"
           unCheckedChildren="OpenLayers"
         />
+        <Checkbox
+          checked={hideUnsupported}
+          onChange={this.onHideUnsupportedChange}
+        >
+          Hide unsupported properties
+        </Checkbox>
         <hr/>
-        <UnsupportedPropertiesContext.Provider value={parser.unsupportedProperties}>
+        <UnsupportedPropertiesContext.Provider value={{
+          unsupportedProperties: parser.unsupportedProperties,
+          options: {
+            hideUnsupported
+          }
+        }}>
           <FillEditor
             symbolizer={{
               kind: 'Fill',

--- a/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.example.md
+++ b/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.example.md
@@ -1,7 +1,7 @@
 <!--
  * Released under the BSD 2-Clause License
  *
- * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * Copyright © 2022-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,9 +28,9 @@
  *
 -->
 
-The `UnsupportedPropertiesContext` deploys unsuported properties to underlying components.
-The components themeselve will disable field that are marked as not supported and add notes
-for fields that are only partialy supported.
+The `UnsupportedPropertiesContext` deploys unsupported properties to underlying components.
+The components themeselves will disable fields that are marked as not supported and add notes
+for fields that are only partially supported.
 
 #### Example
 

--- a/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.tsx
+++ b/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.tsx
@@ -1,6 +1,6 @@
 /* Released under the BSD 2-Clause License
  *
- * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * Copyright © 2022-present, terrestris GmbH & Co. KG and GeoStyler contributors
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.tsx
+++ b/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.tsx
@@ -29,4 +29,15 @@
 import { UnsupportedProperties } from 'geostyler-style';
 import { createContext } from 'react';
 
-export const UnsupportedPropertiesContext = createContext<UnsupportedProperties>({});
+export type UnsupportedPropertiesContextOptions = {
+  hideUnsupported: boolean;
+};
+
+export type UnsupportedPropertiesContextType = {
+  unsupportedProperties: UnsupportedProperties;
+  options?: UnsupportedPropertiesContextOptions;
+};
+
+export const UnsupportedPropertiesContext = createContext<UnsupportedPropertiesContextType>({
+  unsupportedProperties: {}
+});

--- a/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.tsx
+++ b/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.tsx
@@ -1,0 +1,32 @@
+/* Released under the BSD 2-Clause License
+ *
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { UnsupportedProperties } from 'geostyler-style';
+import React from 'react';
+
+export const UnsupportedPropertiesContext = React.createContext<UnsupportedProperties>({});

--- a/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.tsx
+++ b/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.tsx
@@ -28,9 +28,11 @@
 
 import { UnsupportedProperties } from 'geostyler-style';
 import { createContext } from 'react';
+import { GeoStylerLocale } from '../../locale/locale';
 
 export type UnsupportedPropertiesContextOptions = {
-  hideUnsupported: boolean;
+  hideUnsupported?: boolean;
+  locale?: GeoStylerLocale['UnsupportedPropertiesUtil'];
 };
 
 export type UnsupportedPropertiesContextType = {

--- a/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.tsx
+++ b/src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.tsx
@@ -27,6 +27,6 @@
  */
 
 import { UnsupportedProperties } from 'geostyler-style';
-import React from 'react';
+import { createContext } from 'react';
 
-export const UnsupportedPropertiesContext = React.createContext<UnsupportedProperties>({});
+export const UnsupportedPropertiesContext = createContext<UnsupportedProperties>({});

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ import withDefaultsContext from './hoc/withDefaultsContext';
 import { localize } from './Component/LocaleWrapper/LocaleWrapper';
 import { CompositionContext } from './context/CompositionContext/CompositionContext';
 import { DefaultValueContext } from './context/DefaultValueContext/DefaultValueContext';
+import { UnsupportedPropertiesContext } from './context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
 import { GeoStylerLocale } from './locale/locale';
 
 import { ConfigProvider } from 'antd';
@@ -235,6 +236,7 @@ export {
   TextEditor,
   TextFilterField,
   UploadButton,
+  UnsupportedPropertiesContext,
   WellKnownNameEditor,
   WellKnownNameField,
   WidthField,

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -410,6 +410,10 @@ const de_DE: GeoStylerLocale = {
     symbolizerUnitsMeter: 'Meter',
     symbolizerUnitsFoot: 'Fuß'
   },
+  UnsupportedPropertiesUtil: {
+    notSupported: 'Vom ausgewählten Parser nicht unterstützt.',
+    partiallySupported: 'Vom ausgewählten Parser nur teilweise unterstützt.'
+  },
   ...antd_de_DE
 };
 

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -409,6 +409,10 @@ const en_US: GeoStylerLocale = {
     symbolizerUnitsMeter: 'meter',
     symbolizerUnitsFoot: 'foot'
   },
+  UnsupportedPropertiesUtil: {
+    notSupported: 'Not supported by selected parser.',
+    partiallySupported: 'Only partialy supported by selected parser.'
+  },
   ...antd_en_US
 };
 

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -411,7 +411,7 @@ const en_US: GeoStylerLocale = {
   },
   UnsupportedPropertiesUtil: {
     notSupported: 'Not supported by selected parser.',
-    partiallySupported: 'Only partialy supported by selected parser.'
+    partiallySupported: 'Only partially supported by selected parser.'
   },
   ...antd_en_US
 };

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -412,7 +412,7 @@ const es_ES: GeoStylerLocale = {
   },
   UnsupportedPropertiesUtil: {
     notSupported: 'TODO(es_ES):Not supported by selected parser.',
-    partiallySupported: 'TODO(es_ES):Only partialy supported by selected parser.'
+    partiallySupported: 'TODO(es_ES):Only partially supported by selected parser.'
   },
   ...antd_es_ES
 };

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -410,6 +410,10 @@ const es_ES: GeoStylerLocale = {
     symbolizerUnitsMeter: 'Metro',
     symbolizerUnitsFoot: 'Escándalo'
   },
+  UnsupportedPropertiesUtil: {
+    notSupported: 'TODO(es_ES):Not supported by selected parser.',
+    partiallySupported: 'TODO(es_ES):Only partialy supported by selected parser.'
+  },
   ...antd_es_ES
 };
 

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -410,6 +410,10 @@ const fr_FR: GeoStylerLocale = {
     symbolizerUnitsMeter: 'mètres',
     symbolizerUnitsFoot: 'pieds'
   },
+  UnsupportedPropertiesUtil: {
+    notSupported: 'TODO(fr_FR):Not supported by selected parser.',
+    partiallySupported: 'TODO(fr_FR):Only partialy supported by selected parser.'
+  },
   ...antd_fr_FR
 };
 

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -412,7 +412,7 @@ const fr_FR: GeoStylerLocale = {
   },
   UnsupportedPropertiesUtil: {
     notSupported: 'TODO(fr_FR):Not supported by selected parser.',
-    partiallySupported: 'TODO(fr_FR):Only partialy supported by selected parser.'
+    partiallySupported: 'TODO(fr_FR):Only partially supported by selected parser.'
   },
   ...antd_fr_FR
 };

--- a/src/locale/locale.ts
+++ b/src/locale/locale.ts
@@ -385,4 +385,8 @@ export interface GeoStylerLocale extends Locale {
   Editor: {
     kindFieldLabel: string;
   };
+  UnsupportedPropertiesUtil: {
+    notSupported: string;
+    partiallySupported: string;
+  };
 };

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -410,6 +410,10 @@ const zh_CN: GeoStylerLocale = {
     symbolizerUnitsMeter: '儀表',
     symbolizerUnitsFoot: '富斯'
   },
+  UnsupportedPropertiesUtil: {
+    notSupported: 'TODO(zh_CN):Not supported by selected parser.',
+    partiallySupported: 'TODO(zh_CN):Only partialy supported by selected parser.'
+  },
   ...antd_zh_CN
 };
 

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -412,7 +412,7 @@ const zh_CN: GeoStylerLocale = {
   },
   UnsupportedPropertiesUtil: {
     notSupported: 'TODO(zh_CN):Not supported by selected parser.',
-    partiallySupported: 'TODO(zh_CN):Only partialy supported by selected parser.'
+    partiallySupported: 'TODO(zh_CN):Only partially supported by selected parser.'
   },
   ...antd_zh_CN
 };

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -166,6 +166,9 @@ module.exports = {
     sections: [{
       name: 'CompositionContext',
       content: 'src/context/CompositionContext/CompositionContext.example.md'
+    }, {
+      name: 'UnsupportedPropertiesContext',
+      content: 'src/context/UnsupportedPropertiesContext/UnsupportedPropertiesContext.example.md'
     }],
     sectionDepth: 1
   }],


### PR DESCRIPTION
## Description

This introduces the `UnsupportedPropertiesContext`, `UnsupportedPropertiesUtil` and makes use of them in the Symbolizer Editors.

![geostyler-unsupported-properties-editor](https://user-images.githubusercontent.com/1849416/183077181-fdc4b11b-9442-448f-b090-2cc7fcdcf5ed.gif)


Supported Editors:

- [x] LineEditor
- [x] FillEditor
- [x] MarkEditor
- [x] IconEditor
- [x] TextEditor
- [x] RasterEditor

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!

