### PR TITLE
feat: use GeoStylerContext composition on FillEditor.

### DIFF
--- a/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
+++ b/src/Component/Symbolizer/Field/OpacityField/OpacityField.tsx
@@ -35,7 +35,7 @@ import { InputNumberProps } from 'antd/lib/input-number';
 import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface OpacityFieldProps extends Partial<InputNumberProps> {
+export interface OpacityFieldProps extends Partial<InputNumberProps<number>> {
   opacity?: number;
 }
 

--- a/src/Component/Symbolizer/Field/WidthField/WidthField.tsx
+++ b/src/Component/Symbolizer/Field/WidthField/WidthField.tsx
@@ -30,7 +30,7 @@ import * as React from 'react';
 import { InputNumber, InputNumberProps } from 'antd';
 import FieldUtil from '../../../../Util/FieldUtil';
 
-export interface WidthFieldProps extends InputNumberProps {
+export interface WidthFieldProps extends InputNumberProps<number> {
   width?: number;
 }
 

--- a/src/Component/Symbolizer/FillEditor/FillEditor.example.md
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.example.md
@@ -69,3 +69,116 @@ class FillEditorExample extends React.Component {
 
 <FillEditorExample />
 ```
+
+This demonstrates the usage of `FillEditor` with the `GeoStylerContext`.
+
+```jsx
+import React, { useState } from 'react';
+import { Switch } from 'antd';
+import { FillEditor, GeoStylerContext } from 'geostyler';
+
+function FillEditorExample () {
+
+  const [myContext, setMyContext] = useState({
+    composition: {
+      FillEditor: {
+        fillColorField: {
+          visibility: true
+        },
+        fillOpacityField: {
+          visibility: true
+        },
+        opacityField: {
+          visibility: true
+        },
+        outlineOpacityField: {
+          visibility: true
+        },
+        outlineColorField: {
+          visibility: true
+        },
+        outlineWidthField: {
+          visibility: true
+        },
+        outlineDasharrayField: {
+          visibility: true
+        }
+      }
+    }
+  });
+
+  const [symbolizer, setSymbolizer] = useState({
+    kind: 'Fill'
+  });
+
+  const onSymbolizerChange = (s) => {
+    setSymbolizer(s);
+  };
+
+  const onVisibilityChange = (visibility, prop) => {
+    setMyContext(oldContext => {
+      const newContext = {...oldContext};
+      newContext.composition.FillEditor[prop].visibility = visibility;
+      return newContext;
+    })
+  };
+
+  return (
+    <div>
+      <div style={{display: 'flex', flexWrap: 'wrap', gap: '15px'}}>
+        <Switch
+          checked={myContext.composition.FillEditor.fillColorField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'fillColorField')}}
+          checkedChildren="Fill-Color"
+          unCheckedChildren="Fill-Color"
+        />
+        <Switch
+          checked={myContext.composition.FillEditor.fillOpacityField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'fillOpacityField')}}
+          checkedChildren="Fill-Opacity"
+          unCheckedChildren="Fill-Opacity"
+        />
+        <Switch
+          checked={myContext.composition.FillEditor.opacityField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'opacityField')}}
+          checkedChildren="Opacity"
+          unCheckedChildren="Opacity"
+        />
+        <Switch
+          checked={myContext.composition.FillEditor.outlineOpacityField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'outlineOpacityField')}}
+          checkedChildren="Stroke-Opacity"
+          unCheckedChildren="Stroke-Opacity"
+        />
+        <Switch
+          checked={myContext.composition.FillEditor.outlineColorField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'outlineColorField')}}
+          checkedChildren="Outline-Color"
+          unCheckedChildren="Outline-Color"
+        />
+        <Switch
+          checked={myContext.composition.FillEditor.outlineWidthField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'outlineWidthField')}}
+          checkedChildren="Outline-Width"
+          unCheckedChildren="Outline-Width"
+        />
+        <Switch
+          checked={myContext.composition.FillEditor.outlineDasharrayField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'outlineDasharrayField')}}
+          checkedChildren="Outline-Dasharray"
+          unCheckedChildren="Outline-Dasharray"
+        />
+      </div>
+      <hr />
+      <GeoStylerContext.Provider value={myContext}>
+        <FillEditor
+          symbolizer={symbolizer}
+          onSymbolizerChange={onSymbolizerChange}
+        />
+      </GeoStylerContext.Provider>
+    </div>
+  );
+};
+
+<FillEditorExample />
+```

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -51,15 +51,13 @@ import _isEqual from 'lodash/isEqual';
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 import LineDashField from '../Field/LineDashField/LineDashField';
-import { CompositionContext, Compositions } from '../../../context/CompositionContext/CompositionContext';
-import CompositionUtil from '../../../Util/CompositionUtil';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
-import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 import { GeoStylerLocale } from '../../../locale/locale';
 import {
   UnsupportedPropertiesContext
 } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
 import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
+import { useGeoStylerComposition } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 const Panel = Collapse.Panel;
 
@@ -71,17 +69,21 @@ interface FillEditorDefaultProps {
 export interface FillEditorProps extends Partial<FillEditorDefaultProps> {
   symbolizer: FillSymbolizer;
   onSymbolizerChange?: (changedSymb: Symbolizer) => void;
-  defaultValues?: DefaultValues;
 }
 
 const COMPONENTNAME = 'FillEditor';
 
-export const FillEditor: React.FC<FillEditorProps> = ({
-  locale = en_US.FillEditor,
-  symbolizer,
-  onSymbolizerChange,
-  defaultValues
-}) => {
+export const FillEditor: React.FC<FillEditorProps> = (props) => {
+
+  const composition = useGeoStylerComposition('FillEditor', {});
+
+  const composed = {...props, ...composition};
+
+  const {
+    locale = en_US.FillEditor,
+    symbolizer,
+    onSymbolizerChange
+  } = composed;
 
   const {
     unsupportedProperties,
@@ -174,146 +176,118 @@ export const FillEditor: React.FC<FillEditorProps> = ({
   };
 
   return (
-    <CompositionContext.Consumer>
-      {(composition: Compositions) => (
-        <div className="gs-fill-symbolizer-editor" >
-          <Collapse bordered={false} defaultActiveKey={['1']}>
-            <Panel header="General" key="1">
+    <div className="gs-fill-symbolizer-editor" >
+      <Collapse bordered={false} defaultActiveKey={['1']}>
+        <Panel header="General" key="1">
+          {
+            composition.fillColorField?.visibility === false ? null : (
               <Form.Item
                 label={locale.fillColorLabel}
                 {...getSupportProps('color')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'FillEditor.fillColorField',
-                    onChange: onFillColorChange,
-                    propName: 'color',
-                    propValue: color,
-                    defaultValue: defaultValues?.FillEditor?.defaultFillColor,
-                    defaultElement: <ColorField />
-                  })
-                }
+                <ColorField
+                  color={color as string}
+                  defaultValue={composition.fillColorField?.default}
+                  onChange={onFillColorChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.fillOpacityField?.visibility === false ? null : (
               <Form.Item
                 label={locale.fillOpacityLabel}
                 {...getSupportProps('fillOpacity')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'FillEditor.fillOpacityField',
-                    onChange: onFillOpacityChange,
-                    propName: 'fillOpacity',
-                    propValue: fillOpacity,
-                    defaultValue: defaultValues?.FillEditor?.defaultFillOpacity,
-                    defaultElement: <OpacityField />
-                  })
-                }
+                <OpacityField
+                  opacity={fillOpacity as number}
+                  defaultValue={composition.fillOpacityField?.default}
+                  onChange={onFillOpacityChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.opacityField?.visibility === false ? null : (
               <Form.Item
                 label={locale.opacityLabel}
                 {...getSupportProps('opacity')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'FillEditor.opacityField',
-                    onChange: onOpacityChange,
-                    propName: 'opacity',
-                    propValue: opacity,
-                    defaultValue: defaultValues?.FillEditor?.defaultOpacity,
-                    defaultElement: <OpacityField />
-                  })
-                }
+                <OpacityField
+                  opacity={opacity as number}
+                  defaultValue={composition.opacityField?.default}
+                  onChange={onOpacityChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.outlineOpacityField?.visibility === false ? null : (
               <Form.Item
                 label={locale.outlineOpacityLabel}
                 {...getSupportProps('outlineOpacity')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'FillEditor.outlineOpacityField',
-                    onChange: onOutlineOpacityChange,
-                    propName: 'opacity',
-                    propValue: outlineOpacity,
-                    defaultValue: defaultValues?.FillEditor?.defaultOutlineOpacity,
-                    defaultElement: <OpacityField />
-                  })
-                }
+                <OpacityField
+                  opacity={outlineOpacity as number}
+                  defaultValue={composition.outlineOpacityField?.default}
+                  onChange={onOutlineOpacityChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.outlineColorField?.visibility === false ? null : (
               <Form.Item
                 label={locale.outlineColorLabel}
                 {...getSupportProps('outlineColor')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'FillEditor.outlineColorField',
-                    onChange: onOutlineColorChange,
-                    propName: 'color',
-                    propValue: outlineColor,
-                    defaultValue: defaultValues?.FillEditor?.defaultOutlineColor,
-                    defaultElement: <ColorField />
-                  })
-                }
+                <ColorField
+                  color={outlineColor as string}
+                  defaultValue={composition.outlineColorField?.default}
+                  onChange={onOutlineColorChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.outlineWidthField?.visibility === false ? null : (
               <Form.Item
                 label={locale.outlineWidthLabel}
                 {...getSupportProps('outlineWidth')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'FillEditor.outlineWidthField',
-                    onChange: onOutlineWidthChange,
-                    propName: 'width',
-                    propValue: outlineWidth,
-                    defaultValue: defaultValues?.FillEditor?.defaultOutlineWidth,
-                    defaultElement: <WidthField />
-                  })
-                }
+                <WidthField
+                  width={outlineWidth as number}
+                  defaultValue={composition.outlineWidthField?.default}
+                  onChange={onOutlineWidthChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.outlineDasharrayField?.visibility === false ? null : (
               <Form.Item
                 label={locale.outlineDasharrayLabel}
                 {...getSupportProps('outlineDasharray')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'FillEditor.outlineDasharrayField',
-                    onChange: onOutlineDasharrayChange,
-                    propName: 'dashArray',
-                    propValue: outlineDasharray,
-                    defaultElement: <LineDashField />
-                  })
-                }
+                <LineDashField
+                  dashArray={outlineDasharray as number[]}
+                  onChange={onOutlineDasharrayChange}
+                />
               </Form.Item>
-            </Panel>
-            <Panel header="Graphic Fill" key="2">
-              {
-                CompositionUtil.handleComposition({
-                  composition,
-                  path: 'FillEditor.graphicEditorField',
-                  onChange: onGraphicChange,
-                  onChangeName: 'onGraphicChange',
-                  propName: 'graphic',
-                  propValue: graphicFill,
-                  defaultElement: (
-                    <GraphicEditor
-                      graphicTypeFieldLabel={locale.graphicFillTypeLabel}
-                      graphic={graphicFill}
-                      graphicType={_get(graphicFill, 'kind') as GraphicType}
-                    />
-                  )
-                })
-              }
-            </Panel>
-          </Collapse>
-        </div>
-      )}
-    </CompositionContext.Consumer>
+            )
+          }
+        </Panel>
+        <Panel header="Graphic Fill" key="2">
+          {/* TODO allow changing graphicFill via composition context */}
+          <GraphicEditor
+            graphicTypeFieldLabel={locale.graphicFillTypeLabel}
+            graphic={graphicFill}
+            graphicType={_get(graphicFill, 'kind') as GraphicType}
+            onGraphicChange={onGraphicChange}
+          />
+        </Panel>
+      </Collapse>
+    </div>
   );
 };
 

--- a/src/context/GeoStylerContext/GeoStylerContext.tsx
+++ b/src/context/GeoStylerContext/GeoStylerContext.tsx
@@ -46,7 +46,8 @@ export type CompositionContext = {
     opacityField?: InputConfig<OpacityFieldProps['opacity']>;
     outlineOpacityField?: InputConfig<OpacityFieldProps['opacity']>;
     outlineColorField?: InputConfig<ColorFieldProps['color']>;
-    outlineDasharrayField?: InputConfig<LineDashFieldProps['dashArray']>;
+    // TODO add support for default values in LineDashField
+    outlineDasharrayField?: Omit<InputConfig<LineDashFieldProps['dashArray']>, 'default'>;
     outlineWidthField?: InputConfig<WidthFieldProps['width']>;
   };
   IconEditor?: {


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This introduces the usage of GeoStylerContext for default values and composition in the `<FillEditor>`.

BREAKING CHANGE: This removes the support of the deprecated CompositionContext in favor of the new GeoStylerContext for the FillEditor. This also removes the `defaultValues` property from FillEditor. Please use GeoStylerContext.composition instead.

![geostyler-filleditor-context](https://user-images.githubusercontent.com/12186477/236837239-1ae0373e-6a75-4499-b968-651bff0d3049.gif)

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

