### PR TITLE
feat: use vertical form layout

### DIFF
--- a/src/Component/BulkEditor/BulkEditor.tsx
+++ b/src/Component/BulkEditor/BulkEditor.tsx
@@ -95,16 +95,10 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
     onStylePropChange('image', newImage);
   };
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   return (
     <div className='gs-bulkeditor'>
       <Form.Item
         label={locale.colorLabel}
-        {...formItemLayout}
       >
         <ColorField
           color={color}
@@ -113,7 +107,6 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.radiusLabel}
-        {...formItemLayout}
       >
         <RadiusField
           radius={radius}
@@ -122,7 +115,6 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.opacityLabel}
-        {...formItemLayout}
       >
         <OpacityField
           opacity={opacity}
@@ -131,7 +123,6 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.symbolLabel}
-        {...formItemLayout}
       >
         <Input.Group compact>
           <Form.Item
@@ -144,7 +135,6 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
             />
           </Form.Item>
           <Form.Item
-            {...formItemLayout}
             noStyle
           >
             {

--- a/src/Component/RuleFieldContainer/RuleFieldContainer.less
+++ b/src/Component/RuleFieldContainer/RuleFieldContainer.less
@@ -1,3 +1,30 @@
+/* Released under the BSD 2-Clause License
+ *
+ * Copyright © 2021-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
 .gs-rule-field-container {
   display: flex;
 
@@ -22,12 +49,4 @@
       cursor: default;
     }
   }
-
-  .ant-col.ant-col-4.ant-form-item-label {
-    white-space: normal;
-  }
-
-  .ant-form-item-control-input {
-    margin-left: 10px;
-}
 }

--- a/src/Component/RuleFieldContainer/RuleFieldContainer.tsx
+++ b/src/Component/RuleFieldContainer/RuleFieldContainer.tsx
@@ -82,34 +82,30 @@ export const RuleFieldContainer: React.FC<RuleFieldContainerProps> = ({
   data
 }) => {
 
-  const formItemLayout = {
-    labelCol: { span: 4 },
-    wrapperCol: { span: 20 }
-  };
-
   return (
     <FieldContainer className="gs-rule-field-container">
       <div className='gs-rule-field-container-header'>
-        <Form.Item
-          label={locale.nameFieldLabel}
-          {...formItemLayout}
+        <Form
+          layout='vertical'
         >
-          <NameField
-            value={name}
-            onChange={onNameChange}
-            placeholder={locale.nameFieldPlaceholder}
+          <Form.Item
+            label={locale.nameFieldLabel}
+          >
+            <NameField
+              value={name}
+              onChange={onNameChange}
+              placeholder={locale.nameFieldPlaceholder}
+            />
+          </Form.Item>
+          <MinScaleDenominator
+            value={minScale}
+            onChange={onMinScaleChange}
           />
-        </Form.Item>
-        <MinScaleDenominator
-          value={minScale}
-          onChange={onMinScaleChange}
-          {...formItemLayout}
-        />
-        <MaxScaleDenominator
-          value={maxScale}
-          onChange={onMaxScaleChange}
-          {...formItemLayout}
-        />
+          <MaxScaleDenominator
+            value={maxScale}
+            onChange={onMaxScaleChange}
+          />
+        </Form>
       </div>
       <Divider type="vertical" />
       <Renderer

--- a/src/Component/RuleGenerator/RuleGenerator.less
+++ b/src/Component/RuleGenerator/RuleGenerator.less
@@ -29,17 +29,8 @@
 .gs-rule-generator {
   padding: 20px;
 
-  .ant-form-item {
-    display: flex;
-    align-items: center;
-
-    .ant-form-item-control-wrapper {
-      flex: 1;
-    }
-
-    .all-distinct-values-button {
-      margin: 1px 0 0 5px;
-    }
+  .ant-input-number {
+    width: 100%;
   }
 
   .gs-rule-generator-submit-button {

--- a/src/Component/RuleGenerator/RuleGenerator.tsx
+++ b/src/Component/RuleGenerator/RuleGenerator.tsx
@@ -169,7 +169,7 @@ export const RuleGenerator: React.FC<RuleGeneratorProps> = ({
 
   return (
     <div className="gs-rule-generator" >
-      <Form layout="horizontal">
+      <Form layout="vertical">
         <AttributeCombo
           value={attributeName}
           internalDataDef={internalDataDef}

--- a/src/Component/ScaleDenominator/ScaleDenominator.tsx
+++ b/src/Component/ScaleDenominator/ScaleDenominator.tsx
@@ -101,7 +101,6 @@ export const ScaleDenominator: React.FC<ScaleDenominatorProps> = ({
           <MinScaleDenominator
             value={scaleDenominator?.min}
             onChange={onMinScaleDenomChange}
-            label={locale.minScaleDenominatorLabelText}
             placeholder={locale.minScaleDenominatorPlaceholderText}
           />
         </Col>
@@ -109,7 +108,6 @@ export const ScaleDenominator: React.FC<ScaleDenominatorProps> = ({
           <MaxScaleDenominator
             value={scaleDenominator?.max}
             onChange={onMaxScaleDenomChange}
-            label={locale.maxScaleDenominatorLabelText}
             placeholder={locale.maxScaleDenominatorPlaceholderText}
           />
         </Col>

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -463,17 +463,11 @@ export const Style: React.FC<StyleProps> = ({
 
   let rules: GsRule[] =  style?.rules || [];
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   return (
     <div className="gs-style" >
       <div className="gs-style-name-classification-row">
         <Form.Item
           label={locale.nameFieldLabel}
-          {...formItemLayout}
         >
           <NameField
             value={style.name}

--- a/src/Component/StyleFieldContainer/StyleFieldContainer.tsx
+++ b/src/Component/StyleFieldContainer/StyleFieldContainer.tsx
@@ -61,33 +61,30 @@ export const StyleFieldContainer: React.FC<StyleFieldContainerProps> = ({
   onTitleChange,
 }) => {
 
-  const formItemLayout = {
-    labelCol: { span: 4 },
-    wrapperCol: { span: 20 }
-  };
-
   return (
     <FieldContainer className="gs-style-field-container">
-      <Form.Item
-        label={locale.nameFieldLabel}
-        {...formItemLayout}
+      <Form
+        layout='vertical'
       >
-        <NameField
-          value={name}
-          onChange={onNameChange}
-          placeholder={locale.nameFieldPlaceholder}
-        />
-      </Form.Item>
-      <Form.Item
-        label={locale.titleFieldLabel}
-        {...formItemLayout}
-      >
-        <NameField
-          value={title}
-          onChange={onTitleChange}
-          placeholder={locale.titleFieldPlaceholder}
-        />
-      </Form.Item>
+        <Form.Item
+          label={locale.nameFieldLabel}
+        >
+          <NameField
+            value={name}
+            onChange={onNameChange}
+            placeholder={locale.nameFieldPlaceholder}
+          />
+        </Form.Item>
+        <Form.Item
+          label={locale.titleFieldLabel}
+        >
+          <NameField
+            value={title}
+            onChange={onTitleChange}
+            placeholder={locale.titleFieldPlaceholder}
+          />
+        </Form.Item>
+      </Form>
     </FieldContainer>
   );
 

--- a/src/Component/StyleOverview/StyleOverview.less
+++ b/src/Component/StyleOverview/StyleOverview.less
@@ -1,0 +1,27 @@
+/* Released under the BSD 2-Clause License
+ *
+ * Copyright © 2021-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */

--- a/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
+++ b/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
@@ -265,11 +265,6 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = ({
     render: opacityRenderer
   }];
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   // make sure colorMapEntries does exist
   let colorMapEntries: ColorMapEntry[] = colorMap?.colorMapEntries;
   if (!colorMapEntries) {
@@ -281,13 +276,11 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = ({
     <div className="gs-colormap-symbolizer-editor" >
       <div className="gs-colormap-header-row">
         <Form.Item
-          {...formItemLayout}
         >
           <span>{locale.titleLabel}</span>
         </Form.Item>
         <Form.Item
           label={locale.typeLabel}
-          {...formItemLayout}
         >
           <ColorMapTypeField
             colorMapType={colorMap?.type}
@@ -296,7 +289,6 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = ({
         </Form.Item>
         <Form.Item
           label={locale.nrOfClassesLabel}
-          {...formItemLayout}
         >
           <InputNumber
             className="number-of-classes-field"
@@ -308,7 +300,6 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = ({
         </Form.Item>
         <Form.Item
           label={locale.colorRampLabel}
-          {...formItemLayout}
         >
           <ColorRampCombo
             onChange={onColorRampChange}
@@ -318,7 +309,6 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = ({
         </Form.Item>
         <Form.Item
           label={locale.extendedLabel}
-          {...formItemLayout}
         >
           <ExtendedField
             extended={colorMap?.extended as boolean}

--- a/src/Component/Symbolizer/Editor/Editor.less
+++ b/src/Component/Symbolizer/Editor/Editor.less
@@ -26,10 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-.gs-symbolizer-editor .editor-field {
-  width: 200px;
-}
-
-.gs-symbolizer-editor .ant-form-item {
-  margin: 0;
+.gs-symbolizer-editor {
+  .ant-input-number {
+    width: 100%;
+  }
 }

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -209,31 +209,29 @@ export const Editor: React.FC<EditorProps> = ({
     onSymbolizerChange(newSymbolizer);
   };
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   return (
     <CompositionContext.Consumer>
       {(composition: Compositions) => (
         <div className="gs-symbolizer-editor" >
-          <Form.Item
-            label={locale.kindFieldLabel}
-            {...formItemLayout}
+          <Form
+            layout='vertical'
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'Editor.kindField',
-                onChange: onKindFieldChange,
-                propName: 'kind',
-                propValue: symbolizer.kind,
-                defaultElement: <KindField />
-              })
-            }
-          </Form.Item>
-          {getUiForSymbolizer(composition)}
+            <Form.Item
+              label={locale.kindFieldLabel}
+            >
+              {
+                CompositionUtil.handleComposition({
+                  composition,
+                  path: 'Editor.kindField',
+                  onChange: onKindFieldChange,
+                  propName: 'kind',
+                  propValue: symbolizer.kind,
+                  defaultElement: <KindField />
+                })
+              }
+            </Form.Item>
+            {getUiForSymbolizer(composition)}
+          </Form>
         </div>
       )}
     </CompositionContext.Consumer>

--- a/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
+++ b/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
@@ -113,16 +113,10 @@ export const ChannelField: React.FC<ChannelFieldProps> = ({
   const contrastEnhancementType = _get(channel, 'contrastEnhancement.enhancementType');
   const gamma = _get(channel, 'contrastEnhancement.gammaValue');
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   return (
     <div>
       <Form.Item
         label={locale.sourceChannelNameLabel}
-        {...formItemLayout}
       >
         <SourceChannelNameField
           onChange={onSourceChannelNameChange}
@@ -132,7 +126,6 @@ export const ChannelField: React.FC<ChannelFieldProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.contrastEnhancementTypeLabel}
-        {...formItemLayout}
       >
         <ContrastEnhancementField
           contrastEnhancement={contrastEnhancementType}
@@ -142,7 +135,6 @@ export const ChannelField: React.FC<ChannelFieldProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.gammaValueLabel}
-        {...formItemLayout}
       >
         <GammaField
           gamma={gamma as any}

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.less
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.less
@@ -36,8 +36,7 @@
 
   button.color-clear {
     border-radius: 0 2px 2px 0;
-    width: 16px;
-    background-color: #ebebeb;
+    width: 32px;
   }
 }
 
@@ -45,8 +44,4 @@
   position: absolute;
   z-index: 200;
   top: 3em;
-}
-
-.color-field {
-  width: 90px;
 }

--- a/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.tsx
+++ b/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.tsx
@@ -84,16 +84,10 @@ export const ColorMapEntryField: React.FC<ColorMapEntryFieldProps> = ({
     updateColorMapEntry('opacity', opacity as number);
   };
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   return (
     <div>
       <Form.Item
         label={locale.colorLabel}
-        {...formItemLayout}
       >
         <ColorField
           color={_get(colorMapEntry, 'color') as string}
@@ -102,7 +96,6 @@ export const ColorMapEntryField: React.FC<ColorMapEntryFieldProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.quantityLabel}
-        {...formItemLayout}
       >
         <OffsetField
           offset={_get(colorMapEntry, 'quantity') as number}
@@ -111,7 +104,6 @@ export const ColorMapEntryField: React.FC<ColorMapEntryFieldProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.labelLabel}
-        {...formItemLayout}
       >
         <Input
           className="editor-field colormapentry-label-field"
@@ -125,7 +117,6 @@ export const ColorMapEntryField: React.FC<ColorMapEntryFieldProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.opacityLabel}
-        {...formItemLayout}
       >
         <OpacityField
           opacity={_get(colorMapEntry, 'opacity') as number}

--- a/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.tsx
+++ b/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.tsx
@@ -81,16 +81,10 @@ export const GrayChannelField: React.FC<GrayChannelFieldProps> = ({
     }
   };
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   return (
     <div>
       <Form.Item
         label={locale.grayLabel}
-        {...formItemLayout}
       >
         <SourceChannelNameField
           sourceChannelNames={sourceChannelNames}

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.less
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.less
@@ -25,17 +25,3 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-
-.gs-image-field {
-  .gs-image-field-gallery-icon {
-    cursor: pointer;
-  }
-
-  .ant-input-group-wrapper {
-    width: auto;
-  }
-
-  .gs-image-field-gallery-addon {
-    width: calc(200px - 37px) !important;
-  }
-}

--- a/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.tsx
+++ b/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.tsx
@@ -120,16 +120,10 @@ export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
     }
   };
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   return (
     <div>
       <Form.Item
         label={locale.redLabel}
-        {...formItemLayout}
       >
         <SourceChannelNameField
           sourceChannelNames={sourceChannelNames}
@@ -139,7 +133,6 @@ export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.greenLabel}
-        {...formItemLayout}
       >
         <SourceChannelNameField
           sourceChannelNames={sourceChannelNames}
@@ -149,7 +142,6 @@ export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.blueLabel}
-        {...formItemLayout}
       >
         <SourceChannelNameField
           sourceChannelNames={sourceChannelNames}

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -153,11 +153,6 @@ export const FillEditor: React.FC<FillEditorProps> = ({
     }
   };
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   const {
     color,
     fillOpacity,
@@ -187,7 +182,6 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               <Form.Item
                 label={locale.fillColorLabel}
                 {...getSupportProps('color')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -204,7 +198,6 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               <Form.Item
                 label={locale.fillOpacityLabel}
                 {...getSupportProps('fillOpacity')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -221,7 +214,6 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               <Form.Item
                 label={locale.opacityLabel}
                 {...getSupportProps('opacity')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -238,7 +230,6 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               <Form.Item
                 label={locale.outlineOpacityLabel}
                 {...getSupportProps('outlineOpacity')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -255,7 +246,6 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               <Form.Item
                 label={locale.outlineColorLabel}
                 {...getSupportProps('outlineColor')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -272,7 +262,6 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               <Form.Item
                 label={locale.outlineWidthLabel}
                 {...getSupportProps('outlineWidth')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -289,7 +278,6 @@ export const FillEditor: React.FC<FillEditorProps> = ({
               <Form.Item
                 label={locale.outlineDasharrayLabel}
                 {...getSupportProps('outlineDasharray')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -107,16 +107,10 @@ export const GraphicEditor: React.FC<GraphicEditorProps> = ({
     }
   };
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   return (
     <div>
       <Form.Item
         label={graphicTypeFieldLabel}
-        {...formItemLayout}
       >
         <GraphicTypeField
           graphicType={graphicType}

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -145,11 +145,6 @@ export const IconEditor: React.FC<IconEditorProps> = ({
     }
   };
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   const {
     opacity,
     image,
@@ -176,7 +171,6 @@ export const IconEditor: React.FC<IconEditorProps> = ({
           <Form.Item
             label={locale.imageLabel}
             {...getSupportProps('image')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -202,7 +196,6 @@ export const IconEditor: React.FC<IconEditorProps> = ({
           <Form.Item
             label={locale.sizeLabel}
             {...getSupportProps('size')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -219,7 +212,6 @@ export const IconEditor: React.FC<IconEditorProps> = ({
           <Form.Item
             label={locale.offsetXLabel}
             {...getSupportProps('offset')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -236,7 +228,6 @@ export const IconEditor: React.FC<IconEditorProps> = ({
           <Form.Item
             label={locale.offsetYLabel}
             {...getSupportProps('offset')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -253,7 +244,6 @@ export const IconEditor: React.FC<IconEditorProps> = ({
           <Form.Item
             label={locale.rotateLabel}
             {...getSupportProps('rotate')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -270,7 +260,6 @@ export const IconEditor: React.FC<IconEditorProps> = ({
           <Form.Item
             label={locale.opacityLabel}
             {...getSupportProps('opacity')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -174,11 +174,6 @@ export const LineEditor: React.FC<LineEditorProps> = ({
     }
   };
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   const {
     color,
     width,
@@ -210,7 +205,6 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               <Form.Item
                 label={locale.colorLabel}
                 {...getSupportProps('color')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -227,7 +221,6 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               <Form.Item
                 label={locale.widthLabel}
                 {...getSupportProps('width')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -244,7 +237,6 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               <Form.Item
                 label={locale.perpendicularOffsetLabel}
                 {...getSupportProps('perpendicularOffset')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -261,7 +253,6 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               <Form.Item
                 label={locale.opacityLabel}
                 {...getSupportProps('opacity')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -278,7 +269,6 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               <Form.Item
                 label={locale.dashLabel}
                 {...getSupportProps('dasharray')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -294,7 +284,6 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               <Form.Item
                 label={locale.dashOffsetLabel}
                 {...getSupportProps('dashOffset')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -316,7 +305,6 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               <Form.Item
                 label={locale.capLabel}
                 {...getSupportProps('cap')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -333,7 +321,6 @@ export const LineEditor: React.FC<LineEditorProps> = ({
               <Form.Item
                 label={locale.joinLabel}
                 {...getSupportProps('join')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -85,11 +85,6 @@ export const MarkEditor: React.FC<MarkEditorProps> = ({
     }
   };
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   const getSupportProps = (propName: keyof MarkSymbolizer) => {
     return UnsupportedPropertiesUtil.getSupportProps<MarkSymbolizer>({
       propName,
@@ -106,7 +101,6 @@ export const MarkEditor: React.FC<MarkEditorProps> = ({
           <Form.Item
             label={locale.wellKnownNameFieldLabel}
             {...getSupportProps('wellKnownName')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.less
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.less
@@ -35,5 +35,7 @@
 
   .gs-symbolizer-multi-editor-tab {
     padding: 10px;
+    max-height: 70vh;
+    overflow-y: auto;
   }
 }

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.less
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.less
@@ -28,10 +28,6 @@
 
 .gs-text-symbolizer-prop-editor {
 
-  .ant-select-selection {
-    width: 90px;
-  }
-
   .ant-row.ant-form-item.ant-form-item-no-colon {
     margin-bottom: 0;
   }

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
@@ -192,16 +192,10 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
     offsetY = offset[1];
   }
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   return (
     <div className="gs-text-symbolizer-prop-editor" >
       <Form.Item
         label={locale.propFieldLabel}
-        {...formItemLayout}
       >
         <AttributeCombo
           value={symbolizer.label ? formatLabel(symbolizer.label as string) : undefined}
@@ -211,7 +205,6 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.colorLabel}
-        {...formItemLayout}
       >
         <ColorField
           color={color as string}
@@ -220,7 +213,6 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.fontLabel}
-        {...formItemLayout}
       >
         <FontPicker
           font={font as string[]}
@@ -229,7 +221,6 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.opacityLabel}
-        {...formItemLayout}
       >
         <OpacityField
           opacity={opacity as number}
@@ -238,7 +229,6 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.sizeLabel}
-        {...formItemLayout}
       >
         <WidthField
           width={size as number}
@@ -247,7 +237,6 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.offsetXLabel}
-        {...formItemLayout}
       >
         <OffsetField
           offset={offsetX as number}
@@ -256,7 +245,6 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.offsetYLabel}
-        {...formItemLayout}
       >
         <OffsetField
           offset={offsetY as number}
@@ -265,7 +253,6 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.rotateLabel}
-        {...formItemLayout}
       >
         <RotateField
           rotate={rotate as number}
@@ -274,7 +261,6 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.haloColorLabel}
-        {...formItemLayout}
       >
         <ColorField
           color={haloColor as string}
@@ -283,7 +269,6 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
       </Form.Item>
       <Form.Item
         label={locale.haloWidthLabel}
-        {...formItemLayout}
       >
         <WidthField
           width={haloWidth as number}

--- a/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
+++ b/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
@@ -134,21 +134,14 @@ export const RasterChannelEditor: React.FC<RasterChannelEditorProps> = ({
     grayChannel = channelSelection.grayChannel;
   }
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   return (
     <div>
       <Form.Item
-        {...formItemLayout}
       >
         <span>{locale.titleLabel}</span>
       </Form.Item>
       <Form.Item
         label={locale.channelSelectionLabel}
-        {...formItemLayout}
       >
         <Select
           className="editor-field rgb-or-gray-field"

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -169,11 +169,6 @@ export const RasterEditor: React.FC<RasterEditorProps> = ({
     wrapperCol: {span: 24}
   };
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   const getSupportProps = (propName: keyof RasterSymbolizer) => {
     return UnsupportedPropertiesUtil.getSupportProps<RasterSymbolizer>({
       propName,
@@ -193,7 +188,6 @@ export const RasterEditor: React.FC<RasterEditorProps> = ({
                 key='opacity'
                 label={locale.opacityLabel}
                 {...getSupportProps('opacity')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -211,7 +205,6 @@ export const RasterEditor: React.FC<RasterEditorProps> = ({
                 key='contrastEnhancement'
                 label={locale.contrastEnhancementLabel}
                 {...getSupportProps('contrastEnhancement')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({
@@ -228,7 +221,6 @@ export const RasterEditor: React.FC<RasterEditorProps> = ({
                 key='gamma'
                 label={locale.gammaValueLabel}
                 {...getSupportProps('contrastEnhancement')}
-                {...formItemLayout}
               >
                 {
                   CompositionUtil.handleComposition({

--- a/src/Component/Symbolizer/TextEditor/TextEditor.less
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.less
@@ -27,10 +27,6 @@
  */
 
 .gs-text-symbolizer-editor {
-  .ant-select-selection {
-    width: 90px;
-  }
-
   .ant-row.ant-form-item.ant-form-item-no-colon {
     margin-bottom: 0;
   }

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -202,11 +202,6 @@ export const TextEditor: React.FC<TextEditorProps> = ({
   }
   const properties = internalDataDef && internalDataDef.schema ? Object.keys(internalDataDef.schema.properties) : [];
 
-  const formItemLayout = {
-    labelCol: { span: 8 },
-    wrapperCol: { span: 16 }
-  };
-
   const getSupportProps = (propName: keyof TextSymbolizer) => {
     return UnsupportedPropertiesUtil.getSupportProps<TextSymbolizer>({
       propName,
@@ -223,7 +218,6 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           <Form.Item
             label={locale.templateFieldLabel}
             {...getSupportProps('label')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -249,7 +243,6 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           <Form.Item
             label={locale.colorLabel}
             {...getSupportProps('color')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -266,7 +259,6 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           <Form.Item
             label={locale.fontLabel}
             {...getSupportProps('font')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -283,7 +275,6 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           <Form.Item
             label={locale.opacityLabel}
             {...getSupportProps('opacity')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -300,7 +291,6 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           <Form.Item
             label={locale.sizeLabel}
             {...getSupportProps('size')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -317,7 +307,6 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           <Form.Item
             label={locale.offsetXLabel}
             {...getSupportProps('offset')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -334,7 +323,6 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           <Form.Item
             label={locale.offsetYLabel}
             {...getSupportProps('offset')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -351,7 +339,6 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           <Form.Item
             label={locale.rotateLabel}
             {...getSupportProps('rotate')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -368,7 +355,6 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           <Form.Item
             label={locale.haloColorLabel}
             {...getSupportProps('haloColor')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({
@@ -385,7 +371,6 @@ export const TextEditor: React.FC<TextEditorProps> = ({
           <Form.Item
             label={locale.haloWidthLabel}
             {...getSupportProps('haloWidth')}
-            {...formItemLayout}
           >
             {
               CompositionUtil.handleComposition({

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -159,14 +159,9 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = ({
    * to the From Item label.
    */
   const wrapFormItem = (label: string, element: React.ReactElement): React.ReactElement => {
-    const formItemLayout = {
-      labelCol: { span: 8 },
-      wrapperCol: { span: 16 }
-    };
     return element == null ? null : (
       <Form.Item
         label={label}
-        {...formItemLayout}
       >
         {element}
       </Form.Item>


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

Form items now use a vertical layout, which means that the labels are on top of the input field. Before, they were located in the same line as the input fields. This should finally fix all form inconsistencies and simplifies this strongly.

Symbolizer Editor

![image](https://user-images.githubusercontent.com/12186477/223386165-e23020a1-5f30-41bf-b3af-dd9bddc54351.png)

Card Style

![image](https://user-images.githubusercontent.com/12186477/219693649-581eb3ca-2500-4c35-b415-99e0e2cb81f0.png)

Rule Generator

![image](https://user-images.githubusercontent.com/12186477/219693720-6814dc2e-1fcc-4609-aae0-fc9fa294193f.png)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

