### PR TITLE
ColorRampCombo style

### DIFF
--- a/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.example.md
+++ b/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.example.md
@@ -1,0 +1,44 @@
+<!--
+ * Released under the BSD 2-Clause License
+ *
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+-->
+
+This demonstrates the use of `RuleGenerator`.
+
+```jsx
+import * as React from 'react';
+import { ColorRampCombo } from 'geostyler';
+
+function ColorRampComboExample() {
+  const [colorRamp, setColorRamp] = React.useState('GeoStyler');
+
+  return <ColorRampCombo colorRamp={colorRamp} onChange={setColorRamp}/>
+}
+
+<ColorRampComboExample />
+```

--- a/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.example.md
+++ b/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.example.md
@@ -28,7 +28,7 @@
  *
 -->
 
-This demonstrates the use of `RuleGenerator`.
+This demonstrates the usage of `ColorRampCombo`.
 
 ```jsx
 import * as React from 'react';

--- a/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.less
+++ b/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.less
@@ -35,6 +35,12 @@
     background-color: inherit;
   }
 
+  &.ant-select.ant-select-single {
+    .ant-select-selector {
+      background-color: unset;
+    }
+  }
+
   li.gs-color-ramp-option {
     font-weight: bold;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import ColorField from './Component/Symbolizer/Field/ColorField/ColorField';
 import ColorMapEditor from './Component/Symbolizer/ColorMapEditor/ColorMapEditor';
 import ColorMapEntryField from './Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField';
 import ColorMapTypeField from './Component/Symbolizer/Field/ColorMapTypeField/ColorMapTypeField';
+import ColorRampCombo from './Component/RuleGenerator/ColorRampCombo/ColorRampCombo';
 import ComparisonFilter from './Component/Filter/ComparisonFilter/ComparisonFilter';
 import ContrastEnhancementField from './Component/Symbolizer/Field/ContrastEnhancementField/ContrastEnhancementField';
 import ContrastField from './Component/Symbolizer/Field/ContrastField/ContrastField';
@@ -157,6 +158,7 @@ export {
   ColorMapEditor,
   ColorMapEntryField,
   ColorMapTypeField,
+  ColorRampCombo,
   ComparisonFilter,
   CompositionContext,
   ConfigProvider,


### PR DESCRIPTION
## Description

This fixes the styling of the `ColorRampCombo` by adding an additional selector to hide the default background.
It also adds an example for this component and adds it to the exports of the index.ts.

## Related issues or pull requests

Fixes #1969 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
