### PR TITLE
Extend version range to allow ol >=6

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
   "peerDependencies": {
     "@ant-design/icons": "4.x",
     "antd": "4.x",
-    "ol": "6.x",
+    "ol": ">=6.x",
     "react": ">=16.x",
     "react-dom": ">=16.x"
   }


### PR DESCRIPTION
This extends the version range for ol in the peerDependencies to allow the use of ol 7.

