### PR TITLE
Remove internal state handling for CardStyle

### DIFF
--- a/src/Component/RuleOverview/RuleOverview.tsx
+++ b/src/Component/RuleOverview/RuleOverview.tsx
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import {
   Rule as GsRule,
@@ -77,37 +77,31 @@ export const RuleOverview: React.FC<RuleOverviewProps> = ({
   locale = en_US.RuleOverview,
 }) => {
 
-  const [stateRule, setStateRule] = useState<GsRule>(rule);
-
   const onNameChange = (name: string) => {
-    const newRule: GsRule = {...stateRule, name};
-    setStateRule(newRule);
+    const newRule: GsRule = {...rule, name};
     onRuleChange(newRule);
   };
 
   const onMinScaleChange = (minScale: number) => {
-    let newRule: GsRule = {...stateRule};
+    let newRule: GsRule = {...rule};
     if (!newRule.scaleDenominator) {
       newRule.scaleDenominator = {};
     }
     newRule.scaleDenominator.min = minScale;
-    setStateRule(newRule);
     onRuleChange(newRule);
   };
 
   const onMaxScaleChange = (maxScale: number) => {
-    let newRule: GsRule = {...stateRule};
+    let newRule: GsRule = {...rule};
     if (!newRule.scaleDenominator) {
       newRule.scaleDenominator = {};
     }
     newRule.scaleDenominator.max = maxScale;
-    setStateRule(newRule);
     onRuleChange(newRule);
   };
 
   const onSymbolizersChange = (symbolizers: GsSymbolizer[]) => {
-    let newRule: GsRule = {...stateRule, symbolizers};
-    setStateRule(newRule);
+    let newRule: GsRule = {...rule, symbolizers};
     onRuleChange(newRule);
   };
 

--- a/src/Component/StyleOverview/StyleOverview.tsx
+++ b/src/Component/StyleOverview/StyleOverview.tsx
@@ -27,7 +27,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import {
   Rule as GsRule,
@@ -78,19 +78,15 @@ export const StyleOverview: React.FC<StyleOverviewProps> = ({
   rulesProps
 }) => {
 
-  const [stateStyle, setStateStyle] = useState<GsStyle>(style);
-
   const onNameChange = (name: string) => {
-    let newStyle = _cloneDeep(stateStyle);
+    let newStyle = _cloneDeep(style);
     newStyle.name = name;
-    setStateStyle(newStyle);
     onStyleChange(newStyle);
   };
 
   const onRulesChange = (rules: GsRule[]) => {
-    let newStyle = _cloneDeep(stateStyle);
+    let newStyle = _cloneDeep(style);
     newStyle.rules = rules;
-    setStateStyle(newStyle);
     onStyleChange(newStyle);
   };
 
@@ -111,11 +107,11 @@ export const StyleOverview: React.FC<StyleOverviewProps> = ({
       <h2>{locale.styleTitle}</h2>
       <Divider />
       <StyleFieldContainer
-        name={stateStyle.name}
+        name={style.name}
         onNameChange={onNameChange}
       />
       <Rules
-        rules={stateStyle.rules}
+        rules={style.rules}
         data={data}
         onRulesChange={onRulesChange}
         onEditRuleClick={onEditRule}


### PR DESCRIPTION
## Description

This removes the internal state handling for the `StyleOverview` and `RuleOverview` components. This should fix the issue, that these components don't get rerendered when the style is change outside of the `CardStyle` component. E.g. When editing in the CodeEditor in the demo.

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
