### PR TITLE
Update CodeEditor example to format SLD

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.example.md
+++ b/src/Component/CodeEditor/CodeEditor.example.md
@@ -40,7 +40,12 @@ class CodeEditorExample extends React.Component {
     super(props);
 
     this.state = {
-      sldParser: new SldStyleParser({sldVersion: '1.1.0'}),
+      sldParser: new SldStyleParser({
+        sldVersion: '1.1.0',
+        builderOptions: {
+          format: true
+        }
+      }),
       style: {
         "name": "Demo Style",
         "rules": [


### PR DESCRIPTION
This updates the CodeEditor example and adds a `format` option to the used SldParser.