### PR TITLE
CardStyle harmonization

### DIFF
--- a/src/Component/CardStyle/CardStyle.tsx
+++ b/src/Component/CardStyle/CardStyle.tsx
@@ -53,14 +53,15 @@ import Breadcrumb, { Crumb } from '../Breadcrumb/Breadcrumb';
 import StyleOverview, { StyleOverviewProps } from '../StyleOverview/StyleOverview';
 import RuleOverview, { RuleOverviewProps } from '../RuleOverview/RuleOverview';
 import CardViewUtil from '../../Util/CardViewUtil';
-import { Editor, EditorProps } from '../Symbolizer/Editor/Editor';
+import Editor, { EditorProps } from '../Symbolizer/Editor/Editor';
 import FilterTree from '../Filter/FilterTree/FilterTree';
-import RuleGenerator, { RuleGeneratorProps } from '../RuleGenerator/RuleGenerator';
-import { BulkEditor } from '../BulkEditor/BulkEditor';
+import RuleGenerator from '../RuleGenerator/RuleGenerator';
+import BulkEditor from '../BulkEditor/BulkEditor';
 import IconSelector, { IconLibrary } from '../Symbolizer/IconSelector/IconSelector';
 import { ComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
 import { GeoStylerLocale } from '../../locale/locale';
 import Renderer from '../Renderer/Renderer';
+import { brewer, InterpolationMode } from 'chroma-js';
 
 // default props
 interface CardStyleDefaultProps {
@@ -84,14 +85,20 @@ export interface CardStyleProps extends Partial<CardStyleDefaultProps> {
   styleOverviewProps?: Partial<StyleOverviewProps>;
   /** The passthrough props for the RuleOverview component. */
   ruleOverviewProps?: Partial<RuleOverviewProps>;
-  /** The passthrough props for the RuleGenerator component. */
-  ruleGeneratorProps?: Partial<RuleGeneratorProps>;
   /** The passthrough props for the Editor component. */
   editorProps?: Partial<EditorProps>;
   // /** List of supported icons ordered as library */
   iconLibraries?: IconLibrary[];
   /** Enable classification */
   enableClassification?: boolean;
+  /** Object containing the predefined color ramps */
+  colorRamps?: {
+    [name: string]: string[];
+  };
+  /** Use Brewer color ramps */
+  useBrewerColorRamps?: boolean;
+  /** List of supported color spaces */
+  colorSpaces?: (InterpolationMode)[];
 }
 
 export interface CardView {
@@ -121,7 +128,9 @@ export const CardStyle: React.FC<CardStyleProps> = ({
   styleOverviewProps,
   ruleOverviewProps,
   editorProps,
-  ruleGeneratorProps
+  colorRamps,
+  useBrewerColorRamps,
+  colorSpaces
 }) => {
 
   const defaultCrumb: Crumb = {view: STYLEVIEW, title: locale.styleTitle, indices: []};
@@ -314,6 +323,11 @@ export const CardStyle: React.FC<CardStyleProps> = ({
   };
   const mergedStyleOverviewProps = {...styleOverviewProps, ...styleOverviewPropsOverwrites};
 
+  let ramps = colorRamps;
+  if (colorRamps && useBrewerColorRamps) {
+    ramps = Object.assign(colorRamps, brewer);
+  }
+
   return (
     <div
       className='gs-card-style'
@@ -397,7 +411,8 @@ export const CardStyle: React.FC<CardStyleProps> = ({
           <RuleGenerator
             internalDataDef={data}
             onRulesChange={onRulesChange}
-            {...ruleGeneratorProps}
+            colorRamps={ramps}
+            colorSpaces={colorSpaces}
           />
         )
       }


### PR DESCRIPTION
## Description

Removed props `ruleGeneratorProps` and replaced it with props `colorRamps`, `useBrewerColorRamps` and `colorSpaces` in order to harmonize `<CardStyle />` with `<Style />`.

This PR is opened against branch `harmonization` since this is part of a bigger series of related PRs.

## Related issues or pull requests

https://github.com/geostyler/geostyler-demo/issues/406

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
