### PR TITLE
Fix CodeEditor

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -26,7 +26,12 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useState
+} from 'react';
 
 import Editor, { useMonaco } from '@monaco-editor/react';
 
@@ -100,8 +105,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   style
 }) => {
 
-  let editTimeout: number;
-
+  const editTimeout = useRef<number>();
   const [activeParser, setActiveParser] = useState<StyleParser>(defaultParser);
   const [isSldParser, setIsSldParser] = useState<boolean>(false);
   const [value, setValue] = useState<string>('');
@@ -196,9 +200,8 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   };
 
   const handleOnChange = (v?: string) => {
-    // TODO: this should only be called if the code gets manually changed
-    clearTimeout(editTimeout);
-    editTimeout = window.setTimeout(
+    clearTimeout(editTimeout.current);
+    editTimeout.current = window.setTimeout(
       () => {
         onChange(v);
       },

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -168,12 +168,14 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
     try {
       let parsedStyle;
       if (activeParser) {
-        setReadStyleResult(await activeParser.readStyle(v));
+        const result = await activeParser.readStyle(v);
+        setReadStyleResult(result);
+        onStyleChange(result.output);
       } else {
         parsedStyle = JSON.parse(v);
+        onStyleChange(parsedStyle);
       }
-      onStyleChange(parsedStyle);
-    } catch (err) {
+    } catch (err: any) {
       setReadStyleResult({
         errors: [err.message]
       });
@@ -194,6 +196,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   };
 
   const handleOnChange = (v?: string) => {
+    // TODO: this should only be called if the code gets manually changed
     clearTimeout(editTimeout);
     editTimeout = window.setTimeout(
       () => {


### PR DESCRIPTION
## Description

This fixes the change handling of the `CodeEditor`.

1. Actual call of `onStyleChange` was readded to parser related codeblock.
2. OnChange loop was fixed by using `useRef` for the timeout.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
