### PR TITLE
fix: add check for string before using .toLowerCase() in TextFilterField

### DIFF
--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -135,7 +135,10 @@ export const TextFilterField: React.FC<TextFilterFieldProps> = ({
               onChange={onAutoCompleteChange}
               placeholder={locale.placeholder}
               dataSource={sampleValues}
-              filterOption={(val: string , option: any) => {
+              filterOption={(val: string|number, option: any) => {
+                if (typeof val !== 'string') {
+                  return false;
+                }
                 return option.key.toLowerCase().includes(val.toLowerCase());
               }}
             />


### PR DESCRIPTION
## Description

This adds a check to ensure that a variable is actually a string, before using `.toLowerCase()` in `<TextFilterField />`. Before, it was possible to crash geostyler when adding a value to a numeric filter and then switching to a text filter. This at least happens with antd@4.9, whereas the problem could not be reproduced with antd@4.24.2.

## Related issues or pull requests
--

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
