### PR TITLE
breaking: remove unnecessary props from Rules

### DIFF
--- a/src/Component/RuleCard/RuleCard.example.md
+++ b/src/Component/RuleCard/RuleCard.example.md
@@ -145,3 +145,81 @@ class RuleCardExample extends React.Component {
 
 <RuleCardExample />
 ```
+
+With amount and duplicates deactivated.
+
+```jsx
+import * as React from 'react';
+import { RuleCard } from 'geostyler';
+
+class RuleCardExample extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      rule: {
+        name: 'myRule',
+        scaleDenominator: {
+          min: 500,
+          max: 1000
+        },
+        filter: [
+          '==',
+          'foo',
+          '2'
+        ],
+        symbolizers: [{
+          kind: 'Mark',
+          wellKnownName: 'circle'
+        }]
+      },
+      data: {
+        exampleFeatures: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              properties: {
+                foo: '1'
+              },
+              geometry: {
+                type: 'Point',
+                coordinates: [7, 50]
+              }
+            },
+            {
+              type: 'Feature',
+              properties: {
+                foo: '2'
+              },
+              geometry: {
+                type: 'Point',
+                coordinates: [6, 50]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  render() {
+    const {
+      rule,
+      data
+    } = this.state;
+
+    return (
+      <div style={{height: '300px'}}>
+        <RuleCard
+          rule={rule}
+          data={data}
+          showAmount={false}
+          showDuplicates={false}
+        />
+      </div>
+    );
+  }
+}
+
+<RuleCardExample />
+```

--- a/src/Component/RuleCard/RuleCard.tsx
+++ b/src/Component/RuleCard/RuleCard.tsx
@@ -45,6 +45,10 @@ const { Text } = Typography;
 
 // default props
 interface RuleCardDefaultProps {
+  /** Display the number of features that match a rule */
+  showAmount: boolean;
+  /** Display the number of features that match more than one rule */
+  showDuplicates: boolean;
 }
 
 // non default props
@@ -66,7 +70,9 @@ export const RuleCard: React.FC<RuleCardProps> = ({
   duplicates,
   onClick,
   data,
-  rendererProps
+  rendererProps,
+  showAmount = true,
+  showDuplicates = true
 }) => {
 
   let amount;
@@ -96,14 +102,22 @@ export const RuleCard: React.FC<RuleCardProps> = ({
         <h2>{rule.name}</h2>
         <span><>1:{rule.scaleDenominator?.min || '-'} <MinusOutlined /> 1:{rule.scaleDenominator?.max || '-'}</></span>
         <span className='gs-rule-card-content-icon-row'>
-          <Text type='secondary'>
-            <span className='gs-rule-card-icon'>Σ</span>
-            {amount !== undefined ? amount : '-'}
-          </Text>
-          <Text type='secondary'>
-            <BlockOutlined className='gs-rule-card-icon' />
-            {duplicates !== undefined ? duplicates : '-'}
-          </Text>
+          {
+            showAmount && (
+              <Text type='secondary'>
+                <span className='gs-rule-card-icon'>Σ</span>
+                {amount !== undefined ? amount : '-'}
+              </Text>
+            )
+          }
+          {
+            showDuplicates && (
+              <Text type='secondary'>
+                <BlockOutlined className='gs-rule-card-icon' />
+                {duplicates !== undefined ? duplicates : '-'}
+              </Text>
+            )
+          }
         </span>
         <span className='gs-rule-card-cql'>
           {

--- a/src/Component/Rules/Rules.tsx
+++ b/src/Component/Rules/Rules.tsx
@@ -42,8 +42,6 @@ import {
   SLDRendererAdditonalProps } from '../Renderer/SLDRenderer/SLDRenderer';
 import DataUtil from '../../Util/DataUtil';
 import { Data } from 'geostyler-data';
-import { ComparisonFilterProps } from '../Filter/ComparisonFilter/ComparisonFilter';
-import { IconLibrary } from '../Symbolizer/IconSelector/IconSelector';
 import { Button, Switch, Divider } from 'antd';
 
 import _cloneDeep from 'lodash/cloneDeep';
@@ -83,14 +81,6 @@ export interface RulesProps extends Partial<RulesDefaultProps> {
   onEditSelectionClick?: (selectedIdxs: number[]) => void;
   /** The callback function that is triggered when the rule was clicked */
   onEditRuleClick?: (ruleId: number) => void;
-  /** Properties that will be passed to the Comparison Filters */
-  filterUiProps?: Partial<ComparisonFilterProps>;
-  /** List of supported icons ordered as library */
-  iconLibraries?: IconLibrary[];
-  /** Object containing predefined color ramps */
-  colorRamps?: {
-    [name: string]: string[];
-  };
   /** The passthrough props for the RuleCard component. */
   ruleCardProps?: Partial<RuleCardProps>;
 }
@@ -98,17 +88,12 @@ export interface RulesProps extends Partial<RulesDefaultProps> {
 export const Rules: React.FC<RulesProps> = ({
   locale = en_US.Rules,
   ruleCardProps,
-  showAmount = true,
-  showDuplicates = true,
   data,
   rules,
   onRulesChange,
   onClassificationClick,
   onEditSelectionClick,
   onEditRuleClick,
-  filterUiProps,
-  iconLibraries = [],
-  colorRamps,
   enableClassification = true
 }) => {
   const [multiEditActive, setMultiEditActive] = useState<boolean>(false);


### PR DESCRIPTION
## Description

Removes props `filterUiProps`, `iconLibraries`, `colorRamps` from `<Rules />`. Moves `showAmount`, `showDuplicates` to `<RuleCard />` and to `ruleCardProps` on `<Rules />`.

## Related issues or pull requests

https://github.com/geostyler/geostyler-demo/issues/406

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
