### PR TITLE
Add missing offset fields to symbolizer editors

### DIFF
--- a/src/Component/Symbolizer/IconEditor/IconEditor.spec.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.spec.tsx
@@ -80,6 +80,36 @@ describe('IconEditor', () => {
     });
   });
 
+  describe('onOffsetXChange', () => {
+    it('calls the onOffsetXChange prop with correct symbolizer ', async () => {
+      const textEditor = render(<IconEditor {...props} />);
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.offset = [3, 0];
+      const input = textEditor.container.querySelectorAll('.offset-field input')[0];
+      await act(async() => {
+        fireEvent.change(input, {
+          target: { value: 3 }
+        });
+      });
+      expect(props.onSymbolizerChange).toBeCalledWith(newSymbolizer);
+    });
+  });
+
+  describe('onOffsetYChange', () => {
+    it('calls the onOffsetYChange prop with correct symbolizer ', async () => {
+      const textEditor = render(<IconEditor {...props} />);
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.offset = [0, 10];
+      const input = textEditor.container.querySelectorAll('.offset-field input')[1];
+      await act(async() => {
+        fireEvent.change(input, {
+          target: { value: 10 }
+        });
+      });
+      expect(props.onSymbolizerChange).toBeCalledWith(newSymbolizer);
+    });
+  });
+
   describe('onRotateChange', () => {
     it('calls the onRotateChange prop with correct symbolizer ', async() => {
       const iconEditor = render(<IconEditor {...props} />);

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -224,11 +224,11 @@ export const IconEditor: React.FC<IconEditorProps> = ({
             {
               CompositionUtil.handleComposition({
                 composition,
-                path: 'TextEditor.offsetXField',
+                path: 'IconEditor.offsetXField',
                 onChange: onOffsetXChange,
                 propName: 'offset',
                 propValue: offset?.[0],
-                defaultValue: defaultValues?.TextEditor?.defaultOffsetX,
+                defaultValue: defaultValues?.IconEditor?.defaultOffsetX,
                 defaultElement: <OffsetField />
               })
             }
@@ -241,11 +241,11 @@ export const IconEditor: React.FC<IconEditorProps> = ({
             {
               CompositionUtil.handleComposition({
                 composition,
-                path: 'TextEditor.offsetYField',
+                path: 'IconEditor.offsetYField',
                 onChange: onOffsetYChange,
                 propName: 'offset',
                 propValue: offset?.[1],
-                defaultValue: defaultValues?.TextEditor?.defaultOffsetY,
+                defaultValue: defaultValues?.IconEditor?.defaultOffsetY,
                 defaultElement: <OffsetField />
               })
             }

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -56,6 +56,7 @@ import {
   UnsupportedPropertiesContext
 } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
 import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
+import OffsetField from '../Field/OffsetField/OffsetField';
 
 // default props
 export interface IconEditorDefaultProps {
@@ -110,6 +111,24 @@ export const IconEditor: React.FC<IconEditorProps> = ({
     }
   };
 
+  const onOffsetXChange = (value: number) => {
+    const symbolizerClone = _cloneDeep(symbolizer);
+    let newOffset: [number, number] = [value, (symbolizerClone.offset ? symbolizerClone.offset[1] : 0) as number];
+    symbolizerClone.offset = newOffset;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizerClone);
+    }
+  };
+
+  const onOffsetYChange = (value: number) => {
+    const symbolizerClone = _cloneDeep(symbolizer);
+    let newOffset: [number, number] = [(symbolizerClone.offset ? symbolizerClone.offset[0] : 0) as number, value];
+    symbolizerClone.offset = newOffset;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizerClone);
+    }
+  };
+
   const onRotateChange = (value: number) => {
     const symbolizerClone = _cloneDeep(symbolizer);
     symbolizerClone.rotate = value;
@@ -135,7 +154,8 @@ export const IconEditor: React.FC<IconEditorProps> = ({
     opacity,
     image,
     size,
-    rotate
+    rotate,
+    offset
   } = symbolizer;
 
   const imageSrc = !_isEmpty(image) ? image : locale.imagePlaceholder;
@@ -193,6 +213,40 @@ export const IconEditor: React.FC<IconEditorProps> = ({
                 propValue: size,
                 defaultValue: defaultValues?.IconEditor?.defaultSize,
                 defaultElement: <SizeField />
+              })
+            }
+          </Form.Item>
+          <Form.Item
+            label={locale.offsetXLabel}
+            {...getSupportProps('offset')}
+            {...formItemLayout}
+          >
+            {
+              CompositionUtil.handleComposition({
+                composition,
+                path: 'TextEditor.offsetXField',
+                onChange: onOffsetXChange,
+                propName: 'offset',
+                propValue: offset?.[0],
+                defaultValue: defaultValues?.TextEditor?.defaultOffsetX,
+                defaultElement: <OffsetField />
+              })
+            }
+          </Form.Item>
+          <Form.Item
+            label={locale.offsetYLabel}
+            {...getSupportProps('offset')}
+            {...formItemLayout}
+          >
+            {
+              CompositionUtil.handleComposition({
+                composition,
+                path: 'TextEditor.offsetYField',
+                onChange: onOffsetYChange,
+                propName: 'offset',
+                propValue: offset?.[1],
+                defaultValue: defaultValues?.TextEditor?.defaultOffsetY,
+                defaultElement: <OffsetField />
               })
             }
           </Form.Item>

--- a/src/Component/Symbolizer/LineEditor/LineEditor.spec.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.spec.tsx
@@ -76,6 +76,21 @@ describe('LineEditor', () => {
     });
   });
 
+  describe('onPerpendicularOffsetChange', () => {
+    it('calls the onSymbolizerChange prop with correct symbolizer ', async () => {
+      const wellKnownNameEditor = render(<LineEditor {...props} />);
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.perpendicularOffset = 13;
+      const input = wellKnownNameEditor.container.querySelectorAll('.offset-field input')[0];
+      await act(async() => {
+        fireEvent.change(input, {
+          target: { value: 13}
+        });
+      });
+      expect(props.onSymbolizerChange).toBeCalledWith(newSymbolizer);
+    });
+  });
+
   describe('onOpacityChange', () => {
     it('calls the onSymbolizerChange prop with correct symbolizer ', async () => {
       const wellKnownNameEditor = render(<LineEditor {...props} />);
@@ -116,7 +131,7 @@ describe('LineEditor', () => {
       );
       const newSymbolizer = {...passedSymbolizer};
       newSymbolizer.dashOffset = 7;
-      const input = wellKnownNameEditor.container.querySelectorAll('.offset-field input')[0];
+      const input = wellKnownNameEditor.container.querySelectorAll('.offset-field input')[1];
       await act(async() => {
         fireEvent.change(input, {
           target: { value: 7 }

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -110,6 +110,14 @@ export const LineEditor: React.FC<LineEditorProps> = ({
     }
   };
 
+  const onPerpendicularOffsetChange = (value: LineSymbolizer['perpendicularOffset']) => {
+    const sybolizerClone = _cloneDeep(symbolizer);
+    sybolizerClone.perpendicularOffset = value;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(sybolizerClone);
+    }
+  };
+
   const onOpacityChange = (value: LineSymbolizer['opacity']) => {
     const sybolizerClone = _cloneDeep(symbolizer);
     sybolizerClone.opacity = value;
@@ -150,17 +158,17 @@ export const LineEditor: React.FC<LineEditorProps> = ({
     }
   };
 
-  const onGraphicStrokeChange = (gStroke: PointSymbolizer) => {
+  const onGraphicStrokeChange = (value: PointSymbolizer) => {
     const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.graphicStroke = gStroke;
+    sybolizerClone.graphicStroke = value;
     if (onSymbolizerChange) {
       onSymbolizerChange(sybolizerClone);
     }
   };
 
-  const onGraphicFillChange = (gFill: PointSymbolizer) => {
+  const onGraphicFillChange = (value: PointSymbolizer) => {
     const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.graphicFill = gFill;
+    sybolizerClone.graphicFill = value;
     if (onSymbolizerChange) {
       onSymbolizerChange(sybolizerClone);
     }
@@ -180,6 +188,7 @@ export const LineEditor: React.FC<LineEditorProps> = ({
     cap,
     join,
     graphicStroke,
+    perpendicularOffset,
     graphicFill
   } = _cloneDeep(symbolizer);
 
@@ -229,6 +238,23 @@ export const LineEditor: React.FC<LineEditorProps> = ({
                     propValue: width,
                     defaultValue: defaultValues?.LineEditor?.defaultWidth,
                     defaultElement: <WidthField />
+                  })
+                }
+              </Form.Item>
+              <Form.Item
+                label={locale.perpendicularOffsetLabel}
+                {...getSupportProps('perpendicularOffset')}
+                {...formItemLayout}
+              >
+                {
+                  CompositionUtil.handleComposition({
+                    composition,
+                    path: 'LineEditor.perpendicularOffsetField',
+                    onChange: onPerpendicularOffsetChange,
+                    propName: 'offset',
+                    propValue: perpendicularOffset,
+                    defaultValue: defaultValues?.LineEditor?.defaultPerpendicularOffset,
+                    defaultElement: <OffsetField />
                   })
                 }
               </Form.Item>

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -95,82 +95,82 @@ export const LineEditor: React.FC<LineEditorProps> = ({
   } = useContext(UnsupportedPropertiesContext);
 
   const onColorChange = (value: LineSymbolizer['color']) => {
-    const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.color = value;
+    const symbolizerClone = _cloneDeep(symbolizer);
+    symbolizerClone.color = value;
     if (onSymbolizerChange) {
-      onSymbolizerChange(sybolizerClone);
+      onSymbolizerChange(symbolizerClone);
     }
   };
 
   const onWidthChange = (value: LineSymbolizer['width']) => {
-    const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.width = value;
+    const symbolizerClone = _cloneDeep(symbolizer);
+    symbolizerClone.width = value;
     if (onSymbolizerChange) {
-      onSymbolizerChange(sybolizerClone);
+      onSymbolizerChange(symbolizerClone);
     }
   };
 
   const onPerpendicularOffsetChange = (value: LineSymbolizer['perpendicularOffset']) => {
-    const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.perpendicularOffset = value;
+    const symbolizerClone = _cloneDeep(symbolizer);
+    symbolizerClone.perpendicularOffset = value;
     if (onSymbolizerChange) {
-      onSymbolizerChange(sybolizerClone);
+      onSymbolizerChange(symbolizerClone);
     }
   };
 
   const onOpacityChange = (value: LineSymbolizer['opacity']) => {
-    const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.opacity = value;
+    const symbolizerClone = _cloneDeep(symbolizer);
+    symbolizerClone.opacity = value;
     if (onSymbolizerChange) {
-      onSymbolizerChange(sybolizerClone);
+      onSymbolizerChange(symbolizerClone);
     }
   };
 
   const onDasharrayChange = (value: LineSymbolizer['dasharray']) => {
-    const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.dasharray = value;
+    const symbolizerClone = _cloneDeep(symbolizer);
+    symbolizerClone.dasharray = value;
     if (onSymbolizerChange) {
-      onSymbolizerChange(sybolizerClone);
+      onSymbolizerChange(symbolizerClone);
     }
   };
 
   const onDashOffsetChange = (value: LineSymbolizer['dashOffset']) => {
-    const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.dashOffset = value;
+    const symbolizerClone = _cloneDeep(symbolizer);
+    symbolizerClone.dashOffset = value;
     if (onSymbolizerChange) {
-      onSymbolizerChange(sybolizerClone);
+      onSymbolizerChange(symbolizerClone);
     }
   };
 
   const onCapChange = (value: LineSymbolizer['cap']) => {
-    const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.cap = value;
+    const symbolizerClone = _cloneDeep(symbolizer);
+    symbolizerClone.cap = value;
     if (onSymbolizerChange) {
-      onSymbolizerChange(sybolizerClone);
+      onSymbolizerChange(symbolizerClone);
     }
   };
 
   const onJoinChange = (value: LineSymbolizer['join']) => {
-    const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.join = value;
+    const symbolizerClone = _cloneDeep(symbolizer);
+    symbolizerClone.join = value;
     if (onSymbolizerChange) {
-      onSymbolizerChange(sybolizerClone);
+      onSymbolizerChange(symbolizerClone);
     }
   };
 
   const onGraphicStrokeChange = (value: PointSymbolizer) => {
-    const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.graphicStroke = value;
+    const symbolizerClone = _cloneDeep(symbolizer);
+    symbolizerClone.graphicStroke = value;
     if (onSymbolizerChange) {
-      onSymbolizerChange(sybolizerClone);
+      onSymbolizerChange(symbolizerClone);
     }
   };
 
   const onGraphicFillChange = (value: PointSymbolizer) => {
-    const sybolizerClone = _cloneDeep(symbolizer);
-    sybolizerClone.graphicFill = value;
+    const symbolizerClone = _cloneDeep(symbolizer);
+    symbolizerClone.graphicFill = value;
     if (onSymbolizerChange) {
-      onSymbolizerChange(sybolizerClone);
+      onSymbolizerChange(symbolizerClone);
     }
   };
 

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.spec.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.spec.tsx
@@ -66,6 +66,36 @@ describe('WellKnownNameEditor', () => {
     });
   });
 
+  describe('onOffsetXChange', () => {
+    it('calls the onOffsetXChange prop with correct symbolizer ', async () => {
+      const textEditor = render(<WellKnownNameEditor {...props} />);
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.offset = [3, 0];
+      const input = textEditor.container.querySelectorAll('.offset-field input')[0];
+      await act(async() => {
+        fireEvent.change(input, {
+          target: { value: 3 }
+        });
+      });
+      expect(props.onSymbolizerChange).toBeCalledWith(newSymbolizer);
+    });
+  });
+
+  describe('onOffsetYChange', () => {
+    it('calls the onOffsetYChange prop with correct symbolizer ', async () => {
+      const textEditor = render(<WellKnownNameEditor {...props} />);
+      const newSymbolizer = {...dummySymbolizer};
+      newSymbolizer.offset = [0, 10];
+      const input = textEditor.container.querySelectorAll('.offset-field input')[1];
+      await act(async() => {
+        fireEvent.change(input, {
+          target: { value: 10 }
+        });
+      });
+      expect(props.onSymbolizerChange).toBeCalledWith(newSymbolizer);
+    });
+  });
+
   // describe('onColorChange', () => {
   //   it('calls the onSymbolizerChange prop with correct symbolizer ', () => {
   //     const onColorChange = wrapper.instance().onColorChange;

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -49,6 +49,7 @@ import { Form } from 'antd';
 import _cloneDeep from 'lodash/cloneDeep';
 import _isEqual from 'lodash/isEqual';
 import { GeoStylerLocale } from '../../../locale/locale';
+import OffsetField from '../Field/OffsetField/OffsetField';
 
 interface WellKnownNameEditorDefaultProps {
   locale: GeoStylerLocale['WellKnownNameEditor'];
@@ -58,7 +59,7 @@ interface WellKnownNameEditorDefaultProps {
 export interface WellKnownNameEditorProps extends Partial<WellKnownNameEditorDefaultProps> {
   symbolizer: MarkSymbolizer;
   onSymbolizerChange?: (changedSymb: Symbolizer) => void;
-  defaultValues: DefaultValues;
+  defaultValues?: DefaultValues;
 }
 
 const COMPONENTNAME = 'WellKnownNameEditor';
@@ -73,6 +74,24 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = ({
   const onRadiusChange = (value: number) => {
     const symbolizerClone = _cloneDeep(symbolizer);
     symbolizerClone.radius = value;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizerClone);
+    }
+  };
+
+  const onOffsetXChange = (value: number) => {
+    const symbolizerClone = _cloneDeep(symbolizer);
+    let newOffset: [number, number] = [value, (symbolizerClone.offset ? symbolizerClone.offset[1] : 0) as number];
+    symbolizerClone.offset = newOffset;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizerClone);
+    }
+  };
+
+  const onOffsetYChange = (value: number) => {
+    const symbolizerClone = _cloneDeep(symbolizer);
+    let newOffset: [number, number] = [(symbolizerClone.offset ? symbolizerClone.offset[0] : 0) as number, value];
+    symbolizerClone.offset = newOffset;
     if (onSymbolizerChange) {
       onSymbolizerChange(symbolizerClone);
     }
@@ -162,7 +181,8 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = ({
     rotate,
     strokeColor,
     strokeOpacity,
-    strokeWidth
+    strokeWidth,
+    offset
   } = symbolizer;
 
   return (
@@ -180,6 +200,34 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = ({
                 propValue: radius,
                 defaultValue: defaultValues?.WellKnownNameEditor?.defaultRadius,
                 defaultElement: <RadiusField />
+              })
+            )
+          }
+          {
+            wrapFormItem(
+              locale.offsetXLabel,
+              CompositionUtil.handleComposition({
+                composition,
+                path: 'TextEditor.offsetXField',
+                onChange: onOffsetXChange,
+                propName: 'offset',
+                propValue: offset?.[0],
+                defaultValue: defaultValues?.TextEditor?.defaultOffsetX,
+                defaultElement: <OffsetField />
+              })
+            )
+          }
+          {
+            wrapFormItem(
+              locale.offsetYLabel,
+              CompositionUtil.handleComposition({
+                composition,
+                path: 'TextEditor.offsetYField',
+                onChange: onOffsetYChange,
+                propName: 'offset',
+                propValue: offset?.[1],
+                defaultValue: defaultValues?.TextEditor?.defaultOffsetY,
+                defaultElement: <OffsetField />
               })
             )
           }

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -208,11 +208,11 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = ({
               locale.offsetXLabel,
               CompositionUtil.handleComposition({
                 composition,
-                path: 'TextEditor.offsetXField',
+                path: 'WellKnownNameEditor.offsetXField',
                 onChange: onOffsetXChange,
                 propName: 'offset',
                 propValue: offset?.[0],
-                defaultValue: defaultValues?.TextEditor?.defaultOffsetX,
+                defaultValue: defaultValues?.WellKnownNameEditor?.defaultOffsetX,
                 defaultElement: <OffsetField />
               })
             )
@@ -222,11 +222,11 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = ({
               locale.offsetYLabel,
               CompositionUtil.handleComposition({
                 composition,
-                path: 'TextEditor.offsetYField',
+                path: 'WellKnownNameEditor.offsetYField',
                 onChange: onOffsetYChange,
                 propName: 'offset',
                 propValue: offset?.[1],
-                defaultValue: defaultValues?.TextEditor?.defaultOffsetY,
+                defaultValue: defaultValues?.WellKnownNameEditor?.defaultOffsetY,
                 defaultElement: <OffsetField />
               })
             )

--- a/src/context/DefaultValueContext/DefaultValueContext.tsx
+++ b/src/context/DefaultValueContext/DefaultValueContext.tsx
@@ -46,6 +46,8 @@ export interface DefaultValues {
   IconEditor?: {
     defaultImage?: string;
     defaultSize?: number;
+    defaultOffsetX?: number;
+    defaultOffsetY?: number;
     defaultRotate?: number;
     defaultOpacity?: number;
   };
@@ -78,6 +80,8 @@ export interface DefaultValues {
   };
   WellKnownNameEditor?: {
     defaultRadius?: string;
+    defaultOffsetX?: number;
+    defaultOffsetY?: number;
     defaultColor?: string;
     defaultOpacity?: number;
     defaultFillOpacity?: number;

--- a/src/context/DefaultValueContext/DefaultValueContext.tsx
+++ b/src/context/DefaultValueContext/DefaultValueContext.tsx
@@ -38,6 +38,7 @@ export interface DefaultValues {
     defaultWidth?: number;
     defaultColor?: string;
     defaultOpacity?: number;
+    defaultPerpendicularOffset?: number;
     defaultDashOffset?: number;
     defaultCap?: string;
     defaultJoin?: string;

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -161,12 +161,14 @@ const de_DE: GeoStylerLocale = {
     graphicFillTypeLabel: 'Graphic Fill Type'
   },
   IconEditor: {
-    imagePlaceholder: 'URL zum Icon',
+    iconTooltipLabel: 'Öffne Galerie',
     imageLabel: 'Quelle',
-    sizeLabel: 'Größe',
-    rotateLabel: 'Drehung',
+    imagePlaceholder: 'URL zum Icon',
+    offsetXLabel: 'Versatz X',
+    offsetYLabel: 'Versatz Y',
     opacityLabel: 'Deckkraft',
-    iconTooltipLabel: 'Öffne Galerie'
+    rotateLabel: 'Drehung',
+    sizeLabel: 'Größe',
   },
   LineEditor: {
     capLabel: 'Verschluss',

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -141,14 +141,16 @@ const de_DE: GeoStylerLocale = {
     partiallySupported: 'wird vom verwendeten Parser nur teilweise unterstützt'
   },
   WellKnownNameEditor: {
-    radiusLabel: 'Radius',
-    fillOpacityLabel: 'Fülldeckkraft',
     fillColorLabel: 'Füllfarbe',
+    fillOpacityLabel: 'Fülldeckkraft',
+    offsetXLabel: 'Versatz X',
+    offsetYLabel: 'Versatz Y',
     opacityLabel: 'Deckkraft',
+    radiusLabel: 'Radius',
+    rotateLabel: 'Drehung',
     strokeColorLabel: 'Strichfarbe',
-    strokeWidthLabel: 'Strichstärke',
     strokeOpacityLabel: 'Strichdeckkraft',
-    rotateLabel: 'Drehung'
+    strokeWidthLabel: 'Strichstärke',
   },
   FillEditor: {
     opacityLabel: 'Deckkraft',

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -169,15 +169,16 @@ const de_DE: GeoStylerLocale = {
     iconTooltipLabel: 'Öffne Galerie'
   },
   LineEditor: {
+    capLabel: 'Verschluss',
     colorLabel: 'Farbe',
-    widthLabel: 'Breite',
-    opacityLabel: 'Deckkraft',
     dashLabel: 'Strichmuster',
     dashOffsetLabel: 'Strichmuster Versatz',
-    capLabel: 'Verschluss',
-    joinLabel: 'Verknüpfung',
+    graphicFillTypeLabel: 'Graphic Fill Type',
     graphicStrokeTypeLabel: 'Graphic Stroke Type',
-    graphicFillTypeLabel: 'Graphic Fill Type'
+    joinLabel: 'Verknüpfung',
+    opacityLabel: 'Deckkraft',
+    perpendicularOffsetLabel: 'Senkrechter Versatz',
+    widthLabel: 'Breite',
   },
   MarkEditor: {
     wellKnownNameFieldLabel: 'Symbol'

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -140,14 +140,16 @@ const en_US: GeoStylerLocale = {
     partiallySupported: 'is only partially supported by used parser'
   },
   WellKnownNameEditor: {
-    radiusLabel: 'Radius',
-    fillOpacityLabel: 'Fill-Opacity',
     fillColorLabel: 'Fill-Color',
+    fillOpacityLabel: 'Fill-Opacity',
+    offsetXLabel: 'Offset X',
+    offsetYLabel: 'Offset Y',
     opacityLabel: 'Opacity',
+    radiusLabel: 'Radius',
+    rotateLabel: 'Rotation',
     strokeColorLabel: 'Stroke-Color',
-    strokeWidthLabel: 'Stroke-Width',
     strokeOpacityLabel: 'Stroke-Opacity',
-    rotateLabel: 'Rotation'
+    strokeWidthLabel: 'Stroke-Width',
   },
   FillEditor: {
     opacityLabel: 'Opacity',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -171,15 +171,16 @@ const en_US: GeoStylerLocale = {
     wellKnownNameFieldLabel: 'Symbol'
   },
   LineEditor: {
+    capLabel: 'Cap',
     colorLabel: 'Color',
-    widthLabel: 'Width',
-    opacityLabel: 'Opacity',
     dashLabel: 'Dash Pattern',
     dashOffsetLabel: 'Dash Offset',
-    capLabel: 'Cap',
-    joinLabel: 'Join',
+    graphicFillTypeLabel: 'Graphic Fill Type',
     graphicStrokeTypeLabel: 'Graphic Stroke Type',
-    graphicFillTypeLabel: 'Graphic Fill Type'
+    joinLabel: 'Join',
+    opacityLabel: 'Opacity',
+    perpendicularOffsetLabel: 'Perpendicular Offset',
+    widthLabel: 'Width',
   },
   TextEditor: {
     fontLabel: 'Font',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -160,12 +160,14 @@ const en_US: GeoStylerLocale = {
     graphicFillTypeLabel: 'Graphic Fill Type'
   },
   IconEditor: {
+    iconTooltipLabel: 'Open Gallery',
     imageLabel: 'Source',
     imagePlaceholder: 'URL to Icon',
-    sizeLabel: 'Size',
-    rotateLabel: 'Rotation',
+    offsetXLabel: 'Offset X',
+    offsetYLabel: 'Offset Y',
     opacityLabel: 'Opacity',
-    iconTooltipLabel: 'Open Gallery'
+    rotateLabel: 'Rotation',
+    sizeLabel: 'Size',
   },
   MarkEditor: {
     wellKnownNameFieldLabel: 'Symbol'

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -222,12 +222,14 @@ const es_ES: GeoStylerLocale = {
     graphicFillTypeLabel: 'Tipo gráfico de relleno'
   },
   IconEditor: {
+    iconTooltipLabel: 'Abrir galería',
     imageLabel: 'Fuente',
     imagePlaceholder: 'URL a Icono',
-    sizeLabel: 'Tamaño',
-    rotateLabel: 'Rotación',
+    offsetXLabel: 'Desplazamiento X',
+    offsetYLabel: 'Desplazamiento Y',
     opacityLabel: 'Transparencia',
-    iconTooltipLabel: 'Abrir galería'
+    rotateLabel: 'Rotación',
+    sizeLabel: 'Tamaño',
   },
   LineEditor: {
     capLabel: 'Cap',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -230,15 +230,16 @@ const es_ES: GeoStylerLocale = {
     iconTooltipLabel: 'Abrir galería'
   },
   LineEditor: {
+    capLabel: 'Cap',
     colorLabel: 'Color',
-    widthLabel: 'Ancho',
-    opacityLabel: 'Transparencia',
     dashLabel: 'Patrón de achurado',
     dashOffsetLabel: 'Dash Offset',
-    capLabel: 'Cap',
-    joinLabel: 'Join',
+    graphicFillTypeLabel: 'Tipo de gráfico de relleno',
     graphicStrokeTypeLabel: 'Tipo de gráfico de trazado',
-    graphicFillTypeLabel: 'Tipo de gráfico de relleno'
+    joinLabel: 'Join',
+    opacityLabel: 'Transparencia',
+    perpendicularOffsetLabel: 'Perpendicular Offset',
+    widthLabel: 'Ancho',
   },
   MarkEditor: {
     wellKnownNameFieldLabel: 'Simbolo'

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -202,14 +202,16 @@ const es_ES: GeoStylerLocale = {
     partiallySupported: 'sólo es parcialmente soportado por el parser utilizado'
   },
   WellKnownNameEditor: {
-    radiusLabel: 'Radio',
-    fillOpacityLabel: 'Relleno-Transparencia',
     fillColorLabel: 'Fondo-Color',
+    fillOpacityLabel: 'Relleno-Transparencia',
+    offsetXLabel: 'Desplazamiento X',
+    offsetYLabel: 'Desplazamiento Y',
     opacityLabel: 'Transparencia',
+    radiusLabel: 'Radio',
+    rotateLabel: 'Rotación',
     strokeColorLabel: 'Trazo-Color',
-    strokeWidthLabel: 'Trazo-Ancho',
     strokeOpacityLabel: 'Trazo-Transparencia',
-    rotateLabel: 'Rotación'
+    strokeWidthLabel: 'Trazo-Ancho',
   },
   FillEditor: {
     fillOpacityLabel: 'Relleno-Transparencia',

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -172,15 +172,16 @@ const fr_FR: GeoStylerLocale = {
     wellKnownNameFieldLabel: 'Symbole'
   },
   LineEditor: {
+    capLabel: 'Terminaison',
     colorLabel: 'Couleur',
-    widthLabel: 'Épaisseur',
-    opacityLabel: 'Opacité',
     dashLabel: 'Motif de tireté',
     dashOffsetLabel: 'Décalage du tireté',
-    capLabel: 'Terminaison',
-    joinLabel: 'Jointure',
+    graphicFillTypeLabel: 'Type de remplissage',
     graphicStrokeTypeLabel: 'Type de tracé',
-    graphicFillTypeLabel: 'Type de remplissage'
+    joinLabel: 'Jointure',
+    opacityLabel: 'Opacité',
+    perpendicularOffsetLabel: 'Décalage perpendiculaire',
+    widthLabel: 'Épaisseur',
   },
   TextEditor: {
     fontLabel: 'Police',

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -161,12 +161,14 @@ const fr_FR: GeoStylerLocale = {
     graphicFillTypeLabel: 'Motif du remplissage'
   },
   IconEditor: {
+    iconTooltipLabel: 'Ouvrir la galerie',
     imageLabel: 'Source',
     imagePlaceholder: 'URL de l\'icône',
-    sizeLabel: 'Taille',
-    rotateLabel: 'Rotation',
+    offsetXLabel: 'Décalage horizontal',
+    offsetYLabel: 'Décalage vertical',
     opacityLabel: 'Opacité',
-    iconTooltipLabel: 'Ouvrir la galerie'
+    rotateLabel: 'Rotation',
+    sizeLabel: 'Taille',
   },
   MarkEditor: {
     wellKnownNameFieldLabel: 'Symbole'

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -141,14 +141,16 @@ const fr_FR: GeoStylerLocale = {
     partiallySupported : 'n\'est que partiellement supporté par l\'analyseur utilisé'
   },
   WellKnownNameEditor: {
-    radiusLabel: 'Rayon',
-    fillOpacityLabel: 'Opacité du remplissage',
     fillColorLabel: 'Couleur du remplissage',
+    fillOpacityLabel: 'Opacité du remplissage',
+    offsetXLabel: 'Décalage horizontal',
+    offsetYLabel: 'Décalage vertical',
     opacityLabel: 'Opacité',
+    radiusLabel: 'Rayon',
+    rotateLabel: 'Rotation',
     strokeColorLabel: 'Couleur du contour',
-    strokeWidthLabel: 'Épaisseur du contour',
     strokeOpacityLabel: 'Opacité du contour',
-    rotateLabel: 'Rotation'
+    strokeWidthLabel: 'Épaisseur du contour',
   },
   FillEditor: {
     opacityLabel: 'Opacité',

--- a/src/locale/locale.ts
+++ b/src/locale/locale.ts
@@ -103,14 +103,16 @@ export interface GeoStylerLocale extends Locale {
     partiallySupported: string;
   };
   WellKnownNameEditor: {
-    radiusLabel: string;
-    fillOpacityLabel: string;
     fillColorLabel: string;
+    fillOpacityLabel: string;
+    offsetXLabel: string;
+    offsetYLabel: string;
     opacityLabel: string;
-    strokeColorLabel: string;
-    strokeWidthLabel: string;
-    strokeOpacityLabel: string;
+    radiusLabel: string;
     rotateLabel: string;
+    strokeColorLabel: string;
+    strokeOpacityLabel: string;
+    strokeWidthLabel: string;
   };
   FillEditor: {
     opacityLabel: string;

--- a/src/locale/locale.ts
+++ b/src/locale/locale.ts
@@ -123,12 +123,14 @@ export interface GeoStylerLocale extends Locale {
     graphicFillTypeLabel: string;
   };
   IconEditor: {
+    iconTooltipLabel: string;
     imageLabel: string;
     imagePlaceholder: string;
-    sizeLabel: string;
-    rotateLabel: string;
+    offsetXLabel: string;
+    offsetYLabel: string;
     opacityLabel: string;
-    iconTooltipLabel: string;
+    rotateLabel: string;
+    sizeLabel: string;
   };
   LineEditor: {
     colorLabel: string;

--- a/src/locale/locale.ts
+++ b/src/locale/locale.ts
@@ -136,6 +136,7 @@ export interface GeoStylerLocale extends Locale {
     opacityLabel: string;
     dashLabel: string;
     dashOffsetLabel: string;
+    perpendicularOffsetLabel: string;
     capLabel: string;
     joinLabel: string;
     graphicStrokeTypeLabel: string;

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -161,12 +161,14 @@ const zh_CN: GeoStylerLocale = {
     graphicFillTypeLabel: '填充样式'
   },
   IconEditor: {
+    iconTooltipLabel: '打开图库',
     imageLabel: '来源',
     imagePlaceholder: 'URL到图标',
-    sizeLabel: '尺寸',
-    rotateLabel: '旋转',
+    offsetXLabel: 'X 偏移',
+    offsetYLabel: 'Y 偏移',
     opacityLabel: '不透明度',
-    iconTooltipLabel: '打开图库'
+    rotateLabel: '旋转',
+    sizeLabel: '尺寸',
   },
   MarkEditor: {
     wellKnownNameFieldLabel: '符号'

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -141,14 +141,16 @@ const zh_CN: GeoStylerLocale = {
     partiallySupported: '仅被使用的解析器部分支持'
   },
   WellKnownNameEditor: {
-    radiusLabel: '半径',
-    fillOpacityLabel: '填充-不透明度',
     fillColorLabel: '填充-颜色',
+    fillOpacityLabel: '填充-不透明度',
+    offsetXLabel: 'X 偏移',
+    offsetYLabel: 'Y 偏移',
     opacityLabel: '不透明度',
+    radiusLabel: '半径',
+    rotateLabel: '旋转',
     strokeColorLabel: '描边-颜色',
-    strokeWidthLabel: '描边-宽度',
     strokeOpacityLabel: '描边-不透明度',
-    rotateLabel: '旋转'
+    strokeWidthLabel: '描边-宽度',
   },
   FillEditor: {
     fillOpacityLabel: '填充-不透明度',

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -176,6 +176,7 @@ const zh_CN: GeoStylerLocale = {
     widthLabel: '宽度',
     opacityLabel: '不透明度',
     dashLabel: '虚线样式',
+    perpendicularOffsetLabel: '垂直偏移',
     dashOffsetLabel: '偏移',
     capLabel: '端点',
     joinLabel: '角点',


### PR DESCRIPTION
## Description

This adds the missing input fields for offset:

- `LineSymbolizer.perpendicularOffset` to `LineEditor`
- `IconSymbolizer.offset` to `IconEditor`
- `MarkSymbolizer.offset` to `WellKnownNameEditor`

## Related issues or pull requests

Fixes #1495 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
