### PR TITLE
Introduces uploadButtonProps to DataLoader

### DIFF
--- a/src/Component/DataInput/DataLoader/DataLoader.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.tsx
@@ -41,7 +41,7 @@ import {
 
 import { ReadParams } from 'geostyler-wfs-parser';
 
-import UploadButton from '../../UploadButton/UploadButton';
+import UploadButton, { UploadButtonProps } from '../../UploadButton/UploadButton';
 import WfsParserInput from '../WfsParserInput/WfsParserInput';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
@@ -61,11 +61,14 @@ interface DataLoaderDefaultProps {
 export interface DataLoaderProps extends Partial<DataLoaderDefaultProps> {
   /** List of data parsers to use */
   parsers: DataParser[];
+  /** Properties that get passed to the UploadButton. */
+  uploadButtonProps?: Omit<UploadButtonProps, 'name' | 'action'>;
 }
 
 export const DataLoader: React.FC<DataLoaderProps> = ({
   parsers,
   locale = en_US.DataLoader,
+  uploadButtonProps,
   onDataRead = () => {
     return;
   }
@@ -153,12 +156,14 @@ export const DataLoader: React.FC<DataLoaderProps> = ({
           return (
             <UploadButton
               customRequest={parseGeoJsonUploadData}
+              {...uploadButtonProps}
             />
           );
         case 'Shapefile Data Parser':
           return (
             <UploadButton
               customRequest={parseShapefileUploadData}
+              {...uploadButtonProps}
             />
           );
         case 'WFS Data Parser':

--- a/src/Component/DataInput/DataLoader/DataLoader.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.tsx
@@ -62,7 +62,7 @@ export interface DataLoaderProps extends Partial<DataLoaderDefaultProps> {
   /** List of data parsers to use */
   parsers: DataParser[];
   /** Properties that get passed to the UploadButton. */
-  uploadButtonProps?: Omit<UploadButtonProps, 'name' | 'action'>;
+  uploadButtonProps?: UploadButtonProps;
 }
 
 export const DataLoader: React.FC<DataLoaderProps> = ({

--- a/src/Component/UploadButton/UploadButton.tsx
+++ b/src/Component/UploadButton/UploadButton.tsx
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
+import React from 'react';
 
 import {
   Upload,
@@ -55,7 +55,7 @@ interface UploadButtonDefaultProps {
 }
 
 // non default props
-export type UploadButtonProps = UploadButtonDefaultProps & UploadProps<any>;
+export type UploadButtonProps = UploadButtonDefaultProps & Omit<UploadProps<any>, 'name' | 'action'>;
 
 /**
  * Button to upload / import geodata file.


### PR DESCRIPTION
## Description

This adds the `uploadButtonProps` property to the `DataLoader`. This way you can pass properties to the used `UploadButton`.
e.g. Its now possible to add a callback to remove the data from the geostlyler after removing an uploaded geojson in the Demo

## Related issues or pull requests

https://github.com/geostyler/geostyler-demo/issues/405

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
