### PR TITLE
Expand FilterTree by default and add posibility to pass TreeProps

### DIFF
--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -32,7 +32,8 @@ import {
   Tree,
   Dropdown,
   Menu,
-  Button
+  Button,
+  TreeProps
 } from 'antd';
 
 import {
@@ -97,15 +98,14 @@ export interface FilterTreeProps extends Partial<FilterTreeDefaultProps> {
  *   - A combo to select the operator
  *   - An input field for the value
  */
-export const FilterTree: React.FC<FilterTreeProps> = ({
+export const FilterTree: React.FC<FilterTreeProps & Partial<TreeProps>> = ({
   filter: rootFilter = ['==', '', null],
   internalDataDef,
   locale = en_US.FilterTree,
   onFilterChange,
-  filterUiProps
+  filterUiProps,
+  ...passThroughProps
 }) => {
-
-  const [expandedKeys, setExpandedKeys] = React.useState<string[]>();
 
   /**
    * Changehandler for ComparsionFilters.
@@ -368,20 +368,12 @@ export const FilterTree: React.FC<FilterTreeProps> = ({
     onFilterChange(newFilter);
   };
 
-  /**
-   * Expand handler which is passed to the Tree.
-   * Sets the expandedKeys to the state and so back to the tree.
-   */
-  const onExpand = (newExpandedKeys: (number|string)[]) => {
-    setExpandedKeys(newExpandedKeys as string[]);
-  };
-
   return (
     <Tree
       className="gs-filter-tree"
       draggable={true}
-      expandedKeys={expandedKeys}
-      onExpand={onExpand}
+      defaultExpandAll={true}
+      {...passThroughProps}
       onDrop={onDrop}
     >
       {getNodeByFilter(rootFilter)}


### PR DESCRIPTION
## Description

This expands all nodes in the FilterTree by default. It also removes the handling of expanded nodes as it is already done by antd.

This PR also adds the possibilty to pass props to the underlying antd Tree.

## Related issues or pull requests

Fixes #1979 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [ ] Bugfix
- [x] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
