### PR TITLE
feat: use GeoStylerContext composition on LineEditor

### DIFF
--- a/src/Component/Symbolizer/LineEditor/LineEditor.example.md
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.example.md
@@ -69,3 +69,125 @@ class LineEditorExample extends React.Component {
 
 <LineEditorExample />
 ```
+
+This demonstrates the usage of `LineEditor` with `GeoStylerContext`.
+
+```jsx
+import React, { useState } from 'react';
+import { Switch } from 'antd';
+import { LineEditor, GeoStylerContext } from 'geostyler';
+
+function LineEditorExample () {
+
+  const [myContext, setMyContext] = useState({
+    composition: {
+      LineEditor: {
+        colorField: {
+          visibility: true
+        },
+        widthField: {
+          visibility: true
+        },
+        perpendicularOffsetField: {
+          visibility: true
+        },
+        opacityField: {
+          visibility: true
+        },
+        lineDashField: {
+          visibility: true
+        },
+        dashOffsetField: {
+          visibility: true
+        },
+        capField: {
+          visibility: true
+        },
+        joinField: {
+          visibility: true
+        },
+      }
+    }
+  });
+
+  const [symbolizer, setSymbolizer] = useState({
+    kind: 'Line'
+  });
+
+  const onSymbolizerChange = (s) => {
+    setSymbolizer(s);
+  };
+
+  const onVisibilityChange = (visibility, prop) => {
+    setMyContext(oldContext => {
+      const newContext = {...oldContext};
+      newContext.composition.LineEditor[prop].visibility = visibility;
+      return newContext;
+    })
+  };
+
+  return (
+    <div>
+      <div style={{display: 'flex', flexWrap: 'wrap', gap: '15px'}}>
+        <Switch
+          checked={myContext.composition.LineEditor.colorField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'colorField')}}
+          checkedChildren="Color"
+          unCheckedChildren="Color"
+        />
+        <Switch
+          checked={myContext.composition.LineEditor.widthField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'widthField')}}
+          checkedChildren="Width"
+          unCheckedChildren="Width"
+        />
+        <Switch
+          checked={myContext.composition.LineEditor.perpendicularOffsetField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'perpendicularOffsetField')}}
+          checkedChildren="Perpendicular Offset"
+          unCheckedChildren="Perpendicular Offset"
+        />
+        <Switch
+          checked={myContext.composition.LineEditor.opacityField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'opacityField')}}
+          checkedChildren="Opacity"
+          unCheckedChildren="Opacity"
+        />
+        <Switch
+          checked={myContext.composition.LineEditor.lineDashField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'lineDashField')}}
+          checkedChildren="Dash Pattern"
+          unCheckedChildren="Dash Pattern"
+        />
+        <Switch
+          checked={myContext.composition.LineEditor.dashOffsetField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'dashOffsetField')}}
+          checkedChildren="Dash Offset"
+          unCheckedChildren="Dash Offset"
+        />
+        <Switch
+          checked={myContext.composition.LineEditor.capField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'capField')}}
+          checkedChildren="Cap"
+          unCheckedChildren="Cap"
+        />
+        <Switch
+          checked={myContext.composition.LineEditor.joinField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'joinField')}}
+          checkedChildren="Join"
+          unCheckedChildren="Join"
+        />
+      </div>
+      <hr />
+      <GeoStylerContext.Provider value={myContext}>
+        <LineEditor
+          symbolizer={symbolizer}
+          onSymbolizerChange={onSymbolizerChange}
+        />
+      </GeoStylerContext.Provider>
+    </div>
+  );
+};
+
+<LineEditorExample />
+```

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -55,8 +55,6 @@ import _isEqual from 'lodash/isEqual';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
-import { CompositionContext, Compositions } from '../../../context/CompositionContext/CompositionContext';
-import CompositionUtil from '../../../Util/CompositionUtil';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
 import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 import { GeoStylerLocale } from '../../../locale/locale';
@@ -64,6 +62,7 @@ import {
   UnsupportedPropertiesContext
 } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
 import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
+import { useGeoStylerComposition } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 const Panel = Collapse.Panel;
 
@@ -82,12 +81,17 @@ export interface LineEditorProps extends Partial<LineEditorDefaultProps> {
 }
 const COMPONENTNAME = 'LineEditor';
 
-export const LineEditor: React.FC<LineEditorProps> = ({
-  locale = en_US.LineEditor,
-  symbolizer,
-  onSymbolizerChange,
-  defaultValues
-}) => {
+export const LineEditor: React.FC<LineEditorProps> = (props) => {
+
+  const composition = useGeoStylerComposition('LineEditor', {});
+
+  const composed = {...props, ...composition};
+
+  const {
+    locale = en_US.LineEditor,
+    symbolizer,
+    onSymbolizerChange
+  } = composed;
 
   const {
     unsupportedProperties,
@@ -197,186 +201,143 @@ export const LineEditor: React.FC<LineEditorProps> = ({
   };
 
   return (
-    <CompositionContext.Consumer>
-      {(composition: Compositions) => (
-        <div className="gs-line-symbolizer-editor" >
-          <Collapse bordered={false} defaultActiveKey={['1']}>
-            <Panel header="General" key="1">
+    <div className="gs-line-symbolizer-editor" >
+      <Collapse bordered={false} defaultActiveKey={['1']}>
+        <Panel header="General" key="1">
+          {
+            composition.colorField?.visibility === false ? null : (
               <Form.Item
                 label={locale.colorLabel}
                 {...getSupportProps('color')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'LineEditor.colorField',
-                    onChange: onColorChange,
-                    propName: 'color',
-                    propValue: color,
-                    defaultValue: defaultValues?.LineEditor?.defaultColor,
-                    defaultElement: <ColorField />
-                  })
-                }
+                <ColorField
+                  color={color as string}
+                  defaultValue={composition.colorField?.default}
+                  onChange={onColorChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.widthField?.visibility === false ? null : (
               <Form.Item
                 label={locale.widthLabel}
                 {...getSupportProps('width')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'LineEditor.widthField',
-                    onChange: onWidthChange,
-                    propName: 'width',
-                    propValue: width,
-                    defaultValue: defaultValues?.LineEditor?.defaultWidth,
-                    defaultElement: <WidthField />
-                  })
-                }
+                <WidthField
+                  width={width as number}
+                  defaultValue={composition.widthField?.default}
+                  onChange={onWidthChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.perpendicularOffsetField?.visibility === false ? null : (
               <Form.Item
                 label={locale.perpendicularOffsetLabel}
                 {...getSupportProps('perpendicularOffset')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'LineEditor.perpendicularOffsetField',
-                    onChange: onPerpendicularOffsetChange,
-                    propName: 'offset',
-                    propValue: perpendicularOffset,
-                    defaultValue: defaultValues?.LineEditor?.defaultPerpendicularOffset,
-                    defaultElement: <OffsetField />
-                  })
-                }
+                <OffsetField
+                  offset={perpendicularOffset as number}
+                  defaultValue={composition.perpendicularOffsetField?.default}
+                  onChange={onPerpendicularOffsetChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.opacityField?.visibility === false ? null : (
               <Form.Item
                 label={locale.opacityLabel}
                 {...getSupportProps('opacity')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'LineEditor.opacityField',
-                    onChange: onOpacityChange,
-                    propName: 'opacity',
-                    propValue: opacity,
-                    defaultValue: defaultValues?.LineEditor?.defaultOpacity,
-                    defaultElement: <OpacityField />
-                  })
-                }
+                <OpacityField
+                  opacity={opacity as number}
+                  defaultValue={composition.opacityField?.default}
+                  onChange={onOpacityChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.lineDashField?.visibility === false ? null : (
               <Form.Item
                 label={locale.dashLabel}
                 {...getSupportProps('dasharray')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'LineEditor.lineDashField',
-                    onChange: onDasharrayChange,
-                    propName: 'dashArray',
-                    propValue: dasharray,
-                    defaultElement: <LineDashField />
-                  })
-                }
+                <LineDashField
+                  dashArray={dasharray as number[]}
+                  onChange={onDasharrayChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.dashOffsetField?.visibility === false ? null : (
               <Form.Item
                 label={locale.dashOffsetLabel}
                 {...getSupportProps('dashOffset')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'LineEditor.dashOffsetField',
-                    onChange: onDashOffsetChange,
-                    propName: 'offset',
-                    propValue: dashOffset,
-                    defaultValue: defaultValues?.LineEditor?.defaultDashOffset,
-                    defaultElement: (
-                      <OffsetField
-                        disabled={
-                          symbolizer.dasharray === undefined || _get(symbolizer, 'dasharray.length') === 0
-                        }
-                      />)
-                  })
-                }
+                <OffsetField
+                  offset={dashOffset as number}
+                  defaultValue={composition.dashOffsetField?.default}
+                  onChange={onDashOffsetChange}
+                  disabled={
+                    symbolizer.dasharray === undefined || _get(symbolizer, 'dasharray.length') === 0
+                  }
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.capField?.visibility === false ? null : (
               <Form.Item
                 label={locale.capLabel}
                 {...getSupportProps('cap')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'LineEditor.capField',
-                    onChange: onCapChange,
-                    propName: 'cap',
-                    propValue: cap,
-                    defaultValue: defaultValues?.LineEditor?.defaultCap,
-                    defaultElement: <LineCapField />
-                  })
-                }
+                <LineCapField
+                  cap={cap}
+                  onChange={onCapChange}
+                />
               </Form.Item>
+            )
+          }
+          {
+            composition.joinField?.visibility === false ? null : (
               <Form.Item
                 label={locale.joinLabel}
                 {...getSupportProps('join')}
               >
-                {
-                  CompositionUtil.handleComposition({
-                    composition,
-                    path: 'LineEditor.joinField',
-                    onChange: onJoinChange,
-                    propName: 'join',
-                    propValue: join,
-                    defaultValue: defaultValues?.LineEditor?.defaultJoin,
-                    defaultElement: <LineJoinField />
-                  })
-                }
+                <LineJoinField
+                  join={join}
+                  onChange={onJoinChange}
+                />
               </Form.Item>
-            </Panel>
-            <Panel header="Graphic Stroke" key="2">
-              {
-                CompositionUtil.handleComposition({
-                  composition,
-                  path: 'LineEditor.graphicStrokeField',
-                  onChange: onGraphicStrokeChange,
-                  propName: 'graphic',
-                  propValue: graphicStroke,
-                  onChangeName: 'onGraphicChange',
-                  defaultElement: (
-                    <GraphicEditor
-                      graphicTypeFieldLabel={locale.graphicStrokeTypeLabel}
-                      graphic={graphicStroke}
-                      graphicType={_get(graphicStroke, 'kind') as GraphicType}
-                    />)
-                })
-              }
-            </Panel>
-            <Panel header="Graphic Fill" key="3">
-              {
-                CompositionUtil.handleComposition({
-                  composition,
-                  path: 'LineEditor.graphicFillField',
-                  onChange: onGraphicFillChange,
-                  propName: 'graphic',
-                  propValue: graphicFill,
-                  onChangeName: 'onGraphicChange',
-                  defaultElement: (
-                    <GraphicEditor
-                      graphicTypeFieldLabel={locale.graphicFillTypeLabel}
-                      graphic={graphicFill}
-                      graphicType={_get(graphicFill, 'kind') as GraphicType}
-                    />)
-                })
-              }
-            </Panel>
-          </Collapse>
-        </div>)
-      }
-    </CompositionContext.Consumer>
+            )
+          }
+        </Panel>
+        <Panel header="Graphic Stroke" key="2">
+          {/* TODO allow changing graphicStroke via composition context */}
+          <GraphicEditor
+            graphic={graphicStroke}
+            onGraphicChange={onGraphicStrokeChange}
+            graphicTypeFieldLabel={locale.graphicStrokeTypeLabel}
+            graphicType={_get(graphicStroke, 'kind') as GraphicType}
+          />
+        </Panel>
+        <Panel header="Graphic Fill" key="3">
+          {/* TODO allow changing graphicFill via composition context */}
+          <GraphicEditor
+            graphic={graphicFill}
+            onGraphicChange={onGraphicFillChange}
+            graphicTypeFieldLabel={locale.graphicFillTypeLabel}
+            graphicType={_get(graphicFill, 'kind') as GraphicType}
+          />
+        </Panel>
+      </Collapse>
+    </div>
   );
-
 };
 
 export default withDefaultsContext(localize(LineEditor, COMPONENTNAME));

--- a/src/context/GeoStylerContext/GeoStylerContext.tsx
+++ b/src/context/GeoStylerContext/GeoStylerContext.tsx
@@ -49,6 +49,7 @@ export type CompositionContext = {
     // TODO add support for default values in LineDashField
     outlineDasharrayField?: Omit<InputConfig<LineDashFieldProps['dashArray']>, 'default'>;
     outlineWidthField?: InputConfig<WidthFieldProps['width']>;
+    // TODO add support for graphicFill
   };
   IconEditor?: {
     visibility: boolean;
@@ -68,9 +69,15 @@ export type CompositionContext = {
     widthField?: InputConfig<WidthFieldProps['width']>;
     perpendicularOffsetField?: InputConfig<OffsetFieldProps['offset']>;
     opacityField?: InputConfig<OpacityFieldProps['opacity']>;
-    lineDashField?: InputConfig<LineDashFieldProps['dashArray']>;
-    capField?: InputConfig<LineCapFieldProps['cap']>;
+    // TODO add support for default values in LineDashField
+    lineDashField?: Omit<InputConfig<LineDashFieldProps['dashArray']>, 'default'>;
+    dashOffsetField?: InputConfig<OffsetFieldProps['offset']>;
+    // TODO add support for default values in LineCapField
+    capField?: Omit<InputConfig<LineCapFieldProps['cap']>, 'default'>;
+    // TODO add support for default values in LineJoinField
     joinField?: InputConfig<LineJoinFieldProps['join']>;
+    // TODO add support for graphicStroke
+    // TODO add support for graphicFill
   };
   MarkEditor?: {
     visibility?: boolean;


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This makes use of the GeoStylerContext.composition in `LineEditor`.

BREAKING CHANGE: This removes the support of the deprecated CompositionContext in favor of the new GeoStylerContext for the LineEditor. This also removes the `defaultValue` property from LineEditor. Please use GeoStylerContext.composition instead. For now, composition of graphicFill and graphicStroke was changed without replacement. Support will be re-added again in the future.

![geostyler-lineeditor-composition](https://user-images.githubusercontent.com/12186477/236866383-c0908527-325b-454f-a6db-99b5e6de529a.gif)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

