### PR TITLE
feat: use GeoStylerContext composition on IconEditor

### DIFF
--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
@@ -33,7 +33,7 @@ import { InputNumberProps } from 'antd/lib/input-number';
 import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface OffsetFieldProps extends InputNumberProps {
+export interface OffsetFieldProps extends InputNumberProps<number> {
   offset?: number;
 }
 

--- a/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
+++ b/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
@@ -34,7 +34,7 @@ import {
 import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface RotateFieldProps extends InputNumberProps {
+export interface RotateFieldProps extends InputNumberProps<number> {
   rotate?: number;
 }
 

--- a/src/Component/Symbolizer/IconEditor/IconEditor.example.md
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.example.md
@@ -69,3 +69,107 @@ class IconEditorExample extends React.Component {
 
 <IconEditorExample />
 ```
+
+This demonstrates the usage of `IconEditor` with `GeoStylerContext`.
+
+```jsx
+import React, { useState } from 'react';
+import { Switch } from 'antd';
+import { IconEditor, GeoStylerContext } from 'geostyler';
+
+function IconEditorExample () {
+
+  const [myContext, setMyContext] = useState({
+    composition: {
+      IconEditor: {
+        imageField: {
+          visibility: true
+        },
+        sizeField: {
+          visibility: true
+        },
+        offsetXField: {
+          visibility: true
+        },
+        offsetYField: {
+          visibility: true
+        },
+        rotateField: {
+          visibility: true
+        },
+        opacityField: {
+          visibility: true
+        }
+      }
+    }
+  });
+
+  const [symbolizer, setSymbolizer] = useState({
+    kind: 'Icon'
+  });
+
+  const onSymbolizerChange = (s) => {
+    setSymbolizer(s);
+  };
+
+  const onVisibilityChange = (visibility, prop) => {
+    setMyContext(oldContext => {
+      const newContext = {...oldContext};
+      newContext.composition.IconEditor[prop].visibility = visibility;
+      return newContext;
+    })
+  };
+
+  return (
+    <div>
+      <div style={{display: 'flex', flexWrap: 'wrap', gap: '15px'}}>
+        <Switch
+          checked={myContext.composition.IconEditor.imageField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'imageField')}}
+          checkedChildren="Source"
+          unCheckedChildren="Source"
+        />
+        <Switch
+          checked={myContext.composition.IconEditor.sizeField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'sizeField')}}
+          checkedChildren="Size"
+          unCheckedChildren="Size"
+        />
+        <Switch
+          checked={myContext.composition.IconEditor.offsetXField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'offsetXField')}}
+          checkedChildren="Offset X"
+          unCheckedChildren="Offset X"
+        />
+        <Switch
+          checked={myContext.composition.IconEditor.offsetYField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'offsetYField')}}
+          checkedChildren="Offset Y"
+          unCheckedChildren="Offset Y"
+        />
+        <Switch
+          checked={myContext.composition.IconEditor.rotateField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'rotateField')}}
+          checkedChildren="Rotation"
+          unCheckedChildren="Rotation"
+        />
+        <Switch
+          checked={myContext.composition.IconEditor.opacityField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'opacityField')}}
+          checkedChildren="Opacity"
+          unCheckedChildren="Opacity"
+        />
+      </div>
+      <hr />
+      <GeoStylerContext.Provider value={myContext}>
+        <IconEditor
+          symbolizer={symbolizer}
+          onSymbolizerChange={onSymbolizerChange}
+        />
+      </GeoStylerContext.Provider>
+    </div>
+  );
+};
+
+<IconEditorExample />
+```

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -47,16 +47,14 @@ import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
 import { Form } from 'antd';
 
-import { CompositionContext, Compositions } from '../../../context/CompositionContext/CompositionContext';
-import CompositionUtil from '../../../Util/CompositionUtil';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
-import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 import { GeoStylerLocale } from '../../../locale/locale';
 import {
   UnsupportedPropertiesContext
 } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
 import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
 import OffsetField from '../Field/OffsetField/OffsetField';
+import { useGeoStylerComposition } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 // default props
 export interface IconEditorDefaultProps {
@@ -68,7 +66,6 @@ export interface IconEditorProps extends Partial<IconEditorDefaultProps> {
   symbolizer: IconSymbolizer;
   onSymbolizerChange?: (changedSymb: Symbolizer) => void;
   iconLibraries?: IconLibrary[];
-  defaultValues?: DefaultValues;
   /**
    * The props for the image field. Properties 'iconLibraries' and
    * 'tooltipLabel' should not be used here currently, as they will
@@ -80,14 +77,19 @@ export interface IconEditorProps extends Partial<IconEditorDefaultProps> {
 
 const COMPONENTNAME = 'IconEditor';
 
-export const IconEditor: React.FC<IconEditorProps> = ({
-  locale = en_US.IconEditor,
-  symbolizer,
-  onSymbolizerChange,
-  iconLibraries,
-  defaultValues,
-  imageFieldProps
-}) => {
+export const IconEditor: React.FC<IconEditorProps> = (props) => {
+
+  const composition = useGeoStylerComposition('IconEditor', {});
+
+  const composed = {...props, ...composition};
+
+  const {
+    locale = en_US.IconEditor,
+    symbolizer,
+    onSymbolizerChange,
+    iconLibraries,
+    imageFieldProps
+  } = composed;
 
   const {
     unsupportedProperties,
@@ -165,117 +167,96 @@ export const IconEditor: React.FC<IconEditorProps> = ({
   };
 
   return (
-    <CompositionContext.Consumer>
-      {(composition: Compositions) => (
-        <div className="gs-icon-symbolizer-editor" >
+    <div className="gs-icon-symbolizer-editor" >
+      {
+        composition.imageField?.visibility === false ? null : (
           <Form.Item
             label={locale.imageLabel}
             {...getSupportProps('image')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'IconEditor.imageField',
-                onChange: onImageSrcChange,
-                propName: 'value',
-                propValue: imageSrc,
-                defaultValue: defaultValues?.IconEditor?.defaultImage,
-                defaultElement: (
-                  <ImageField
-                    // To keep backwards compatibility,
-                    // we overwrite imageFieldProps with the props
-                    // that were explicitly set as props on IconEditor.
-                    {...imageFieldProps}
-                    iconLibraries={iconLibraries}
-                    tooltipLabel={locale.iconTooltipLabel}
-                  />
-                )
-              })
-            }
+            <ImageField
+              value={imageSrc as string}
+              onChange={onImageSrcChange}
+              // To keep backwards compatibility,
+              // we overwrite imageFieldProps with the props
+              // that were explicitly set as props on IconEditor.
+              {...imageFieldProps}
+              iconLibraries={composition.iconLibraries || iconLibraries}
+              tooltipLabel={locale.iconTooltipLabel}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.sizeField?.visibility === false ? null : (
           <Form.Item
             label={locale.sizeLabel}
             {...getSupportProps('size')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'IconEditor.sizeField',
-                onChange: onSizeChange,
-                propName: 'size',
-                propValue: size,
-                defaultValue: defaultValues?.IconEditor?.defaultSize,
-                defaultElement: <SizeField />
-              })
-            }
+            <SizeField
+              size={size as number}
+              onChange={onSizeChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.offsetXField?.visibility === false ? null : (
           <Form.Item
             label={locale.offsetXLabel}
             {...getSupportProps('offset')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'IconEditor.offsetXField',
-                onChange: onOffsetXChange,
-                propName: 'offset',
-                propValue: offset?.[0],
-                defaultValue: defaultValues?.IconEditor?.defaultOffsetX,
-                defaultElement: <OffsetField />
-              })
-            }
+            <OffsetField
+              offset={offset?.[0] as number}
+              defaultValue={composition.offsetXField?.default}
+              onChange={onOffsetXChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.offsetYField?.visibility === false ? null : (
           <Form.Item
             label={locale.offsetYLabel}
             {...getSupportProps('offset')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'IconEditor.offsetYField',
-                onChange: onOffsetYChange,
-                propName: 'offset',
-                propValue: offset?.[1],
-                defaultValue: defaultValues?.IconEditor?.defaultOffsetY,
-                defaultElement: <OffsetField />
-              })
-            }
+            <OffsetField
+              offset={offset?.[1] as number}
+              defaultValue={composition.offsetYField?.default}
+              onChange={onOffsetYChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.rotateField?.visibility === false ? null : (
           <Form.Item
             label={locale.rotateLabel}
             {...getSupportProps('rotate')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'IconEditor.rotateField',
-                onChange: onRotateChange,
-                propName: 'rotate',
-                propValue: rotate,
-                defaultValue: defaultValues?.IconEditor?.defaultRotate,
-                defaultElement: <RotateField />
-              })
-            }
+            <RotateField
+              rotate={rotate as number}
+              defaultValue={composition.rotateField?.default}
+              onChange={onRotateChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.opacityField?.visibility === false ? null : (
           <Form.Item
             label={locale.opacityLabel}
             {...getSupportProps('opacity')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'IconEditor.opacityField',
-                onChange: onOpacityChange,
-                propName: 'opacity',
-                propValue: opacity,
-                defaultValue: defaultValues?.IconEditor?.defaultOpacity,
-                defaultElement: <OpacityField />
-              })
-            }
+            <OpacityField
+              opacity={opacity as number}
+              defaultValue={composition.opacityField?.default}
+              onChange={onOpacityChange}
+            />
           </Form.Item>
-        </div>
-      )}
-    </CompositionContext.Consumer>
+        )
+      }
+    </div>
   );
 };
 

--- a/src/context/GeoStylerContext/GeoStylerContext.tsx
+++ b/src/context/GeoStylerContext/GeoStylerContext.tsx
@@ -52,8 +52,10 @@ export type CompositionContext = {
   };
   IconEditor?: {
     visibility: boolean;
-    imageField: InputConfig<ImageFieldProps['value']>;
-    sizeField: InputConfig<SizeFieldProps['size']>;
+    // TODO add support for default values in ImageField
+    imageField: Omit<InputConfig<ImageFieldProps['value']>, 'default'>;
+    // TODO add support for default values in SizeField
+    sizeField: Omit<InputConfig<SizeFieldProps['size']>, 'default'>;
     offsetXField?: InputConfig<OffsetFieldProps['offset']>;
     offsetYField?: InputConfig<OffsetFieldProps['offset']>;
     rotateField?: InputConfig<RotateFieldProps['rotate']>;


### PR DESCRIPTION

<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This makes use of the GeoStylerContext.composition in `<IconEditor>`.

BREAKING CHANGE: This removes the support of the deprecated CompositionContext in favor of the new GeoStylerContext for the IconEditor. This also removes the `defaultValues` property from IconEditor. Please use GeoStylerContext.composition instead.

![geostyler-iconeditor-context](https://user-images.githubusercontent.com/12186477/236847538-3cb29127-fb2d-4ca4-9700-0ac2678d5762.gif)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

