### PR TITLE
Introduces srsName input to `WfsParserInput`

### DIFF
--- a/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
+++ b/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
@@ -71,6 +71,7 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
   const [typeName, setTypeName] = useState<string>('terrestris:bundeslaender');
   const [featureID, setFeatureID] = useState<string>();
   const [propertyName, setPropertyName] = useState<string>();
+  const [srsName, setSrsName] = useState<string>();
   const [maxFeatures, setMaxFeatures] = useState<number>();
   const [validation, setValidation] = useState({
     url: undefined,
@@ -79,7 +80,8 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
     featureID: undefined,
     propertyName: undefined,
     maxFeatures: undefined,
-    fetchParams: undefined
+    fetchParams: undefined,
+    srsName: undefined
   });
 
   const onUrlChange = (event: any) => {
@@ -133,6 +135,10 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
     setFeatureID(event.target.value);
   };
 
+  const onSrsNameChange = (event: any) => {
+    setSrsName(event.target.value);
+  };
+
   const onPropertyNameChange = (newPropertyName: string) => {
     setPropertyName(newPropertyName);
   };
@@ -142,14 +148,15 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
   };
 
   const onClick = () => {
-    let requestParams;
+    let requestParams: RequestParams;
     if (version === '1.1.0') {
       requestParams = {
         version,
         typeName,
         maxFeatures,
         featureID,
-        propertyName
+        propertyName,
+        srsName
       };
     } else {
       requestParams = {
@@ -157,7 +164,8 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
         typeNames: typeName,
         count: maxFeatures,
         featureID,
-        propertyName
+        propertyName,
+        srsName
       };
     }
     onClickProp({
@@ -210,6 +218,18 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
           <Option value="1.1.0">1.1.0</Option>
           <Option value="2.0.0">2.0.0</Option>
         </Select>
+      </Form.Item>
+      <Form.Item
+        label={locale.srsNameLabel}
+        validateStatus={validation?.srsName?.status}
+        help={validation?.srsName?.message}
+        hasFeedback={true}
+      >
+        <Input
+          className='wfs-srsName-input'
+          value={srsName}
+          onChange={onSrsNameChange}
+        />
       </Form.Item>
       <Form.Item
         label={locale.featureIDLabel}

--- a/src/Component/PreviewMap/PreviewMap.tsx
+++ b/src/Component/PreviewMap/PreviewMap.tsx
@@ -36,6 +36,7 @@ import { ProjectionLike } from 'ol/proj';
 import OlFeature from 'ol/Feature';
 import OlLayerTile from 'ol/layer/Tile';
 import OlSourceOSM from 'ol/source/OSM';
+import { isEmpty } from 'ol/extent';
 
 import { Style } from 'geostyler-style';
 import { Data, VectorData } from 'geostyler-data';
@@ -105,12 +106,10 @@ export const PreviewMap: React.FC<PreviewMapProps> = ({
   const zoomToData = () => {
     const map = mapRef.current;
     const dataLayer = dataLayerRef.current;
-    map.getView().fit(
-      dataLayer.getSource().getExtent(),
-      {
-        maxZoom: 10
-      }
-    );
+    const extent = dataLayer.getSource().getExtent();
+    if (extent && !isEmpty(extent)) {
+      map.getView().fit(extent, { maxZoom: 10 });
+    }
   };
 
   /**

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -133,7 +133,8 @@ const de_DE: GeoStylerLocale = {
     featureIDLabel: 'FeatureID',
     propertyNameLabel: 'PropertyName',
     maxFeaturesLabel: 'MaxFeatures',
-    fetchParamsLabel: 'fetchParams'
+    fetchParamsLabel: 'fetchParams',
+    srsNameLabel: 'SrsName'
   },
   ParserFeedback: {
     notSupported: 'wird vom verwendeten Parser nicht unterstützt',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -124,7 +124,8 @@ const en_US: GeoStylerLocale = {
     featureIDLabel: 'FeatureID',
     propertyNameLabel: 'PropertyName',
     maxFeaturesLabel: 'MaxFeatures',
-    fetchParamsLabel: 'fetchParams'
+    fetchParamsLabel: 'fetchParams',
+    srsNameLabel: 'SrsName'
   },
   CodeEditor: {
     downloadButtonLabel: 'Save as File',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -186,7 +186,8 @@ const es_ES: GeoStylerLocale = {
     featureIDLabel: 'FeatureID',
     propertyNameLabel: 'PropertyName',
     maxFeaturesLabel: 'MaxFeatures',
-    fetchParamsLabel: 'fetchParams'
+    fetchParamsLabel: 'fetchParams',
+    srsNameLabel: 'SrsName'
   },
   CodeEditor: {
     downloadButtonLabel: 'Guardar archivo',

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -125,7 +125,8 @@ const fr_FR: GeoStylerLocale = {
     featureIDLabel: 'FeatureID',
     propertyNameLabel: 'PropertyName',
     maxFeaturesLabel: 'MaxFeatures',
-    fetchParamsLabel: 'fetchParams'
+    fetchParamsLabel: 'fetchParams',
+    srsNameLabel: 'SrsName'
   },
   CodeEditor: {
     downloadButtonLabel: 'Sauvegarder',

--- a/src/locale/locale.ts
+++ b/src/locale/locale.ts
@@ -96,6 +96,7 @@ export interface GeoStylerLocale extends Locale {
     propertyNameLabel: string;
     maxFeaturesLabel: string;
     fetchParamsLabel: string;
+    srsNameLabel: string;
   };
   ParserFeedback: {
     notSupported: string;

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -125,7 +125,8 @@ const zh_CN: GeoStylerLocale = {
     featureIDLabel: 'FeatureID',
     propertyNameLabel: 'PropertyName',
     maxFeaturesLabel: 'MaxFeatures',
-    fetchParamsLabel: 'fetchParams'
+    fetchParamsLabel: 'fetchParams',
+    srsNameLabel: 'SrsName'
   },
   CodeEditor: {
     downloadButtonLabel: '另存为文件',


### PR DESCRIPTION
## Description

This adds a form field to enter the `srsName` for the WFS request to the WfsParserInput.

It also fixes a bug in the `PreviewMap` which causes an application crash.

## Related issues or pull requests

Fixes https://github.com/geostyler/geostyler-demo/issues/403

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
