### PR TITLE
Provide GeoStyler Version in Docs

### DIFF
--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -29,9 +29,11 @@
 const path = require('path');
 const webpackConfig = require('./webpack.dev.config');
 const rdt = require('react-docgen-typescript');
+const packageJson = require('./package.json');
 
 module.exports = {
   title: 'GeoStyler',
+  version: packageJson.version,
   styleguideDir: './build/styleguide',
   webpackConfig: {
     ...webpackConfig,


### PR DESCRIPTION
## Description

This provides the version of GeoStyler in the docs. Version will be derived from `package.json`.

Please note that this will display the latest version for the `master` docs.

![image](https://user-images.githubusercontent.com/12186477/208678733-6ad0e191-4ccd-4bcb-8c28-24b51b1ce480.png)

## Related issues or pull requests

solves https://github.com/geostyler/geostyler/issues/1759

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
