### PR TITLE
feat: use GeoStylerContext composition for WellKnownNameEditor

### DIFF
--- a/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
+++ b/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
@@ -34,7 +34,7 @@ import {
 import FieldUtil from '../../../../Util/FieldUtil';
 
 // non default props
-export interface RadiusFieldProps extends InputNumberProps {
+export interface RadiusFieldProps extends InputNumberProps<number> {
   radius?: number;
 }
 

--- a/src/Component/Symbolizer/FillEditor/FillEditor.example.md
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.example.md
@@ -120,7 +120,7 @@ function FillEditorExample () {
       const newContext = {...oldContext};
       newContext.composition.FillEditor[prop].visibility = visibility;
       return newContext;
-    })
+    });
   };
 
   return (

--- a/src/Component/Symbolizer/IconEditor/IconEditor.example.md
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.example.md
@@ -117,7 +117,7 @@ function IconEditorExample () {
       const newContext = {...oldContext};
       newContext.composition.IconEditor[prop].visibility = visibility;
       return newContext;
-    })
+    });
   };
 
   return (

--- a/src/Component/Symbolizer/LineEditor/LineEditor.example.md
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.example.md
@@ -123,7 +123,7 @@ function LineEditorExample () {
       const newContext = {...oldContext};
       newContext.composition.LineEditor[prop].visibility = visibility;
       return newContext;
-    })
+    });
   };
 
   return (

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.example.md
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.example.md
@@ -86,6 +86,9 @@ function MarkEditorExample () {
         wellKnownNameField: {
           visibility: true
         },
+      },
+      WellKnownNameEditor: {
+        visibility: true
       }
     }
   });
@@ -104,7 +107,15 @@ function MarkEditorExample () {
       const newContext = {...oldContext};
       newContext.composition.MarkEditor[prop].visibility = visibility;
       return newContext;
-    })
+    });
+  };
+
+  const onWknVisibilityChange = (visibility) => {
+    setMyContext(oldContext => {
+      const newContext = {...oldContext};
+      newContext.composition.WellKnownNameEditor.visibility = visibility;
+      return newContext;
+    });
   };
 
   return (
@@ -115,6 +126,12 @@ function MarkEditorExample () {
           onChange={visibility => {onVisibilityChange(visibility, 'wellKnownNameField')}}
           checkedChildren="Symbol"
           unCheckedChildren="Symbol"
+        />
+        <Switch
+          checked={myContext.composition.WellKnownNameEditor.visibility}
+          onChange={visibility => {onWknVisibilityChange(visibility)}}
+          checkedChildren="WellKnownNameEditor"
+          unCheckedChildren="WellKnownNameEditor"
         />
       </div>
       <hr />

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -65,6 +65,7 @@ const COMPONENTNAME = 'MarkEditor';
 export const MarkEditor: React.FC<MarkEditorProps> = (props) => {
 
   const composition = useGeoStylerComposition('MarkEditor', {});
+  const wknComposition = useGeoStylerComposition('WellKnownNameEditor', {});
 
   const composed = {...props, ...composition};
 
@@ -111,10 +112,14 @@ export const MarkEditor: React.FC<MarkEditorProps> = (props) => {
           </Form.Item>
         )
       }
-      <WellKnownNameEditor
-        symbolizer={symbolizer}
-        onSymbolizerChange={onSymbolizerChange}
-      />
+      {
+        wknComposition.visibility === false ? null : (
+          <WellKnownNameEditor
+            symbolizer={symbolizer}
+            onSymbolizerChange={onSymbolizerChange}
+          />
+        )
+      }
     </div>
   );
 };

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.example.md
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.example.md
@@ -70,3 +70,144 @@ class WellKnownNameEditorExample extends React.Component {
 
 <WellKnownNameEditorExample />
 ```
+
+This demonstrates the usage of `WellKnownNameEditor` with `GeoStylerContext`.
+
+```jsx
+import React, { useState } from 'react';
+import { Switch } from 'antd';
+import { WellKnownNameEditor, GeoStylerContext } from 'geostyler';
+
+function WellKnownNameEditorExample () {
+
+  const [myContext, setMyContext] = useState({
+    composition: {
+      WellKnownNameEditor: {
+        radiusField: {
+          visibility: true
+        },
+        offsetXField: {
+          visibility: true
+        },
+        offsetYField: {
+          visibility: true
+        },
+        fillColorField: {
+          visibility: true
+        },
+        opacityField: {
+          visibility: true
+        },
+        fillOpacityField: {
+          visibility: true
+        },
+        strokeColorField: {
+          visibility: true
+        },
+        strokeWidthField: {
+          visibility: true
+        },
+        strokeOpacityField: {
+          visibility: true
+        },
+        rotateField: {
+          visibility: true
+        }
+      }
+    }
+  });
+
+  const [symbolizer, setSymbolizer] = useState({
+    kind: 'Mark',
+    wellKnownName: 'circle'
+  });
+
+  const onSymbolizerChange = (s) => {
+    setSymbolizer(s);
+  };
+
+  const onVisibilityChange = (visibility, prop) => {
+    setMyContext(oldContext => {
+      const newContext = {...oldContext};
+      newContext.composition.WellKnownNameEditor[prop].visibility = visibility;
+      return newContext;
+    });
+  };
+
+  return (
+    <div>
+      <div style={{display: 'flex', flexWrap: 'wrap', gap: '15px'}}>
+        <Switch
+          checked={myContext.composition.WellKnownNameEditor.radiusField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'radiusField')}}
+          checkedChildren="Radius"
+          unCheckedChildren="Radius"
+        />
+        <Switch
+          checked={myContext.composition.WellKnownNameEditor.offsetXField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'offsetXField')}}
+          checkedChildren="Offset X"
+          unCheckedChildren="Offset X"
+        />
+        <Switch
+          checked={myContext.composition.WellKnownNameEditor.offsetYField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'offsetYField')}}
+          checkedChildren="Offset Y"
+          unCheckedChildren="Offset Y"
+        />
+        <Switch
+          checked={myContext.composition.WellKnownNameEditor.fillColorField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'fillColorField')}}
+          checkedChildren="Fill-Color"
+          unCheckedChildren="Fill-Color"
+        />
+        <Switch
+          checked={myContext.composition.WellKnownNameEditor.opacityField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'opacityField')}}
+          checkedChildren="Opacity"
+          unCheckedChildren="Opacity"
+        />
+        <Switch
+          checked={myContext.composition.WellKnownNameEditor.fillOpacityField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'fillOpacityField')}}
+          checkedChildren="Fill-Opacity"
+          unCheckedChildren="Fill-Opacity"
+        />
+        <Switch
+          checked={myContext.composition.WellKnownNameEditor.strokeColorField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'strokeColorField')}}
+          checkedChildren="Stroke-Color"
+          unCheckedChildren="Stroke-Color"
+        />
+        <Switch
+          checked={myContext.composition.WellKnownNameEditor.strokeWidthField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'strokeWidthField')}}
+          checkedChildren="Stroke-Width"
+          unCheckedChildren="Stroke-Width"
+        />
+        <Switch
+          checked={myContext.composition.WellKnownNameEditor.strokeOpacityField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'strokeOpacityField')}}
+          checkedChildren="Stroke-Opacity"
+          unCheckedChildren="Stroke-Opacity"
+        />
+        <Switch
+          checked={myContext.composition.WellKnownNameEditor.rotateField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'rotateField')}}
+          checkedChildren="Rotation"
+          unCheckedChildren="Rotation"
+        />
+      </div>
+      <hr />
+      <GeoStylerContext.Provider value={myContext}>
+        <WellKnownNameEditor
+          symbolizer={symbolizer}
+          onSymbolizerChange={onSymbolizerChange}
+        />
+      </GeoStylerContext.Provider>
+    </div>
+  );
+};
+
+<WellKnownNameEditorExample />
+```

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -38,10 +38,7 @@ import OpacityField from '../Field/OpacityField/OpacityField';
 import RadiusField from '../Field/RadiusField/RadiusField';
 import WidthField from '../Field/WidthField/WidthField';
 import RotateField from '../Field/RotateField/RotateField';
-import { CompositionContext, Compositions } from '../../../context/CompositionContext/CompositionContext';
-import CompositionUtil from '../../../Util/CompositionUtil';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
-import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 
 import en_US from '../../../locale/en_US';
 import { Form } from 'antd';
@@ -50,6 +47,7 @@ import _cloneDeep from 'lodash/cloneDeep';
 import _isEqual from 'lodash/isEqual';
 import { GeoStylerLocale } from '../../../locale/locale';
 import OffsetField from '../Field/OffsetField/OffsetField';
+import { useGeoStylerComposition } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 interface WellKnownNameEditorDefaultProps {
   locale: GeoStylerLocale['WellKnownNameEditor'];
@@ -59,17 +57,21 @@ interface WellKnownNameEditorDefaultProps {
 export interface WellKnownNameEditorProps extends Partial<WellKnownNameEditorDefaultProps> {
   symbolizer: MarkSymbolizer;
   onSymbolizerChange?: (changedSymb: Symbolizer) => void;
-  defaultValues?: DefaultValues;
 }
 
 const COMPONENTNAME = 'WellKnownNameEditor';
 
-export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = ({
-  locale =  en_US.WellKnownNameEditor,
-  symbolizer,
-  onSymbolizerChange,
-  defaultValues
-}) => {
+export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) => {
+
+  const composition = useGeoStylerComposition('WellKnownNameEditor', {});
+
+  const composed = {...props, ...composition};
+
+  const {
+    locale =  en_US.WellKnownNameEditor,
+    symbolizer,
+    onSymbolizerChange
+  } = composed;
 
   const onRadiusChange = (value: number) => {
     const symbolizerClone = _cloneDeep(symbolizer);
@@ -154,20 +156,6 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = ({
     }
   };
 
-  /**
-   * Wraps a Form Item around a given element and adds its locale
-   * to the From Item label.
-   */
-  const wrapFormItem = (label: string, element: React.ReactElement): React.ReactElement => {
-    return element == null ? null : (
-      <Form.Item
-        label={label}
-      >
-        {element}
-      </Form.Item>
-    );
-  };
-
   const {
     color,
     fillOpacity,
@@ -181,152 +169,138 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = ({
   } = symbolizer;
 
   return (
-    <CompositionContext.Consumer>
-      {(composition: Compositions) => (
-        <div>
-          {
-            wrapFormItem(
-              locale.radiusLabel,
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'WellKnownNameEditor.radiusField',
-                onChange: onRadiusChange,
-                propName: 'radius',
-                propValue: radius,
-                defaultValue: defaultValues?.WellKnownNameEditor?.defaultRadius,
-                defaultElement: <RadiusField />
-              })
-            )
-          }
-          {
-            wrapFormItem(
-              locale.offsetXLabel,
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'WellKnownNameEditor.offsetXField',
-                onChange: onOffsetXChange,
-                propName: 'offset',
-                propValue: offset?.[0],
-                defaultValue: defaultValues?.WellKnownNameEditor?.defaultOffsetX,
-                defaultElement: <OffsetField />
-              })
-            )
-          }
-          {
-            wrapFormItem(
-              locale.offsetYLabel,
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'WellKnownNameEditor.offsetYField',
-                onChange: onOffsetYChange,
-                propName: 'offset',
-                propValue: offset?.[1],
-                defaultValue: defaultValues?.WellKnownNameEditor?.defaultOffsetY,
-                defaultElement: <OffsetField />
-              })
-            )
-          }
-          {
-            wrapFormItem(
-              locale.fillColorLabel,
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'WellKnownNameEditor.fillColorField',
-                onChange: onColorChange,
-                propName: 'color',
-                propValue: color,
-                defaultValue: defaultValues?.WellKnownNameEditor?.defaultColor,
-                defaultElement: <ColorField />
-              })
-            )
-          }
-          {
-            wrapFormItem(
-              locale.opacityLabel,
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'WellKnownNameEditor.opacityField',
-                onChange: onOpacityChange,
-                propName: 'opacity',
-                propValue: opacity,
-                defaultValue: defaultValues?.WellKnownNameEditor?.defaultOpacity,
-                defaultElement: <OpacityField />
-              })
-            )
-          }
-          {
-            wrapFormItem(
-              locale.fillOpacityLabel,
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'WellKnownNameEditor.fillOpacityField',
-                onChange: onFillOpacityChange,
-                propName: 'opacity',
-                propValue: fillOpacity,
-                defaultValue: defaultValues?.WellKnownNameEditor?.defaultFillOpacity,
-                defaultElement: <OpacityField />
-              })
-            )
-          }
-          {
-            wrapFormItem(
-              locale.strokeColorLabel,
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'WellKnownNameEditor.strokeColorField',
-                onChange: onStrokeColorChange,
-                propName: 'color',
-                propValue: strokeColor,
-                defaultValue: defaultValues?.WellKnownNameEditor?.defaultStrokeColor,
-                defaultElement: <ColorField />
-              })
-            )
-          }
-          {
-            wrapFormItem(
-              locale.strokeWidthLabel,
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'WellKnownNameEditor.strokeWidthField',
-                onChange: onStrokeWidthChange,
-                propName: 'width',
-                propValue: strokeWidth,
-                defaultValue: defaultValues?.WellKnownNameEditor?.defaultStrokeWidth,
-                defaultElement: <WidthField />
-              })
-            )
-          }
-          {
-            wrapFormItem(
-              locale.strokeOpacityLabel,
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'WellKnownNameEditor.strokeOpacityField',
-                onChange: onStrokeOpacityChange,
-                propName: 'opacity',
-                propValue: strokeOpacity,
-                defaultValue: defaultValues?.WellKnownNameEditor?.defaultStrokeOpacity,
-                defaultElement: <OpacityField />
-              })
-            )
-          }
-          {
-            wrapFormItem(
-              locale.rotateLabel,
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'WellKnownNameEditor.rotateField',
-                onChange: onRotateChange,
-                propName: 'rotate',
-                propValue: rotate,
-                defaultValue: defaultValues?.WellKnownNameEditor?.defaultRotate,
-                defaultElement: <RotateField />
-              })
-            )
-          }
-        </div>
-      )}
-    </CompositionContext.Consumer>
+    <div>
+      {
+        composition.radiusField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.radiusLabel}
+          >
+            <RadiusField
+              radius={radius as number}
+              defaultValue={composition.radiusField?.default}
+              onChange={onRadiusChange}
+            />
+          </Form.Item>
+        )
+      }
+      {
+        composition.offsetXField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.offsetXLabel}
+          >
+            <OffsetField
+              offset={offset?.[0] as number}
+              defaultValue={composition.offsetXField?.default}
+              onChange={onOffsetXChange}
+            />
+          </Form.Item>
+        )
+      }
+      {
+        composition.offsetYField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.offsetYLabel}
+          >
+            <OffsetField
+              offset={offset?.[1] as number}
+              defaultValue={composition.offsetYField?.default}
+              onChange={onOffsetYChange}
+            />
+          </Form.Item>
+        )
+      }
+      {
+        composition.fillColorField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.fillColorLabel}
+          >
+            <ColorField
+              color={color as string}
+              defaultValue={composition.fillColorField?.default}
+              onChange={onColorChange}
+            />
+          </Form.Item>
+        )
+      }
+      {
+        composition.opacityField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.opacityLabel}
+          >
+            <OpacityField
+              opacity={opacity as number}
+              defaultValue={composition.opacityField?.default}
+              onChange={onOpacityChange}
+            />
+          </Form.Item>
+        )
+      }
+      {
+        composition.fillOpacityField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.fillOpacityLabel}
+          >
+            <OpacityField
+              opacity={fillOpacity as number}
+              defaultValue={composition.fillOpacityField?.default}
+              onChange={onFillOpacityChange}
+            />
+          </Form.Item>
+        )
+      }
+      {
+        composition.strokeColorField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.strokeColorLabel}
+          >
+            <ColorField
+              color={strokeColor as string}
+              defaultValue={composition.strokeColorField?.default}
+              onChange={onStrokeColorChange}
+            />
+          </Form.Item>
+        )
+      }
+      {
+        composition.strokeWidthField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.strokeWidthLabel}
+          >
+            <WidthField
+              width={strokeWidth as number}
+              defaultValue={composition.strokeWidthField?.default}
+              onChange={onStrokeWidthChange}
+            />
+          </Form.Item>
+        )
+      }
+      {
+        composition.strokeOpacityField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.strokeOpacityLabel}
+          >
+            <OpacityField
+              opacity={strokeOpacity as number}
+              defaultValue={composition.strokeOpacityField?.default}
+              onChange={onStrokeOpacityChange}
+            />
+          </Form.Item>
+        )
+      }
+      {
+        composition.rotateField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.rotateLabel}
+          >
+            <RotateField
+              rotate={rotate as number}
+              defaultValue={composition.rotateField?.default}
+              onChange={onRotateChange}
+            />
+          </Form.Item>
+        )
+      }
+    </div>
   );
 };
 


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This makes use of the `GeoStylerContext` in the `<WellKnownNameEditor>`.

BREAKING CHANGE: This removes the support for the deprecated CompositionContext in favor of the new GeoStylerContext for the WellKnownNameEditor. This also removes the `defaultValues` property for the WellKnownNameEditor. Please use GeoStylerContext.composition instead.

![image](https://user-images.githubusercontent.com/12186477/237055917-3bbcedca-22d5-4915-9fc9-2f923272b533.png)

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

