### PR TITLE
feat: add clear button to color field

### DIFF
--- a/src/Component/Symbolizer/Field/ColorField/ColorField.less
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.less
@@ -25,12 +25,28 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+.color-preview-wrapper {
+  display: flex;
 
-.sketch-picker {
-  position: fixed;
-  z-index: 200;
+  button.color-preview {
+    flex: 1;
+    border-right: 0;
+    border-radius: 2px 0 0 2px;
+  }
+
+  button.color-clear {
+    border-radius: 0 2px 2px 0;
+    width: 16px;
+    background-color: #ebebeb;
+  }
 }
 
-.color-preview {
+.sketch-picker {
+  position: absolute;
+  z-index: 200;
+  top: 3em;
+}
+
+.color-field {
   width: 90px;
 }

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
@@ -28,7 +28,7 @@
 
 import * as React from 'react';
 const Color = require('color');
-// import * as Color from 'color';
+
 import {
   SketchPicker,
   ColorResult
@@ -106,11 +106,23 @@ export const ColorField: React.FC<ColorFieldProps> = ({
         </Button>
         {
           colorPickerVisible ?
-            <SketchPicker
-              color={color}
-              disableAlpha={true}
-              onChangeComplete={onChangeComplete}
-            /> : null
+            <>
+              <Button
+                onClick={() => {
+                  if (onChange) {
+                    onChange(undefined);
+                    setColorPickerVisible(!colorPickerVisible);
+                  }
+                }}
+              >
+                {locale.clearText}
+              </Button>
+              <SketchPicker
+                color={color}
+                disableAlpha={true}
+                onChangeComplete={onChangeComplete}
+              />
+            </> : null
         }
       </div>
     </div>

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
@@ -35,7 +35,8 @@ import {
 } from 'react-color';
 
 import {
-  Button
+  Button,
+  Tooltip
 } from 'antd';
 
 import './ColorField.less';
@@ -43,7 +44,7 @@ import './ColorField.less';
 import { localize } from '../../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../../locale/en_US';
 import { GeoStylerLocale } from '../../../../locale/locale';
-
+import { CloseOutlined } from '@ant-design/icons';
 
 // default props
 interface ColorFieldDefaultProps {
@@ -95,7 +96,7 @@ export const ColorField: React.FC<ColorFieldProps> = ({
     <div className="editor-field color-field">
       <div className="color-preview-wrapper">
         <Button
-          className="color-preview editor-field"
+          className="color-preview"
           style={{
             backgroundColor: color || defaultValue,
             color: textColor
@@ -104,19 +105,21 @@ export const ColorField: React.FC<ColorFieldProps> = ({
         >
           {colorPickerVisible ? locale.closeText : color ? locale.editText : locale.chooseText}
         </Button>
+        <Tooltip title={locale.clearText}>
+          <Button
+            className='color-clear'
+            icon={<CloseOutlined />}
+            onClick={(e) => {
+              if (onChange) {
+                onChange(undefined);
+              }
+              setColorPickerVisible(false);
+            }}
+          />
+        </Tooltip>
         {
           colorPickerVisible ?
             <>
-              <Button
-                onClick={() => {
-                  if (onChange) {
-                    onChange(undefined);
-                    setColorPickerVisible(!colorPickerVisible);
-                  }
-                }}
-              >
-                {locale.clearText}
-              </Button>
               <SketchPicker
                 color={color}
                 disableAlpha={true}

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -250,6 +250,7 @@ const de_DE: GeoStylerLocale = {
     closeEditorText: 'Editor schließen'
   },
   ColorField: {
+    clearText: 'Löschen',
     closeText: 'Schließen',
     editText: 'Ändern',
     chooseText: 'Wählen',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -249,6 +249,7 @@ const en_US: GeoStylerLocale = {
     closeEditorText: 'Close Editor'
   },
   ColorField: {
+    clearText: 'Clear',
     closeText: 'Close',
     editText: 'Change',
     chooseText: 'Pick',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -274,6 +274,7 @@ const es_ES: GeoStylerLocale = {
     closeEditorText: 'Cerrar editor'
   },
   ColorField: {
+    clearText: 'TODO(es_ES):Clear',
     closeText: 'Cerrar',
     editText: 'Cambiar',
     chooseText: 'Elegir',

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -250,6 +250,7 @@ const fr_FR: GeoStylerLocale = {
     closeEditorText: 'Fermer l\'éditeur'
   },
   ColorField: {
+    clearText: 'TODO(fr_FR):Clear',
     closeText: 'Fermer',
     editText: 'Modifier',
     chooseText: 'Choisir',

--- a/src/locale/locale.ts
+++ b/src/locale/locale.ts
@@ -212,6 +212,7 @@ export interface GeoStylerLocale extends Locale {
     closeEditorText: string;
   };
   ColorField: {
+    clearText: string;
     closeText: string;
     editText: string;
     chooseText: string;

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -250,6 +250,7 @@ const zh_CN: GeoStylerLocale = {
     closeEditorText: '关闭编辑器'
   },
   ColorField: {
+    clearText: 'TODO(zh_CN):Clear',
     closeText: '关闭',
     editText: '更改',
     chooseText: '选取',


### PR DESCRIPTION
## Description

This adds a clear button to the color field, which appears when the color picker is visible. Clicking it will unset the color.

![localhost_6060_ (7)](https://user-images.githubusercontent.com/1849416/202431483-0ffdf0a5-6951-43c0-9a88-09d66fad964e.png)

![localhost_6060_ (8)](https://user-images.githubusercontent.com/1849416/202431555-bec60388-cf59-4532-a338-65181b61dbf9.png)


## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
