### PR TITLE
Reduce pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,8 +10,8 @@ Comments in this file can be left untouched an will not appear in the Pull Reque
 
 <!--
 - Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
-- Should i link an issue or a pull request? -> #
-- Should i mention some people? -> @
+- Should I link an issue or a pull request? -> #
+- Should I mention some people? -> @
 -->
 
 ## Do you introduce a breaking change?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,42 +1,18 @@
-# Thank you 💞
-
+<!--
 Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
+Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
+This makes it easy for you to give back and for us to accept your changes.
 
-## Some guidelines for the proposed change
-
-Please review the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md) and the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md) of this repository. This makes it easy for you to give back and for us to accept your changes.
-
-Please use the template below the line for the pull request description, and make sure to tick off the boxes in the checklists. In your final pull request everything above the next horizontal line can be removed to not distract reviewers or other readers.
-
-Again: thank you for your contribution.
-
-<!-- You can remove everything above this line, and also the line itself -->
-
-------------
-
+Comments in this file can be left untouched an will not appear in the Pull Request.
+-->
 ## Description
 
-Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible. Make sure to mention people that you think should know about the PR.
 
-## Related issues or pull requests
-
-Please list issues or pull requests that the changes you propose are related to. It does not matter if they are still open and/or unmerged, any link is appreciated.
-
-## Pull request type
-
-Please check the type of change your PR introduces:
-
-<!-- put an x between the square brackets to check an item, like so: [x] -->
-
-- [ ] Bugfix
-- [ ] Feature
-- [ ] Dependency updates
-- [ ] Code style update (formatting, renaming)
-- [ ] Refactoring (no functional changes, no api changes)
-- [ ] Build related changes
-- [ ] Documentation content changes
-- [ ] Other (please describe)
-- [ ] I am unsure (we'll look into it together)
+<!--
+- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
+- Should i link an issue or a pull request? -> #
+- Should i mention some people? -> @
+-->
 
 ## Do you introduce a breaking change?
 
@@ -44,10 +20,3 @@ Please check the type of change your PR introduces:
 - [ ] No
 - [ ] I am unsure (no worries, we'll find out)
 
-## Checklist
-
-- [ ] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/main/)
-- [ ] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/main/CONTRIBUTING.md)
-- [ ] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/main/CODE_OF_CONDUCT.md)
-- [ ] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
-- [ ] I'm lost; why do I have to check so many boxes? Please help!


### PR DESCRIPTION
## Description

This reduces the pull request template to what is needed. This hopefully reduces the barrier to open a PR and speeds up the process for experienced Github users.

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)
