### PR TITLE
Update `.releaserc`

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -37,6 +37,7 @@
       }
     ],
     "@semantic-release/changelog",
+    "@semantic-release/npm",
     [
       "@semantic-release/git",
       {
@@ -45,6 +46,7 @@
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
-    ]
+    ],
+    "@semantic-release/github"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "geostyler",
-      "version": "9.0.1",
+      "version": "10.0.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@babel/polyfill": "^7.12.1",
@@ -53,6 +53,7 @@
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^8.0.6",
+        "@semantic-release/npm": "^9.0.1",
         "@semantic-release/release-notes-generator": "^10.0.3",
         "@terrestris/eslint-config-typescript-react": "^2.0.0",
         "@testing-library/dom": "^8.19.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^8.0.6",
+    "@semantic-release/npm": "^9.0.1",
     "@semantic-release/release-notes-generator": "^10.0.3",
     "@terrestris/eslint-config-typescript-react": "^2.0.0",
     "@testing-library/dom": "^8.19.0",


### PR DESCRIPTION
This adds the missing plugins for `npm` and `github` to the `.releaserc`.