### PR TITLE
Make RuleGeneratorUtil less prone to errors

### DIFF
--- a/src/Component/CardStyle/CardStyle.tsx
+++ b/src/Component/CardStyle/CardStyle.tsx
@@ -42,7 +42,7 @@ import {
 } from 'geostyler-style';
 
 import {
-  Data
+  Data, VectorData
 } from 'geostyler-data';
 
 import { localize } from '../LocaleWrapper/LocaleWrapper';
@@ -395,7 +395,7 @@ export const CardStyle: React.FC<CardStyleProps> = ({
       {
         currentView.view === CLASSIFICATIONVIEW && (
           <RuleGenerator
-            internalDataDef={data}
+            internalDataDef={data as VectorData}
             onRulesChange={onRulesChange}
             {...ruleGeneratorProps}
           />

--- a/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.less
+++ b/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.less
@@ -1,0 +1,3 @@
+.classification-combo {
+  min-width: 10em;
+}

--- a/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.tsx
+++ b/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.tsx
@@ -26,7 +26,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-import * as React from 'react';
+import React from 'react';
 
 import { Select } from 'antd';
 
@@ -35,6 +35,8 @@ import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import _isEqual from 'lodash/isEqual';
 import { GeoStylerLocale } from '../../../locale/locale';
 import en_US from '../../../locale/en_US';
+
+import './ClassificationCombo.less';
 
 export type ClassificationMethod = 'equalInterval' | 'quantile' | 'logarithmic' | 'kmeans';
 
@@ -80,7 +82,7 @@ export const ClassificationCombo: React.FC<ClassificationComboProps> = ({
 
   return (
     <Select
-      className="color-space-select"
+      className="classification-combo"
       optionFilterProp="children"
       value={classification}
       onChange={onChange}

--- a/src/Component/RuleGenerator/RuleGenerator.example.md
+++ b/src/Component/RuleGenerator/RuleGenerator.example.md
@@ -31,17 +31,121 @@
 This demonstrates the use of `RuleGenerator`.
 
 ```jsx
-import * as React from 'react';
-import { RuleGenerator } from 'geostyler';
+import React, { useEffect, useState } from 'react';
+import { RuleGenerator, RuleTable } from 'geostyler';
+import Parser from 'geostyler-geojson-parser';
 
-class RuleGeneratorExample extends React.Component {
+const geojson = {
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          90.0,
+          10.0
+        ]
+      },
+      "properties": {
+        "name": "point_0",
+        "distance [m]": 10
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          90.01,
+          10.0
+        ]
+      },
+      "properties": {
+        "name": "point_1",
+        "distance [m]": 11
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          90.02,
+          10.0
+        ]
+      },
+      "properties": {
+        "name": "point_2",
+        "distance [m]": 12
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          90.03,
+          10.0
+        ]
+      },
+      "properties": {
+        "name": "point_3",
+        "distance [m]": 13
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          90.04,
+          10.0
+        ]
+      },
+      "properties": {
+        "name": "point_4",
+        "distance [m]": 14
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          90.05,
+          10.0
+        ]
+      },
+      "properties": {
+        "name": "point_5",
+        "distance [m]": 15
+      }
+    }
+  ]
+};
 
-  render() {
+const RuleGeneratorExample = ({}) => {
 
-    return (
-      <RuleGenerator />
-    );
-  }
+  const [data, setData] = useState();
+  const [rules, setRules] = useState();
+
+  const readData = async () => {
+    const parser = new Parser();
+    const newData = await parser.readData(geojson);
+    setData(newData);
+  };
+
+  useEffect(() => {
+    readData();
+  }, [Parser])
+
+  return (
+    <div>
+      <RuleGenerator internalDataDef={data} onRulesChange={setRules} />
+      <RuleTable rules={rules} />
+    </div>
+  );
 }
 
 <RuleGeneratorExample />

--- a/src/Component/RuleGenerator/RuleGenerator.tsx
+++ b/src/Component/RuleGenerator/RuleGenerator.tsx
@@ -28,7 +28,7 @@
 
 import React, { useState } from 'react';
 import { Rule, SymbolizerKind, WellKnownName } from 'geostyler-style';
-import { Data } from 'geostyler-data';
+import { VectorData } from 'geostyler-data';
 import { Radio, Form, Button, InputNumber, Tooltip } from 'antd';
 import en_US from '../../locale/en_US';
 import AttributeCombo from '../Filter/AttributeCombo/AttributeCombo';
@@ -63,7 +63,7 @@ interface RuleGeneratorDefaultProps {
 
 // non default props
 export interface RuleGeneratorProps extends Partial<RuleGeneratorDefaultProps> {
-  internalDataDef: Data;
+  internalDataDef: VectorData;
   onRulesChange?: (rules: Rule[]) => void;
 }
 const COMPONENTNAME = 'RuleGenerator';

--- a/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
+++ b/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
@@ -36,7 +36,7 @@ import {
   Rule
 } from 'geostyler-style';
 
-import { Data } from 'geostyler-data';
+import { VectorData } from 'geostyler-data';
 
 import './RuleGeneratorWindow.less';
 import { Button } from 'antd';
@@ -58,7 +58,7 @@ export interface RuleGeneratorWindowDefaultProps {
 
 // non default props
 export interface RuleGeneratorWindowProps extends Partial<RuleGeneratorWindowDefaultProps> {
-  internalDataDef: Data;
+  internalDataDef: VectorData;
   x?: number;
   y?: number;
   onClose?: () => void;

--- a/src/Component/Rules/Rules.tsx
+++ b/src/Component/Rules/Rules.tsx
@@ -255,6 +255,7 @@ export const Rules: React.FC<RulesProps> = ({
     </Button>
   ];
 
+  // TODO: Classification button should only be available if data is VectorData
   if (enableClassification) {
     defaultActions = [
       ...defaultActions,

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -49,7 +49,7 @@ import {
 } from 'geostyler-style';
 
 import {
-  Data
+  Data, VectorData
 } from 'geostyler-data';
 
 import Rule, { RuleProps } from '../Rule/Rule';
@@ -482,6 +482,7 @@ export const Style: React.FC<StyleProps> = ({
           />
         </Form.Item>
         {
+          // TODO: Rule GeneratorWindow should only be available if data is VectorData
           enableClassification ?
             <Button
               className="gs-style-rulegenerator"
@@ -496,7 +497,7 @@ export const Style: React.FC<StyleProps> = ({
         (!ruleGeneratorWindowVisible) ? null :
           <RuleGeneratorWindow
             y={0}
-            internalDataDef={data}
+            internalDataDef={data as VectorData}
             onClose={onRuleGeneratorWindowClose}
             onRulesChange={onRulesChange}
             colorRamps={colorRamps}

--- a/src/Util/RuleGeneratorUtil.ts
+++ b/src/Util/RuleGeneratorUtil.ts
@@ -28,7 +28,7 @@
 
 import * as CSS from 'csstype';
 const Color = require('color');
-import { Data } from 'geostyler-data';
+import { VectorData } from 'geostyler-data';
 import {
   LevelOfMeasurement
 } from 'src/Component/RuleGenerator/RuleGenerator';
@@ -47,11 +47,10 @@ import {
 } from 'chroma-js';
 import { ClassificationMethod } from 'src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo';
 
-import _get from 'lodash/get';
-import { GeoJsonGeometryTypes } from 'geojson';
+import { Feature, GeoJsonGeometryTypes } from 'geojson';
 
 export interface RuleGenerationParams {
-  data: Data;
+  data: VectorData;
   levelOfMeasurement: LevelOfMeasurement;
   numberOfRules: number;
   attributeName: string;
@@ -67,12 +66,12 @@ export interface RuleGenerationParams {
  */
 class RuleGeneratorUtil {
 
-  static getDistinctValues(data: Data, attributeName: string): any[] {
+  static getDistinctValues(data: VectorData, attributeName: string): any[] {
     const distinctValues: any[] = [];
-    const features: any[] = _get(data, 'exampleFeatures.features');
+    const features: Feature[] = data?.exampleFeatures?.features;
     if (features) {
-      features.forEach((feature: any) => {
-        const value = _get(feature, `properties[${attributeName}]`);
+      features.forEach((feature: Feature) => {
+        const value = feature?.properties?.[attributeName];
         if (value && !distinctValues.includes(value)) {
           distinctValues.push(value);
         }
@@ -82,9 +81,9 @@ class RuleGeneratorUtil {
     return distinctValues;
   }
 
-  static guessSymbolizerFromData(data: Data): SymbolizerKind {
+  static guessSymbolizerFromData(data: VectorData): SymbolizerKind {
     const firstFeatureGeometryType: GeoJsonGeometryTypes
-      = _get(data, 'exampleFeatures.features[0].geometry.type');
+      = data?.exampleFeatures?.features?.[0]?.geometry?.type;
 
     switch (firstFeatureGeometryType) {
       case 'Point':
@@ -144,10 +143,10 @@ class RuleGeneratorUtil {
       if (!classificationMethod) {
         // TODO Add feedback
       } else {
-        const features: any[] = _get(data, 'exampleFeatures.features');
-        const values = features ? features.map((feature: any) => {
-          return _get(feature, `properties[${attributeName}]`);
-        }) : [];
+        const features: any[] = data?.exampleFeatures?.features;
+        const values = features
+          ? features.map((feature: Feature) => feature?.properties?.[attributeName])
+          : [];
         let ranges: number[][] = [];
 
         switch (classificationMethod) {


### PR DESCRIPTION
## Description

This replaces the use of lodash `get` with the corresponding TypeScript syntax in the `RuleGeneratorUtil`.
It also fixes the typing of the `internalDataDef` for the `RuleGenerator`.
It also extends the example for the `RuleGenerator` and adds a minor styling improvement to the `ClassificationCombo`.

## Related issues or pull requests

This fixe #2012 

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
