### PR TITLE
feat: use GeoStylerContext composition for TextEditor

### DIFF
--- a/src/Component/Symbolizer/TextEditor/TextEditor.example.md
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.example.md
@@ -83,3 +83,143 @@ class TextEditorExample extends React.Component {
 
 <TextEditorExample />
 ```
+
+This demonstrates the usage of `TextEditor` with `GeoStylerContext`.
+
+```jsx
+import React, { useState } from 'react';
+import { Switch } from 'antd';
+import { TextEditor, GeoStylerContext } from 'geostyler';
+
+function TextEditorExample () {
+
+  const [myContext, setMyContext] = useState({
+    composition: {
+      TextEditor: {
+        templateField: {
+          visibility: true
+        },
+        colorField: {
+          visibility: true
+        },
+        fontField: {
+          visibility: true
+        },
+        opacityField: {
+          visibility: true
+        },
+        sizeField: {
+          visibility: true
+        },
+        offsetXField: {
+          visibility: true
+        },
+        offsetYField: {
+          visibility: true
+        },
+        rotateField: {
+          visibility: true
+        },
+        haloColorField: {
+          visibility: true
+        },
+        haloWidthField: {
+          visibility: true
+        }
+      }
+    }
+  });
+
+  const [symbolizer, setSymbolizer] = useState({
+    kind: 'Text'
+  });
+
+  const onSymbolizerChange = (s) => {
+    setSymbolizer(s);
+  };
+
+  const onVisibilityChange = (visibility, prop) => {
+    setMyContext(oldContext => {
+      const newContext = {...oldContext};
+      newContext.composition.TextEditor[prop].visibility = visibility;
+      return newContext;
+    });
+  };
+
+  return (
+    <div>
+      <div style={{display: 'flex', flexWrap: 'wrap', gap: '15px'}}>
+        <Switch
+          checked={myContext.composition.TextEditor.templateField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'templateField')}}
+          checkedChildren="Template"
+          unCheckedChildren="Template"
+        />
+        <Switch
+          checked={myContext.composition.TextEditor.colorField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'colorField')}}
+          checkedChildren="Text-Color"
+          unCheckedChildren="Text-Color"
+        />
+        <Switch
+          checked={myContext.composition.TextEditor.fontField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'fontField')}}
+          checkedChildren="Font"
+          unCheckedChildren="Font"
+        />
+        <Switch
+          checked={myContext.composition.TextEditor.opacityField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'opacityField')}}
+          checkedChildren="Text-Opacity"
+          unCheckedChildren="Text-Opacity"
+        />
+        <Switch
+          checked={myContext.composition.TextEditor.sizeField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'sizeField')}}
+          checkedChildren="Text-Size"
+          unCheckedChildren="Text-Size"
+        />
+        <Switch
+          checked={myContext.composition.TextEditor.offsetXField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'offsetXField')}}
+          checkedChildren="Offset X"
+          unCheckedChildren="Offset X"
+        />
+        <Switch
+          checked={myContext.composition.TextEditor.offsetYField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'offsetYField')}}
+          checkedChildren="Offset Y"
+          unCheckedChildren="Offset Y"
+        />
+        <Switch
+          checked={myContext.composition.TextEditor.rotateField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'rotateField')}}
+          checkedChildren="Rotation"
+          unCheckedChildren="Rotation"
+        />
+        <Switch
+          checked={myContext.composition.TextEditor.haloColorField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'haloColorField')}}
+          checkedChildren="Halo-Color"
+          unCheckedChildren="Halo-Color"
+        />
+        <Switch
+          checked={myContext.composition.TextEditor.haloWidthField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'haloWidthField')}}
+          checkedChildren="Halo-Width"
+          unCheckedChildren="Halo-Width"
+        />
+      </div>
+      <hr />
+      <GeoStylerContext.Provider value={myContext}>
+        <TextEditor
+          symbolizer={symbolizer}
+          onSymbolizerChange={onSymbolizerChange}
+        />
+      </GeoStylerContext.Provider>
+    </div>
+  );
+};
+
+<TextEditorExample />
+```

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -47,8 +47,6 @@ import WidthField from '../Field/WidthField/WidthField';
 import FontPicker from '../Field/FontPicker/FontPicker';
 import OffsetField from '../Field/OffsetField/OffsetField';
 import RotateField from '../Field/RotateField/RotateField';
-import { CompositionContext, Compositions } from '../../../context/CompositionContext/CompositionContext';
-import CompositionUtil from '../../../Util/CompositionUtil';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
 import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 
@@ -65,6 +63,7 @@ import {
   UnsupportedPropertiesContext
 } from '../../../context/UnsupportedPropertiesContext/UnsupportedPropertiesContext';
 import UnsupportedPropertiesUtil from '../../../Util/UnsupportedPropertiesUtil';
+import { useGeoStylerComposition } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 interface TextEditorDefaultProps {
   locale: GeoStylerLocale['TextEditor'];
@@ -85,13 +84,18 @@ const COMPONENTNAME = 'TextEditor';
  * where words wrapped in double curly braces ({{}}) will be understood as
  * feature properties and text without curly braces as static text.
  */
-export const TextEditor: React.FC<TextEditorProps> = ({
-  locale = en_US.TextEditor,
-  symbolizer,
-  onSymbolizerChange,
-  internalDataDef,
-  defaultValues
-}) => {
+export const TextEditor: React.FC<TextEditorProps> = (props) => {
+
+  const composition = useGeoStylerComposition('TextEditor', {});
+
+  const composed = {...props, ...composition};
+
+  const {
+    locale = en_US.TextEditor,
+    symbolizer,
+    onSymbolizerChange,
+    internalDataDef
+  } = composed;
 
   const {
     unsupportedProperties,
@@ -212,181 +216,153 @@ export const TextEditor: React.FC<TextEditorProps> = ({
   };
 
   return (
-    <CompositionContext.Consumer>
-      {(composition: Compositions) => (
-        <div className="gs-text-symbolizer-editor" >
+    <div className="gs-text-symbolizer-editor" >
+      {
+        composition.templateField?.visibility === false ? null : (
           <Form.Item
             label={locale.templateFieldLabel}
             {...getSupportProps('label')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'TextEditor.templateField',
-                onChange: onLabelChange,
-                propName: 'value',
-                propValue: symbolizer.label || '',
-                defaultValue: defaultValues?.TextEditor?.defaultLabel,
-                defaultElement: (
-                  <Mentions
-                    className="editor-field"
-                    placeholder={locale.templateFieldLabel}
-                    prefix="{{"
-                    notFoundContent={locale.attributeNotFound}
-                  >
-                    {properties.map(p => <MentionOption key={p} value={`${p}}}`}>{p}</MentionOption>)}
-                  </Mentions>
-                )
-              })
-            }
+            <Mentions
+              className="editor-field"
+              value={symbolizer.label as string || ''}
+              defaultValue={composition.templateField?.default}
+              onChange={onLabelChange}
+              placeholder={locale.templateFieldLabel}
+              prefix="{{"
+              notFoundContent={locale.attributeNotFound}
+            >
+              {properties.map(p => <MentionOption key={p} value={`${p}}}`}>{p}</MentionOption>)}
+            </Mentions>
           </Form.Item>
+        )
+      }
+      {
+        composition.colorField?.visibility === false ? null : (
           <Form.Item
             label={locale.colorLabel}
             {...getSupportProps('color')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'TextEditor.colorField',
-                onChange: onColorChange,
-                propName: 'color',
-                propValue: color,
-                defaultValue: defaultValues?.TextEditor?.defaultColor,
-                defaultElement: <ColorField />
-              })
-            }
+            <ColorField
+              color={color as string}
+              defaultValue={composition.colorField?.default}
+              onChange={onColorChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.fontField?.visibility === false ? null : (
           <Form.Item
             label={locale.fontLabel}
             {...getSupportProps('font')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'TextEditor.fontField',
-                onChange: onFontChange,
-                propName: 'font',
-                propValue: font,
-                defaultValue: defaultValues?.TextEditor?.defaultFont,
-                defaultElement: <FontPicker />
-              })
-            }
+            <FontPicker
+              font={font as string[]}
+              onChange={onFontChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.opacityField?.visibility === false ? null : (
           <Form.Item
             label={locale.opacityLabel}
             {...getSupportProps('opacity')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'TextEditor.opacityField',
-                onChange: onOpacityChange,
-                propName: 'opacity',
-                propValue: opacity,
-                defaultValue: defaultValues?.TextEditor?.defaultOpacity,
-                defaultElement: <OpacityField />
-              })
-            }
+            <OpacityField
+              opacity={opacity as number}
+              defaultValue={composition.opacityField?.default}
+              onChange={onOpacityChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.sizeField?.visibility === false ? null : (
           <Form.Item
             label={locale.sizeLabel}
             {...getSupportProps('size')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'TextEditor.sizeField',
-                onChange: onSizeChange,
-                propName: 'width',
-                propValue: size,
-                defaultValue: defaultValues?.TextEditor?.defaultSize,
-                defaultElement: <WidthField />
-              })
-            }
+            <WidthField
+              width={size as number}
+              defaultValue={composition.sizeField?.default}
+              onChange={onSizeChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.offsetXField?.visibility === false ? null : (
           <Form.Item
             label={locale.offsetXLabel}
             {...getSupportProps('offset')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'TextEditor.offsetXField',
-                onChange: onOffsetXChange,
-                propName: 'offset',
-                propValue: offsetX,
-                defaultValue: defaultValues?.TextEditor?.defaultOffsetX,
-                defaultElement: <OffsetField />
-              })
-            }
+            <OffsetField
+              offset={offsetX}
+              defaultValue={composition.offsetXField?.default}
+              onChange={onOffsetXChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.offsetYField?.visibility === false ? null : (
           <Form.Item
             label={locale.offsetYLabel}
             {...getSupportProps('offset')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'TextEditor.offsetYField',
-                onChange: onOffsetYChange,
-                propName: 'offset',
-                propValue: offsetY,
-                defaultValue: defaultValues?.TextEditor?.defaultOffsetY,
-                defaultElement: <OffsetField />
-              })
-            }
+            <OffsetField
+              offset={offsetY}
+              defaultValue={composition.offsetYField?.default}
+              onChange={onOffsetYChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.rotateField?.visibility === false ? null : (
           <Form.Item
             label={locale.rotateLabel}
             {...getSupportProps('rotate')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'TextEditor.rotateField',
-                onChange: onRotateChange,
-                propName: 'rotate',
-                propValue: rotate,
-                defaultValue: defaultValues?.TextEditor?.defaultRotate,
-                defaultElement: <RotateField />
-              })
-            }
+            <RotateField
+              rotate={rotate as number}
+              defaultValue={composition.rotateField?.default}
+              onChange={onRotateChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.haloColorField?.visibility === false ? null : (
           <Form.Item
             label={locale.haloColorLabel}
             {...getSupportProps('haloColor')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'TextEditor.haloColorField',
-                onChange: onHaloColorChange,
-                propName: 'color',
-                propValue: haloColor,
-                defaultValue: defaultValues?.TextEditor?.defaultHaloColor,
-                defaultElement: <ColorField />
-              })
-            }
+            <ColorField
+              color={haloColor as string}
+              defaultValue={composition.haloColorField?.default}
+              onChange={onHaloColorChange}
+            />
           </Form.Item>
+        )
+      }
+      {
+        composition.haloWidthField?.visibility === false ? null : (
           <Form.Item
             label={locale.haloWidthLabel}
             {...getSupportProps('haloWidth')}
           >
-            {
-              CompositionUtil.handleComposition({
-                composition,
-                path: 'TextEditor.haloWidthField',
-                onChange: onHaloWidthChange,
-                propName: 'width',
-                propValue: haloWidth,
-                defaultValue: defaultValues?.TextEditor?.defaultHaloWidth,
-                defaultElement: <WidthField />
-              })
-            }
+            <WidthField
+              width={haloWidth as number}
+              defaultValue={composition.haloWidthField?.default}
+              onChange={onHaloWidthChange}
+            />
           </Form.Item>
-        </div>
-      )}
-    </CompositionContext.Consumer>
+        )
+      }
+    </div>
   );
 };
 

--- a/src/context/GeoStylerContext/GeoStylerContext.tsx
+++ b/src/context/GeoStylerContext/GeoStylerContext.tsx
@@ -102,7 +102,8 @@ export type CompositionContext = {
     visibility?: boolean;
     templateField?: InputConfig<string>;
     colorField?: InputConfig<ColorFieldProps['color']>;
-    fontField?: InputConfig<FontPickerProps['font']>;
+    // TODO add support for default values in FontPicker
+    fontField?: Omit<InputConfig<FontPickerProps['font']>, 'default'>;
     opacityField?: InputConfig<OpacityFieldProps['opacity']>;
     sizeField?: InputConfig<SizeFieldProps['size']>;
     offsetXField?: InputConfig<OffsetFieldProps['offset']>;


### PR DESCRIPTION


<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This makes use of the `GeoStylerContext` for the `<TextEditor>`.

BREAKING CHANGE: This removes the support for the deprecated CompositionContext in favor of the new GeoStylerContext for the TextEditor. This also removes the `defaultValues` property for the TextEditor. Please use GeoStylerContext.composition instead.

![image](https://github.com/geostyler/geostyler/assets/12186477/c103d9d7-7457-420d-8f0b-2eae578eaadf)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

