### PR TITLE
feat: use GeoStylerContext composition for MarkEditor

### DIFF
--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.example.md
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.example.md
@@ -70,3 +70,63 @@ class MarkEditorExample extends React.Component {
 
 <MarkEditorExample />
 ```
+
+This demonstrates the usage of `MarkEditor` with `GeoStylerContext`.
+
+```jsx
+import React, { useState } from 'react';
+import { Switch } from 'antd';
+import { MarkEditor, GeoStylerContext } from 'geostyler';
+
+function MarkEditorExample () {
+
+  const [myContext, setMyContext] = useState({
+    composition: {
+      MarkEditor: {
+        wellKnownNameField: {
+          visibility: true
+        },
+      }
+    }
+  });
+
+  const [symbolizer, setSymbolizer] = useState({
+    kind: 'Mark',
+    wellKnownName: 'circle'
+  });
+
+  const onSymbolizerChange = (s) => {
+    setSymbolizer(s);
+  };
+
+  const onVisibilityChange = (visibility, prop) => {
+    setMyContext(oldContext => {
+      const newContext = {...oldContext};
+      newContext.composition.MarkEditor[prop].visibility = visibility;
+      return newContext;
+    })
+  };
+
+  return (
+    <div>
+      <div style={{display: 'flex', flexWrap: 'wrap', gap: '15px'}}>
+        <Switch
+          checked={myContext.composition.MarkEditor.wellKnownNameField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'wellKnownNameField')}}
+          checkedChildren="Symbol"
+          unCheckedChildren="Symbol"
+        />
+      </div>
+      <hr />
+      <GeoStylerContext.Provider value={myContext}>
+        <MarkEditor
+          symbolizer={symbolizer}
+          onSymbolizerChange={onSymbolizerChange}
+        />
+      </GeoStylerContext.Provider>
+    </div>
+  );
+};
+
+<MarkEditorExample />
+```

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -38,10 +38,7 @@ import WellKnownNameField from '../Field/WellKnownNameField/WellKnownNameField';
 import WellKnownNameEditor from '../WellKnownNameEditor/WellKnownNameEditor';
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
-import { CompositionContext, Compositions } from '../../../context/CompositionContext/CompositionContext';
-import CompositionUtil from '../../../Util/CompositionUtil';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
-import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 import { Form } from 'antd';
 
 import _cloneDeep from 'lodash/cloneDeep';
@@ -50,6 +47,7 @@ import {
   UnsupportedPropertiesContext
 } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
 import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
+import { useGeoStylerComposition } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 // default props
 interface MarkEditorDefaultProps {
@@ -60,17 +58,21 @@ interface MarkEditorDefaultProps {
 export interface MarkEditorProps extends Partial<MarkEditorDefaultProps> {
   symbolizer: MarkSymbolizer;
   onSymbolizerChange?: (changedSymb: Symbolizer) => void;
-  defaultValues?: DefaultValues;
 }
 
 const COMPONENTNAME = 'MarkEditor';
 
-export const MarkEditor: React.FC<MarkEditorProps> = ({
-  locale = en_US.MarkEditor,
-  symbolizer,
-  onSymbolizerChange,
-  defaultValues
-}) => {
+export const MarkEditor: React.FC<MarkEditorProps> = (props) => {
+
+  const composition = useGeoStylerComposition('MarkEditor', {});
+
+  const composed = {...props, ...composition};
+
+  const {
+    locale = en_US.MarkEditor,
+    symbolizer,
+    onSymbolizerChange,
+  } = composed;
 
   const {
     unsupportedProperties,
@@ -95,32 +97,25 @@ export const MarkEditor: React.FC<MarkEditorProps> = ({
   };
 
   return (
-    <CompositionContext.Consumer>
-      {(composition: Compositions) => (
-        <div className="gs-mark-symbolizer-editor" >
+    <div className="gs-mark-symbolizer-editor" >
+      {
+        composition.wellKnownNameField?.visibility === false ? null : (
           <Form.Item
             label={locale.wellKnownNameFieldLabel}
             {...getSupportProps('wellKnownName')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'MarkEditor.wellKnownNameField',
-                onChange: onWellKnownNameChange,
-                propName: 'wellKnownName',
-                propValue: symbolizer.wellKnownName,
-                defaultValue: defaultValues?.MarkEditor?.defaultWellKnownName,
-                defaultElement: <WellKnownNameField />
-              })
-            }
+            <WellKnownNameField
+              wellKnownName={symbolizer.wellKnownName}
+              onChange={onWellKnownNameChange}
+            />
           </Form.Item>
-          <WellKnownNameEditor
-            symbolizer={symbolizer}
-            onSymbolizerChange={onSymbolizerChange}
-          />
-        </div>
-      )}
-    </CompositionContext.Consumer>
+        )
+      }
+      <WellKnownNameEditor
+        symbolizer={symbolizer}
+        onSymbolizerChange={onSymbolizerChange}
+      />
+    </div>
   );
 };
 

--- a/src/context/GeoStylerContext/GeoStylerContext.tsx
+++ b/src/context/GeoStylerContext/GeoStylerContext.tsx
@@ -81,7 +81,9 @@ export type CompositionContext = {
   };
   MarkEditor?: {
     visibility?: boolean;
-    wellKnownNameField?: InputConfig<WellKnownNameFieldProps['wellKnownName']>;
+    // TODO add support for default values in WellKnownNameField
+    wellKnownNameField?: Omit<InputConfig<WellKnownNameFieldProps['wellKnownName']>, 'default'>;
+    // TODO add wellKnownNames property that specifies the supported WKNs
   };
   WellKnownNameEditor?: {
     visibility?: boolean;


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This makes use of the `GeoStylerContext` in `MarkEditor`. Handling of the `WellKnownNameEditor` will be part of a subsequent PR.

BREAKING CHANGE: This removes the support for the deprecated CompositionContext in favor of the new GeoStylerContext for the MarkEditor. This also removes the `defaultValues` property from MarkEditor.

![geostyler-markeditor-composition](https://user-images.githubusercontent.com/12186477/236870772-a85f03bd-e392-4668-a14f-5e9dc3c5ed81.gif)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

