### PR TITLE
Replace react-rnd windows with modals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "lodash": "^4.17.21",
         "monaco-editor": "^0.38.0",
         "react-color": "^2.19.3",
-        "react-rnd": "^10.4.1",
         "typescript-json-schema": "^0.56.0"
       },
       "devDependencies": {
@@ -8335,6 +8334,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10651,11 +10651,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "node_modules/fast-memoize": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "node_modules/fast-xml-parser": {
       "version": "4.0.11",
@@ -21600,18 +21595,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/re-resizable": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.6.tgz",
-      "integrity": "sha512-0xYKS5+Z0zk+vICQlcZW+g54CcJTTmHluA7JUUgvERDxnKAnytylcyPsA+BSFi759s5hPlHmBRegFrwXs2FuBQ==",
-      "dependencies": {
-        "fast-memoize": "^2.5.1"
-      },
-      "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -21992,19 +21975,6 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/react-draggable": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
-      "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
-      "dependencies": {
-        "clsx": "^1.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": ">= 16.3.0",
-        "react-dom": ">= 16.3.0"
-      }
-    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -22052,25 +22022,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/react-rnd": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.4.1.tgz",
-      "integrity": "sha512-0m887AjQZr6p2ADLNnipquqsDq4XJu/uqVqI3zuoGD19tRm6uB83HmZWydtkilNp5EWsOHbLGF4IjWMdd5du8Q==",
-      "dependencies": {
-        "re-resizable": "6.9.6",
-        "react-draggable": "4.4.5",
-        "tslib": "2.3.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      }
-    },
-    "node_modules/react-rnd/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/react-simple-code-editor": {
       "version": "0.13.1",
@@ -32515,7 +32466,8 @@
     "clsx": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "dev": true
     },
     "co": {
       "version": "4.6.0",
@@ -34274,11 +34226,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "fast-memoize": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-      "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
     },
     "fast-xml-parser": {
       "version": "4.0.11",
@@ -42149,14 +42096,6 @@
         "rc-util": "^5.15.0"
       }
     },
-    "re-resizable": {
-      "version": "6.9.6",
-      "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.6.tgz",
-      "integrity": "sha512-0xYKS5+Z0zk+vICQlcZW+g54CcJTTmHluA7JUUgvERDxnKAnytylcyPsA+BSFi759s5hPlHmBRegFrwXs2FuBQ==",
-      "requires": {
-        "fast-memoize": "^2.5.1"
-      }
-    },
     "react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -42433,15 +42372,6 @@
         "scheduler": "^0.23.0"
       }
     },
-    "react-draggable": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.4.5.tgz",
-      "integrity": "sha512-OMHzJdyJbYTZo4uQE393fHcqqPYsEtkjfMgvCHr6rejT+Ezn4OZbNyGH50vv+SunC1RMvwOTSWkEODQLzw1M9g==",
-      "requires": {
-        "clsx": "^1.1.1",
-        "prop-types": "^15.8.1"
-      }
-    },
     "react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -42477,23 +42407,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
-    },
-    "react-rnd": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/react-rnd/-/react-rnd-10.4.1.tgz",
-      "integrity": "sha512-0m887AjQZr6p2ADLNnipquqsDq4XJu/uqVqI3zuoGD19tRm6uB83HmZWydtkilNp5EWsOHbLGF4IjWMdd5du8Q==",
-      "requires": {
-        "re-resizable": "6.9.6",
-        "react-draggable": "4.4.5",
-        "tslib": "2.3.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        }
-      }
     },
     "react-simple-code-editor": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "lodash": "^4.17.21",
     "monaco-editor": "^0.38.0",
     "react-color": "^2.19.3",
-    "react-rnd": "^10.4.1",
     "typescript-json-schema": "^0.56.0"
   },
   "devDependencies": {

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.less
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.less
@@ -29,6 +29,15 @@
 .gs-comparison-filter-ui {
   padding-left: 5px;
   display: flex;
+  flex: 1;
+
+  .gs-attribute-combo {
+    flex: 1;
+  }
+
+  .gs-text-filter-field {
+    flex: 1;
+  }
 
   &.micro {
     .ant-form-item {

--- a/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.less
+++ b/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.less
@@ -26,32 +26,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-.filter-editor-window {
-  background-color: white;
-  border: 3px solid grey;
-  border-radius: 3px;
-  z-index: 10;
+.filter-editor-modal {
+  .ant-modal-body {
+    padding-top: 15px;
 
-  .header {
-    background-color: lightgrey;
-    padding: 3px;
-    display: flex;
-  }
-
-  .header .title {
-    flex: 1;
-  }
-
-  .filter-editor-window-body {
-    padding: 10px;
-    min-width: 400px;
-  }
-
-  .filter-editor-window-header:hover {
-    cursor: grab;
-  }
-
-  .filter-editor-window-header:active {
-    cursor: grabbing;
+    max-height: calc(100vh - 100px);
+    overflow: auto;
   }
 }

--- a/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
+++ b/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
@@ -27,15 +27,11 @@
  */
 
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 
-import { Rnd } from 'react-rnd';
 import { VectorData } from 'geostyler-data';
 
 import './FilterEditorWindow.less';
-import { Button } from 'antd';
-
-import { CloseOutlined } from '@ant-design/icons';
+import { Modal, ModalProps } from 'antd';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import { Filter } from 'geostyler-style';
@@ -44,22 +40,14 @@ import { ComparisonFilterProps } from '../ComparisonFilter/ComparisonFilter';
 import type GeoStylerLocale from '../../../locale/locale';
 import en_US from '../../../locale/en_US';
 
-// default props
-export interface FilterEditorWindowDefaultProps {
-  /** Locale object containing translated text snippets */
-  locale: GeoStylerLocale['FilterEditorWindow'];
-}
-
 // non default props
-export interface FilterEditorWindowProps extends Partial<FilterEditorWindowDefaultProps> {
+export interface FilterEditorWindowProps extends Partial<ModalProps> {
+  /** Locale object containing translated text snippets */
+  locale?: GeoStylerLocale['FilterEditorWindow'];
   /** The filter to edit */
   filter?: Filter;
   /** Layer metadata in the GeoStyler VectorData format */
   internalDataDef?: VectorData;
-  /** Pixel ordinate of the x-axis */
-  x?: number;
-  /** Pixel ordinate of the y-axis */
-  y?: number;
   /** The callback method that is triggered when the filter window closes */
   onClose?: () => void;
   /** The callback method that is triggered when the state changes */
@@ -68,63 +56,33 @@ export interface FilterEditorWindowProps extends Partial<FilterEditorWindowDefau
   filterUiProps?: Partial<ComparisonFilterProps>;
 }
 
-/**
- * Filter Editor Window UI.
- */
 export const FilterEditorWindow: React.FC<FilterEditorWindowProps> = ({
-  x,
-  y,
   internalDataDef,
   onClose,
   filter,
   onFilterChange,
   filterUiProps,
-  locale = en_US.FilterEditorWindow
+  locale = en_US.FilterEditorWindow,
+  ...passThroughProps
 }) => {
 
   return (
-    ReactDOM.createPortal(
-      <Rnd
-        className="filter-editor-window"
-        default={{
-          x: x || window.innerWidth / 2,
-          y: y || window.innerHeight / 2,
-          width: undefined,
-          height: undefined
-        }}
-        enableResizing={{
-          bottom: false,
-          bottomLeft: false,
-          bottomRight: false,
-          left: false,
-          right: false,
-          top: false,
-          topLeft: false,
-          topRight: false
-        }}
-        dragHandleClassName="title"
-      >
-        <div className="header filter-editor-window-header">
-          <span className="title">
-            {locale.filterEditor}
-          </span>
-          <Button
-            icon={<CloseOutlined />}
-            size="small"
-            onClick={onClose}
-          />
-        </div>
-        <div className="filter-editor-window-body">
-          <FilterTree
-            internalDataDef={internalDataDef}
-            filter={filter}
-            onFilterChange={onFilterChange}
-            filterUiProps={filterUiProps}
-          />
-        </div>
-      </Rnd>,
-      document.body
-    )
+    <Modal
+      className="filter-editor-modal"
+      title={locale.filterEditor}
+      onCancel={onClose}
+      width={800}
+      footer={false}
+      centered={true}
+      {...passThroughProps}
+    >
+      <FilterTree
+        internalDataDef={internalDataDef}
+        filter={filter}
+        onFilterChange={onFilterChange}
+        filterUiProps={filterUiProps}
+      />
+    </Modal>
   );
 };
 

--- a/src/Component/Filter/FilterTree/FilterTree.less
+++ b/src/Component/Filter/FilterTree/FilterTree.less
@@ -42,12 +42,15 @@
     }
 
     .style-filter-node {
+      width: 100%;
+
       &.comparison-filter {
         .ant-tree-switcher {
           display: none;
         }
 
         .ant-tree-node-content-wrapper {
+          width: 100%;
           border: 1px solid #40a9ff;
           border-radius: 4px;
         }

--- a/src/Component/Rule/Rule.tsx
+++ b/src/Component/Rule/Rule.tsx
@@ -321,16 +321,14 @@ export class Rule extends React.Component<RuleProps, RuleState> {
               {...sldRendererProps}
               {...oLRendererProps}
             />
-            {
-              !editorVisible ? null :
-                <SymbolizerEditorWindow
-                  onClose={this.onEditorWindowClose}
-                  symbolizers={rule.symbolizers}
-                  onSymbolizersChange={this.onSymbolizersChange}
-                  iconLibraries={iconLibraries}
-                  colorRamps={colorRamps}
-                />
-            }
+            <SymbolizerEditorWindow
+              open={editorVisible}
+              onClose={this.onEditorWindowClose}
+              symbolizers={rule.symbolizers}
+              onSymbolizersChange={this.onSymbolizersChange}
+              iconLibraries={iconLibraries}
+              colorRamps={colorRamps}
+            />
           </div>
           <div className="gs-rule-right-fields" >
             <Fieldset

--- a/src/Component/RuleGenerator/RuleGeneratorWindow.less
+++ b/src/Component/RuleGenerator/RuleGeneratorWindow.less
@@ -27,26 +27,10 @@
  */
 
 .rule-generator-window {
-  background-color: white;
-  border: 3px solid grey;
-  border-radius: 3px;
-  z-index: 10;
+  .ant-modal-body {
+    padding-top: 15px;
 
-  .header {
-    background-color: lightgrey;
-    padding: 3px;
-    display: flex;
-  }
-
-  .header .title {
-    flex: 1;
-  }
-
-  .rule-generator-window-header:hover {
-    cursor: grab;
-  }
-
-  .rule-generator-window-header:active {
-    cursor: grabbing;
+    max-height: calc(100vh - 100px);
+    overflow: auto;
   }
 }

--- a/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
+++ b/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
@@ -27,10 +27,7 @@
  */
 
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 import { brewer, InterpolationMode } from 'chroma-js';
-
-import { Rnd } from 'react-rnd';
 
 import {
   Rule
@@ -39,9 +36,7 @@ import {
 import { VectorData } from 'geostyler-data';
 
 import './RuleGeneratorWindow.less';
-import { Button } from 'antd';
-
-import { CloseOutlined } from '@ant-design/icons';
+import { Modal, ModalProps } from 'antd';
 
 import { localize } from '../LocaleWrapper/LocaleWrapper';
 import RuleGenerator from './RuleGenerator';
@@ -51,16 +46,10 @@ import _isFinite from 'lodash/isFinite';
 import type GeoStylerLocale from '../../locale/locale';
 import en_US from '../../locale/en_US';
 
-// default props
-export interface RuleGeneratorWindowDefaultProps {
-  locale: GeoStylerLocale['RuleGeneratorWindow'];
-}
-
 // non default props
-export interface RuleGeneratorWindowProps extends Partial<RuleGeneratorWindowDefaultProps> {
+export interface RuleGeneratorWindowProps extends Partial<ModalProps> {
+  locale?: GeoStylerLocale['RuleGeneratorWindow'];
   internalDataDef: VectorData;
-  x?: number;
-  y?: number;
   onClose?: () => void;
   onRulesChange?: (rules: Rule[]) => void;
   colorRamps?: {
@@ -72,19 +61,15 @@ export interface RuleGeneratorWindowProps extends Partial<RuleGeneratorWindowDef
 
 const COMPONENTNAME = 'RuleGeneratorWindow';
 
-/**
- * Symbolizer editorwindow UI.
- */
 export const RuleGeneratorWindow: React.FC<RuleGeneratorWindowProps> = ({
   locale = en_US.RuleGeneratorWindow,
   internalDataDef,
-  x,
-  y,
   onClose,
   onRulesChange,
   colorRamps,
   useBrewerColorRamps,
-  colorSpaces
+  colorSpaces,
+  ...passThroughProps
 }) => {
 
   let ramps = colorRamps;
@@ -93,47 +78,22 @@ export const RuleGeneratorWindow: React.FC<RuleGeneratorWindowProps> = ({
   }
 
   return (
-    ReactDOM.createPortal(
-      <Rnd
-        className="rule-generator-window"
-        default={{
-          x: _isFinite(x) ? x : window.innerWidth / 2,
-          y: _isFinite(y) ? y : window.innerHeight / 2,
-          width: undefined,
-          height: undefined
-        }}
-        enableResizing={{
-          bottom: false,
-          bottomLeft: false,
-          bottomRight: false,
-          left: false,
-          right: false,
-          top: false,
-          topLeft: false,
-          topRight: false
-        }}
-        bounds="window"
-        dragHandleClassName="title"
-      >
-        <div className="header rule-generator-window-header">
-          <span className="title">
-            {locale.ruleGenerator}
-          </span>
-          <Button
-            icon={<CloseOutlined />}
-            size="small"
-            onClick={onClose}
-          />
-        </div>
-        <RuleGenerator
-          internalDataDef={internalDataDef}
-          onRulesChange={onRulesChange}
-          colorRamps={ramps}
-          colorSpaces={colorSpaces}
-        />
-      </Rnd>,
-      document.body
-    )
+    <Modal
+      className="rule-generator-window"
+      title={locale.ruleGenerator}
+      onCancel={onClose}
+      width={800}
+      footer={false}
+      centered={true}
+      {...passThroughProps}
+    >
+      <RuleGenerator
+        internalDataDef={internalDataDef}
+        onRulesChange={onRulesChange}
+        colorRamps={ramps}
+        colorSpaces={colorSpaces}
+      />
+    </Modal>
   );
 };
 

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -154,9 +154,7 @@ export const RuleTable: React.FC<RuleTableProps> = ({
 
   const [ruleEditIndex, setRuleEditIndex] = useState<number>();
   const [symbolizerEditorVisible, setSymbolizerEditorVisible] = useState<boolean>();
-  const [symbolizerEditorPosition, setSymbolizerEditorPosition] = useState<DOMRect>();
   const [filterEditorVisible, setFilterEditorVisible] = useState<boolean>();
-  const [filterEditorPosition, setFilterEditorPosition] = useState<DOMRect>();
   const [hasError, setHasError] = useState<boolean>();
   const [data, setData] = useState<Data>();
   const [rules, setRules] = useState<GsRule[]>();
@@ -197,7 +195,6 @@ export const RuleTable: React.FC<RuleTableProps> = ({
   const onSymbolizerClick = (record: RuleRecord, newSymbolizerEditorPosition: DOMRect) => {
     setRuleEditIndex(record.key);
     setSymbolizerEditorVisible(true);
-    setSymbolizerEditorPosition(newSymbolizerEditorPosition);
     setFilterEditorVisible(false);
   };
 
@@ -258,9 +255,8 @@ export const RuleTable: React.FC<RuleTableProps> = ({
           // }
         }}
         enterButton={<EditOutlined />}
-        onSearch={(value, event: any) => {
-          const filterPosition = event.target.getBoundingClientRect();
-          onFilterEditClick(record.key, filterPosition);
+        onSearch={() => {
+          onFilterEditClick(record.key);
         }}
       />);
     if (cql && cql.length > 0) {
@@ -277,9 +273,8 @@ export const RuleTable: React.FC<RuleTableProps> = ({
     return filterCell;
   };
 
-  const onFilterEditClick = (newRuleEditIndex: number, newFilterEditorPosition: DOMRect) => {
+  const onFilterEditClick = (newRuleEditIndex: number) => {
     setRuleEditIndex(newRuleEditIndex);
-    setFilterEditorPosition(newFilterEditorPosition);
     setSymbolizerEditorVisible(false);
     setFilterEditorVisible(true);
   };
@@ -453,39 +448,23 @@ export const RuleTable: React.FC<RuleTableProps> = ({
         pagination={false}
         {...restProps}
       />
-      {
-        !symbolizerEditorVisible ? null :
-          <SymbolizerEditorWindow
-            x={
-              symbolizerEditorPosition
-                ? symbolizerEditorPosition.x + symbolizerEditorPosition.width
-                : undefined
-            }
-            y={symbolizerEditorPosition ? symbolizerEditorPosition.y : undefined}
-            onClose={onSymbolizerEditorWindowClose}
-            internalDataDef={data}
-            symbolizers={rules[ruleEditIndex]?.symbolizers}
-            onSymbolizersChange={onSymbolizersChange}
-            iconLibraries={iconLibraries}
-            colorRamps={colorRamps}
-          />
-      }
-      {
-        !filterEditorVisible ? null :
-          <FilterEditorWindow
-            x={filterEditorPosition ? filterEditorPosition.x : undefined}
-            y={
-              filterEditorPosition
-                ? filterEditorPosition.y + filterEditorPosition.height
-                : undefined
-            }
-            onClose={onFilterEditorWindowClose}
-            filter={rules[ruleEditIndex].filter}
-            onFilterChange={onFilterChange}
-            filterUiProps={filterUiProps}
-            internalDataDef={data && DataUtil.isVector(data) ? data : undefined}
-          />
-      }
+      <SymbolizerEditorWindow
+        open={symbolizerEditorVisible}
+        onClose={onSymbolizerEditorWindowClose}
+        internalDataDef={data}
+        symbolizers={rules?.[ruleEditIndex]?.symbolizers}
+        onSymbolizersChange={onSymbolizersChange}
+        iconLibraries={iconLibraries}
+        colorRamps={colorRamps}
+      />
+      <FilterEditorWindow
+        open={filterEditorVisible}
+        onClose={onFilterEditorWindowClose}
+        filter={rules?.[ruleEditIndex]?.filter}
+        onFilterChange={onFilterChange}
+        filterUiProps={filterUiProps}
+        internalDataDef={data && DataUtil.isVector(data) ? data : undefined}
+      />
     </div>
   );
 };

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -487,18 +487,15 @@ export const Style: React.FC<StyleProps> = ({
             </Button> : null
         }
       </div>
-      {
-        (!ruleGeneratorWindowVisible) ? null :
-          <RuleGeneratorWindow
-            y={0}
-            internalDataDef={data as VectorData}
-            onClose={onRuleGeneratorWindowClose}
-            onRulesChange={onRulesChange}
-            colorRamps={colorRamps}
-            useBrewerColorRamps={useBrewerColorRamps}
-            colorSpaces={colorSpaces}
-          />
-      }
+      <RuleGeneratorWindow
+        open={ruleGeneratorWindowVisible}
+        internalDataDef={data as VectorData}
+        onClose={onRuleGeneratorWindowClose}
+        onRulesChange={onRulesChange}
+        colorRamps={colorRamps}
+        useBrewerColorRamps={useBrewerColorRamps}
+        colorSpaces={colorSpaces}
+      />
       { compact
         ? <RuleTable
           rules={rules}

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.less
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.less
@@ -44,4 +44,9 @@
   position: absolute;
   z-index: 200;
   top: 3em;
+
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
 }

--- a/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
+++ b/src/Component/Symbolizer/Field/ImageField/ImageField.tsx
@@ -113,19 +113,17 @@ export const ImageField: React.FC<ImageFieldProps> = ({
           }
         }}
       />
-      {
-        !windowVisible ? null :
-          <IconSelectorWindow
-            onClose={closeWindow}
-            iconLibraries={iconLibraries}
-            selectedIconSrc={value}
-            onIconSelect={(src: string) => {
-              if (onChange) {
-                onChange(src);
-              }
-            }}
-          />
-      }
+      <IconSelectorWindow
+        open={windowVisible}
+        onClose={closeWindow}
+        iconLibraries={iconLibraries}
+        selectedIconSrc={value}
+        onIconSelect={(src: string) => {
+          if (onChange) {
+            onChange(src);
+          }
+        }}
+      />
     </div>
   );
 };

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.less
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.less
@@ -27,32 +27,10 @@
  */
 
 .gs-icon-selector-window {
-  background-color: white;
-  border: 3px solid grey;
-  border-radius: 3px;
-  z-index: 11;
+  .ant-modal-body {
+    padding-top: 15px;
 
-  .header {
-    background-color: lightgrey;
-    padding: 3px;
-    display: flex;
-  }
-
-  .header .title {
-    flex: 1;
-  }
-
-  .gs-icon-selector-window-header:hover {
-    cursor: grab;
-  }
-
-  .gs-icon-selector-window-header:active {
-    cursor: grabbing;
-  }
-
-  .gs-icon-selector-window-body {
-    overflow-y: auto;
-    /* TODO proper height detection so that cards don't overflow window */
-    height: calc(100% - 30px);
+    max-height: calc(100vh - 100px);
+    overflow: auto;
   }
 }

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
@@ -27,15 +27,10 @@
  */
 
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
 
 import {
-  Button
+  Modal, ModalProps
 } from 'antd';
-
-import { CloseOutlined } from '@ant-design/icons';
-
-import { Rnd } from 'react-rnd';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
@@ -46,17 +41,9 @@ import './IconSelectorWindow.less';
 import _isEqual from 'lodash/isEqual';
 import type GeoStylerLocale from '../../../locale/locale';
 
-// default props
-export interface IconSelectorWindowDefaultProps {
-  locale: GeoStylerLocale['IconSelectorWindow'];
-}
-
 // non default props
-export interface IconSelectorWindowProps extends Partial<IconSelectorWindowDefaultProps> {
-  x?: number;
-  y?: number;
-  width?: number|string;
-  height?: number|string;
+export interface IconSelectorWindowProps extends Partial<ModalProps> {
+  locale?: GeoStylerLocale['IconSelectorWindow'];
   iconLibraries: IconLibrary[];
   selectedIconSrc?: string;
   onIconSelect?: (iconSrc: string) => void;
@@ -66,59 +53,29 @@ const COMPONENTNAME = 'IconSelectorWindow';
 
 export const IconSelectorWindow: React.FC<IconSelectorWindowProps> = ({
   locale = en_US.IconSelectorWindow,
-  x,
-  y,
-  width,
-  height,
   iconLibraries,
   selectedIconSrc,
   onIconSelect,
-  onClose
+  onClose,
+  ...passThroughProps
 }) => {
 
   return (
-    ReactDOM.createPortal(
-      <Rnd
-        className="gs-icon-selector-window"
-        default={{
-          x: x || window.innerWidth / 2,
-          y: y || window.innerHeight / 2,
-          width: width || '50%',
-          height: height || '50%'
-        }}
-        enableResizing={{
-          bottom: false,
-          bottomLeft: false,
-          bottomRight: false,
-          left: false,
-          right: false,
-          top: false,
-          topLeft: false,
-          topRight: false
-        }}
-        bounds="window"
-        dragHandleClassName="title"
-      >
-        <div className="header gs-icon-selector-window-header">
-          <span className="title">
-            {locale.windowLabel}
-          </span>
-          <Button
-            icon={<CloseOutlined />}
-            size="small"
-            onClick={onClose}
-          />
-        </div>
-        <div className="gs-icon-selector-window-body">
-          <IconSelector
-            iconLibraries={iconLibraries}
-            onIconSelect={onIconSelect}
-            selectedIconSrc={selectedIconSrc}
-          />
-        </div>
-      </Rnd>,
-      document.body
-    )
+    <Modal
+      className="gs-icon-selector-portal"
+      title={locale.windowLabel}
+      onCancel={onClose}
+      width={700}
+      footer={false}
+      centered={true}
+      {...passThroughProps}
+    >
+      <IconSelector
+        iconLibraries={iconLibraries}
+        onIconSelect={onIconSelect}
+        selectedIconSrc={selectedIconSrc}
+      />
+    </Modal>
   );
 };
 

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -106,7 +106,7 @@ export const MultiEditor: React.FC<MultiEditorProps> = ({
       className: 'gs-symbolizer-multi-editor-tab',
       key: idx.toString(),
       closable: true,
-      label: idx,
+      label: `${symbolizer.kind} (${idx})`,
       children: (
         <>
           <Editor

--- a/src/Component/Symbolizer/Preview/Preview.tsx
+++ b/src/Component/Symbolizer/Preview/Preview.tsx
@@ -364,15 +364,6 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
       mapTargetId
     } = this.state;
 
-    let windowX, windowY;
-
-    if (editorVisible && !hideEditButton ) {
-      const buttonElement = document.getElementById(editorId);
-      const buttonBounds = buttonElement.getBoundingClientRect();
-      windowX = buttonBounds.right + window.scrollX;
-      windowY = buttonBounds.top + window.scrollY;
-    }
-
     return (
       <div className="gs-symbolizer-preview">
         <div
@@ -391,17 +382,13 @@ export class Preview extends React.Component<PreviewProps, PreviewState> {
             {editorVisible ? locale.closeEditorText : locale.openEditorText}
           </Button>
           }
-          {
-            editorVisible && !hideEditButton ?
-              <SymbolizerEditorWindow
-                x={windowX}
-                y={windowY}
-                onClose={this.onEditButtonClicked}
-                symbolizers={symbolizers}
-                onSymbolizersChange={onSymbolizersChange}
-                colorRamps={colorRamps}
-              /> : null
-          }
+          <SymbolizerEditorWindow
+            open={editorVisible}
+            onClose={this.onEditButtonClicked}
+            symbolizers={symbolizers}
+            onSymbolizersChange={onSymbolizersChange}
+            colorRamps={colorRamps}
+          />
         </div>
       </div>
     );

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.less
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.less
@@ -26,30 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-.symbolizer-editor-window {
-  background-color: white;
-  border: 3px solid grey;
-  border-radius: 3px;
-  z-index: 10;
-  min-width: 400px;
-
-  .header {
-    background-color: lightgrey;
-    padding: 3px;
-    display: flex;
-  }
-
-  .header .title {
-    flex: 1;
-  }
-
-  .symbolizer-editor-window-header {
-    &:hover {
-      cursor: grab;
-    }
-
-    &:active {
-      cursor: grabbing;
-    }
+.symbolizer-editor-modal {
+  .ant-modal-body {
+    padding-top: 15px;
   }
 }

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
@@ -27,9 +27,6 @@
  */
 
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-
-import { Rnd } from 'react-rnd';
 
 import { Symbolizer } from 'geostyler-style';
 
@@ -39,9 +36,7 @@ import { IconLibrary } from '../IconSelector/IconSelector';
 import { Data } from 'geostyler-data';
 
 import './SymbolizerEditorWindow.less';
-import { Button } from 'antd';
-
-import { CloseOutlined } from '@ant-design/icons';
+import { Modal, ModalProps } from 'antd';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
 import en_US from '../../../locale/en_US';
@@ -49,18 +44,11 @@ import en_US from '../../../locale/en_US';
 import _isEqual from 'lodash/isEqual';
 import type GeoStylerLocale from '../../../locale/locale';
 
-// default props
-export interface SymbolizerEditorWindowDefaultProps {
-  locale: GeoStylerLocale['SymbolizerEditorWindow'];
-  constrainWindow: string;
-}
-
 // non default props
-export interface SymbolizerEditorWindowProps extends Partial<SymbolizerEditorWindowDefaultProps> {
+export interface SymbolizerEditorWindowProps extends Partial<ModalProps> {
+  locale?: GeoStylerLocale['SymbolizerEditorWindow'];
   symbolizers: Symbolizer[];
   internalDataDef?: Data;
-  x?: number;
-  y?: number;
   onClose?: () => void;
   onSymbolizersChange?: (symbolizers: Symbolizer[]) => void;
   iconLibraries?: IconLibrary[];
@@ -71,65 +59,35 @@ export interface SymbolizerEditorWindowProps extends Partial<SymbolizerEditorWin
 
 const COMPONENTNAME = 'SymbolizerEditorWindow';
 
-/**
- * Symbolizer editorwindow UI.
- */
 export const SymbolizerEditorWindow: React.FC<SymbolizerEditorWindowProps> = ({
   locale = en_US.SymbolizerEditorWindow,
-  constrainWindow = 'body',
   symbolizers,
   internalDataDef,
-  x,
-  y,
   onClose,
   onSymbolizersChange,
   iconLibraries,
-  colorRamps
+  colorRamps,
+  ...passThroughProps
 }) => {
 
   return (
-    ReactDOM.createPortal(
-      <Rnd
-        bounds={constrainWindow}
-        className="symbolizer-editor-window"
-        default={{
-          x: x || window.innerWidth / 2,
-          y: y || window.innerHeight / 2,
-          width: undefined,
-          height: undefined
-        }}
-        enableResizing={{
-          bottom: false,
-          bottomLeft: false,
-          bottomRight: false,
-          left: false,
-          right: false,
-          top: false,
-          topLeft: false,
-          topRight: false
-        }}
-        dragHandleClassName="title"
-      >
-        <div className="header symbolizer-editor-window-header">
-          <span className="title">
-            {locale.symbolizersEditor}
-          </span>
-          <Button
-            icon={<CloseOutlined />}
-            size="small"
-            onClick={onClose}
-          />
-        </div>
-        <MultiEditor
-          internalDataDef={internalDataDef}
-          symbolizers={symbolizers}
-          onSymbolizersChange={onSymbolizersChange}
-          iconLibraries={iconLibraries}
-          editorProps={{colorRamps}}
-        />
-      </Rnd>,
-      document.body
-    )
+    <Modal
+      className="symbolizer-editor-modal"
+      title={locale.symbolizersEditor}
+      onCancel={onClose}
+      width={800}
+      footer={false}
+      centered={true}
+      {...passThroughProps}
+    >
+      <MultiEditor
+        internalDataDef={internalDataDef}
+        symbolizers={symbolizers}
+        onSymbolizersChange={onSymbolizersChange}
+        iconLibraries={iconLibraries}
+        editorProps={{colorRamps}}
+      />
+    </Modal>
   );
 };
 


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This replaces all `react-rnd` window components with [antd Modals](https://ant.design/components/modal).

![Peek 2023-05-10 11-38](https://github.com/geostyler/geostyler/assets/1137620/c2ef08f7-2749-4686-9dc9-1b844dd48cb1)

Please review.

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

