### PR TITLE
feat: use GeoStylerContext composition for RasterChannelEditor

### DIFF
--- a/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
+++ b/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
@@ -42,6 +42,7 @@ import GammaField from '../GammaField/GammaField';
 import _get from 'lodash/get';
 import _cloneDeep from 'lodash/cloneDeep';
 import { GeoStylerLocale } from '../../../../locale/locale';
+import { useGeoStylerComposition } from '../../../../context/GeoStylerContext/GeoStylerContext';
 
 // default props
 interface ChannelFieldDefaultProps {
@@ -59,13 +60,19 @@ export interface ChannelFieldProps extends Partial<ChannelFieldDefaultProps> {
 /**
  * ChannelField to select different Channel options
  */
-export const ChannelField: React.FC<ChannelFieldProps> = ({
-  onChange,
-  locale = en_US.ChannelField,
-  sourceChannelNames,
-  contrastEnhancementTypes = ['histogram', 'normalize'],
-  channel
-}) => {
+export const ChannelField: React.FC<ChannelFieldProps> = (props) => {
+
+  const composition = useGeoStylerComposition('RasterChannelEditor', {});
+
+  const composed = {...props, ...composition};
+
+  const {
+    onChange,
+    locale = en_US.ChannelField,
+    sourceChannelNames,
+    contrastEnhancementTypes = ['histogram', 'normalize'],
+    channel
+  } = composed;
 
   const updateChannel = (key: string, value: any) => {
     let newChannel: Channel;
@@ -115,32 +122,45 @@ export const ChannelField: React.FC<ChannelFieldProps> = ({
 
   return (
     <div>
-      <Form.Item
-        label={locale.sourceChannelNameLabel}
-      >
-        <SourceChannelNameField
-          onChange={onSourceChannelNameChange}
-          sourceChannelName={sourceChannelName as string}
-          sourceChannelNames={sourceChannelNames}
-        />
-      </Form.Item>
-      <Form.Item
-        label={locale.contrastEnhancementTypeLabel}
-      >
-        <ContrastEnhancementField
-          contrastEnhancement={contrastEnhancementType}
-          contrastEnhancementOptions={contrastEnhancementTypes}
-          onChange={onContrastEnhancementChange}
-        />
-      </Form.Item>
-      <Form.Item
-        label={locale.gammaValueLabel}
-      >
-        <GammaField
-          gamma={gamma as any}
-          onChange={onGammaChange}
-        />
-      </Form.Item>
+      {
+        composition.sourceChannelNameField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.sourceChannelNameLabel}
+          >
+            <SourceChannelNameField
+              onChange={onSourceChannelNameChange}
+              sourceChannelName={sourceChannelName as string}
+              sourceChannelNames={sourceChannelNames}
+            />
+          </Form.Item>
+        )
+      }
+      {
+        composition.contrastEnhancementField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.contrastEnhancementTypeLabel}
+          >
+            <ContrastEnhancementField
+              contrastEnhancement={contrastEnhancementType}
+              contrastEnhancementOptions={contrastEnhancementTypes}
+              onChange={onContrastEnhancementChange}
+            />
+          </Form.Item>
+        )
+      }
+      {
+        composition.gammaValueField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.gammaValueLabel}
+          >
+            <GammaField
+              gamma={gamma as any}
+              defaultValue={composition.gammaValueField?.default}
+              onChange={onGammaChange}
+            />
+          </Form.Item>
+        )
+      }
     </div>
   );
 };

--- a/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
+++ b/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
@@ -49,6 +49,7 @@ import ChannelField from '../Field/ChannelField/ChannelField';
 import _get from 'lodash/get';
 import _cloneDeep from 'lodash/cloneDeep';
 import { GeoStylerLocale } from '../../../locale/locale';
+import { useGeoStylerComposition } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 // default props
 interface RasterChannelEditorDefaultProps {
@@ -68,15 +69,23 @@ const COMPONENTNAME = 'RasterChannelEditor';
 /**
  * RasterChannelEditor to map bands to rgb or grayscale
  */
-export const RasterChannelEditor: React.FC<RasterChannelEditorProps> = ({
-  locale = en_US.RasterChannelEditor,
-  sourceChannelNames,
-  onChange,
-  channelSelection,
-  contrastEnhancementTypes
-}) => {
+export const RasterChannelEditor: React.FC<RasterChannelEditorProps> = (props) => {
 
-  const defaultRgbOrGray = !channelSelection ? 'rgb' : isGrayChannel(channelSelection) ? 'gray' : 'rgb';
+  const composition = useGeoStylerComposition('RasterChannelEditor', {});
+
+  const composed = {...props, ...composition};
+
+  const {
+    locale = en_US.RasterChannelEditor,
+    sourceChannelNames,
+    onChange,
+    channelSelection,
+    contrastEnhancementTypes
+  } = composed;
+
+  const defaultRgbOrGray = !channelSelection
+    ? composition.channelSelectionField?.default || 'rgb'
+    : isGrayChannel(channelSelection) ? 'gray' : 'rgb';
   const [rgbOrGray, setRgbOrGray] = useState(defaultRgbOrGray);
   const defaultSelectedTab = !channelSelection ? 'red' : isGrayChannel(channelSelection) ? 'gray' : 'red';
   const [selectedTab, setSelectedTab] = useState<'red' | 'green' | 'blue' | 'gray'>(defaultSelectedTab);
@@ -141,90 +150,99 @@ export const RasterChannelEditor: React.FC<RasterChannelEditorProps> = ({
       >
         <span>{locale.titleLabel}</span>
       </Form.Item>
-      <Form.Item
-        label={locale.channelSelectionLabel}
-      >
-        <Select
-          className="editor-field rgb-or-gray-field"
-          allowClear={true}
-          value={rgbOrGray as 'rgb' | 'gray'}
-          onChange={onSelectionChange}
-        >
-          <Option
-            key="rgb"
-            value="rgb"
-          >{locale.channelSelectionRgbLabel}</Option>
-          <Option
-            key="gray"
-            value="gray"
-          >{locale.channelSelectionGrayLabel}</Option>
-        </Select>
-      </Form.Item>
+      {
+        composition.channelSelectionField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.channelSelectionLabel}
+          >
+            <Select
+              className="editor-field rgb-or-gray-field"
+              allowClear={true}
+              value={rgbOrGray as 'rgb' | 'gray'}
+              onChange={onSelectionChange}
+            >
+              <Option
+                key="rgb"
+                value="rgb"
+              >{locale.channelSelectionRgbLabel}</Option>
+              <Option
+                key="gray"
+                value="gray"
+              >{locale.channelSelectionGrayLabel}</Option>
+            </Select>
+          </Form.Item>
+        )
+      }
       { !rgbOrGray ? null :
-        (
+        rgbOrGray === 'rgb' ? (
           <Tabs
             onChange={onTabChange}
             type="card"
             activeKey={selectedTab}
-            items={
-              rgbOrGray === 'rgb' ? (
-                [{
-                  key: 'red',
-                  label: getTabLabel('red'),
-                  children: (
-                    <ChannelField
-                      channel={redChannel}
-                      contrastEnhancementTypes={contrastEnhancementTypes}
-                      onChange={(channel: Channel) => {
-                        onChannelFieldChange('red', channel);
-                      }}
-                      sourceChannelNames={sourceChannelNames}
-                    />
-                  )
-                }, {
-                  key: 'green',
-                  label: getTabLabel('green'),
-                  children: (
-                    <ChannelField
-                      channel={greenChannel}
-                      contrastEnhancementTypes={contrastEnhancementTypes}
-                      onChange={(channel: Channel) => {
-                        onChannelFieldChange('green', channel);
-                      }}
-                      sourceChannelNames={sourceChannelNames}
-                    />
-                  )
-                }, {
-                  key: 'blue',
-                  label: getTabLabel('blue'),
-                  children: (
-                    <ChannelField
-                      channel={blueChannel}
-                      contrastEnhancementTypes={contrastEnhancementTypes}
-                      onChange={(channel: Channel) => {
-                        onChannelFieldChange('blue', channel);
-                      }}
-                      sourceChannelNames={sourceChannelNames}
-                    />
-                  )
-                }]
-              ) : (
-                [{
-                  key: 'gray',
-                  label: getTabLabel('gray'),
-                  children: (
-                    <ChannelField
-                      channel={grayChannel}
-                      contrastEnhancementTypes={contrastEnhancementTypes}
-                      onChange={(channel: Channel) => {
-                        onChannelFieldChange('gray', channel);
-                      }}
-                      sourceChannelNames={sourceChannelNames}
-                    />
-                  )
-                }]
-              )
-            }
+            items={[
+              {
+                key: 'red',
+                label: getTabLabel('red'),
+                children: (
+                  <ChannelField
+                    channel={redChannel}
+                    contrastEnhancementTypes={contrastEnhancementTypes}
+                    onChange={(channel: Channel) => {
+                      onChannelFieldChange('red', channel);
+                    }}
+                    sourceChannelNames={sourceChannelNames}
+                  />
+                )
+              }, {
+                key: 'green',
+                label: getTabLabel('green'),
+                children: (
+                  <ChannelField
+                    channel={greenChannel}
+                    contrastEnhancementTypes={contrastEnhancementTypes}
+                    onChange={(channel: Channel) => {
+                      onChannelFieldChange('green', channel);
+                    }}
+                    sourceChannelNames={sourceChannelNames}
+                  />
+                )
+              }, {
+                key: 'blue',
+                label: getTabLabel('blue'),
+                children: (
+                  <ChannelField
+                    channel={blueChannel}
+                    contrastEnhancementTypes={contrastEnhancementTypes}
+                    onChange={(channel: Channel) => {
+                      onChannelFieldChange('blue', channel);
+                    }}
+                    sourceChannelNames={sourceChannelNames}
+                  />
+                )
+              }
+            ]}
+          />
+        ) : (
+          <Tabs
+            onChange={onTabChange}
+            type="card"
+            activeKey={'gray'}
+            items={[
+              {
+                key: 'gray',
+                label: getTabLabel('gray'),
+                children: (
+                  <ChannelField
+                    channel={grayChannel}
+                    contrastEnhancementTypes={contrastEnhancementTypes}
+                    onChange={(channel: Channel) => {
+                      onChannelFieldChange('gray', channel);
+                    }}
+                    sourceChannelNames={sourceChannelNames}
+                  />
+                )
+              }
+            ]}
           />
         )
       }

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.example.md
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.example.md
@@ -96,7 +96,19 @@ function RasterEditorExample () {
         visibility: true
       },
       RasterChannelEditor: {
-        visibility: true
+        visibility: true,
+        channelSelectionField: {
+          visibility: true
+        },
+        sourceChannelNameField: {
+          visibility: true
+        },
+        contrastEnhancementField: {
+          visibility: true
+        },
+        gammaValueField: {
+          visibility: true
+        }
       }
     }
   });
@@ -109,26 +121,18 @@ function RasterEditorExample () {
     setSymbolizer(s);
   };
 
-  const onVisibilityChange = (visibility, prop) => {
+  const onVisibilityChange = (visibility, editor, prop) => {
     setMyContext(oldContext => {
       const newContext = {...oldContext};
-      newContext.composition.RasterEditor[prop].visibility = visibility;
+      newContext.composition[editor][prop].visibility = visibility;
       return newContext;
     });
   };
 
-  const onCMVisibilityChange = (visibility) => {
+  const onEditorVisibilityChange = (visibility, editor) => {
     setMyContext(oldContext => {
       const newContext = {...oldContext};
-      newContext.composition.ColorMapEditor.visibility = visibility;
-      return newContext;
-    });
-  };
-
-  const onRCVisibilityChange = (visibility) => {
-    setMyContext(oldContext => {
-      const newContext = {...oldContext};
-      newContext.composition.RasterChannelEditor.visibility = visibility;
+      newContext.composition[editor].visibility = visibility;
       return newContext;
     });
   };
@@ -138,33 +142,57 @@ function RasterEditorExample () {
       <div style={{display: 'flex', flexWrap: 'wrap', gap: '15px'}}>
         <Switch
           checked={myContext.composition.RasterEditor.opacityField.visibility}
-          onChange={visibility => {onVisibilityChange(visibility, 'opacityField')}}
+          onChange={visibility => {onVisibilityChange(visibility, 'RasterEditor', 'opacityField')}}
           checkedChildren="Opacity"
           unCheckedChildren="Opacity"
         />
         <Switch
           checked={myContext.composition.RasterEditor.contrastEnhancementField.visibility}
-          onChange={visibility => {onVisibilityChange(visibility, 'contrastEnhancementField')}}
+          onChange={visibility => {onVisibilityChange(visibility, 'RasterEditor', 'contrastEnhancementField')}}
           checkedChildren="Contrast Enhancement"
           unCheckedChildren="Contrast Enhancement"
         />
         <Switch
           checked={myContext.composition.RasterEditor.gammaValueField.visibility}
-          onChange={visibility => {onVisibilityChange(visibility, 'gammaValueField')}}
+          onChange={visibility => {onVisibilityChange(visibility, 'RasterEditor', 'gammaValueField')}}
           checkedChildren="Gamma"
           unCheckedChildren="Gamma"
         />
         <Switch
           checked={myContext.composition.ColorMapEditor.visibility}
-          onChange={visibility => {onCMVisibilityChange(visibility)}}
+          onChange={visibility => {onEditorVisibilityChange(visibility, 'ColorMapEditor')}}
           checkedChildren="Color Map"
           unCheckedChildren="Color Map"
         />
         <Switch
           checked={myContext.composition.RasterChannelEditor.visibility}
-          onChange={visibility => {onRCVisibilityChange(visibility)}}
+          onChange={visibility => {onEditorVisibilityChange(visibility, 'RasterChannelEditor')}}
           checkedChildren="Channel Selection"
           unCheckedChildren="Channel Selection"
+        />
+        <Switch
+          checked={myContext.composition.RasterChannelEditor.channelSelectionField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'RasterChannelEditor', 'channelSelectionField')}}
+          checkedChildren="Edit Channels"
+          unCheckedChildren="Edit Channels"
+        />
+        <Switch
+          checked={myContext.composition.RasterChannelEditor.sourceChannelNameField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'RasterChannelEditor', 'sourceChannelNameField')}}
+          checkedChildren="Channel Name"
+          unCheckedChildren="Channel Name"
+        />
+        <Switch
+          checked={myContext.composition.RasterChannelEditor.contrastEnhancementField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'RasterChannelEditor', 'contrastEnhancementField')}}
+          checkedChildren="Channel Contrast Enhancement"
+          unCheckedChildren="Channel Contrast Enhancement"
+        />
+        <Switch
+          checked={myContext.composition.RasterChannelEditor.gammaValueField.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'RasterChannelEditor', 'gammaValueField')}}
+          checkedChildren="Channel Gamma"
+          unCheckedChildren="Channel Gamma"
         />
       </div>
       <hr />

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -47,7 +47,6 @@ import GammaField from '../Field/GammaField/GammaField';
 import DataUtil from '../../../Util/DataUtil';
 import ColorMapEditor from '../ColorMapEditor/ColorMapEditor';
 import withDefaultsContext from '../../../hoc/withDefaultsContext';
-import { DefaultValues } from '../../../context/DefaultValueContext/DefaultValueContext';
 
 import './RasterEditor.less';
 
@@ -74,7 +73,6 @@ export interface RasterEditorProps extends Partial<RasterEditorDefaultProps> {
   colorRamps?: {
     [name: string]: string[];
   };
-  defaultValues?: DefaultValues;
 }
 
 type ShowDisplay = 'symbolizer' | 'colorMap' | 'contrastEnhancement';

--- a/src/context/GeoStylerContext/GeoStylerContext.tsx
+++ b/src/context/GeoStylerContext/GeoStylerContext.tsx
@@ -22,6 +22,7 @@ import {
 import { GammaFieldProps } from '../../Component/Symbolizer/Field/GammaField/GammaField';
 import { IconLibrary } from '../../Component/Symbolizer/IconSelector/IconSelector';
 import { RendererProps } from '../../Component/Renderer/Renderer/Renderer';
+import { ChannelFieldProps } from '../../Component/Symbolizer/Field/ChannelField/ChannelField';
 
 export type UnsupportedPropertiesContextOptions = {
   hideUnsupported?: boolean;
@@ -121,6 +122,12 @@ export type CompositionContext = {
   };
   RasterChannelEditor?: {
     visibility?: boolean;
+    channelSelectionField?: InputConfig<'rgb'|'gray'>;
+    // TODO add support for default values in SourceChannelNameField
+    sourceChannelNameField?: Omit<InputConfig<ChannelFieldProps['channel']['sourceChannelName']>, 'default'>;
+    // TODO add support for default values in ContrastEnhancementField
+    contrastEnhancementField?: Omit<InputConfig<ContrastEnhancementFieldProps['contrastEnhancement']>, 'default'>;
+    gammaValueField?: InputConfig<GammaFieldProps['gamma']>;
   };
   ColorMapEditor?: {
     visibility?: boolean;


### PR DESCRIPTION


<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This makes use of `GeoStylerContext` for the `<RasterChannelEditor>`.

BREAKING CHANGE: This removes the `defaultValues` property from RasterEditor. Please use GeoStylerContext.composition instead.

![geostyler-rasterchanneleditor-composition](https://github.com/geostyler/geostyler/assets/12186477/9c580349-f56a-4c13-9e4f-21249539be1a)

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

