### PR TITLE
fix: close curly braces on template attributes

### DIFF
--- a/src/Component/Symbolizer/TextEditor/TextEditor.example.md
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.example.md
@@ -38,6 +38,19 @@ class TextEditorExample extends React.Component {
   constructor(props) {
     super(props);
 
+    this.data = {
+      schema: {
+        properties: {
+          foo: {
+            type: 'Number'
+          },
+          bar: {
+            type: 'String'
+          }
+        }
+      }
+    };
+
     this.state = {
       symbolizer: {
         kind: 'Text'
@@ -62,6 +75,7 @@ class TextEditorExample extends React.Component {
       <TextEditor
         symbolizer={symbolizer}
         onSymbolizerChange={this.onSymbolizerChange}
+        internalDataDef={this.data}
       />
     );
   }

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -239,7 +239,7 @@ export const TextEditor: React.FC<TextEditorProps> = ({
                     prefix="{{"
                     notFoundContent={locale.attributeNotFound}
                   >
-                    {properties.map(p => <MentionOption key={p} value={p}>{p}</MentionOption>)}
+                    {properties.map(p => <MentionOption key={p} value={`${p}}}`}>{p}</MentionOption>)}
                   </Mentions>
                 )
               })


### PR DESCRIPTION
## Description

This closes the curly braces (`}}`) after selecting attributes from the dropdown in the text templating input field, in order to have a proper placeholder string.

![geostyler-closing-braces](https://user-images.githubusercontent.com/12186477/190597118-25b57b1c-af3a-48da-ad8c-2664e7f13575.gif)

## Related issues or pull requests

--

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
