### PR TITLE
feat: use GeoStylerContext composition for ComparisonFilter

### DIFF
--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.example.md
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.example.md
@@ -31,17 +31,44 @@
 This demonstrates the usage of the `ComparisonFilter` component.
 
 ```jsx
-import * as React from 'react';
+import React, { useState } from 'react';
 import { ComparisonFilter } from 'geostyler';
 
 function ComparisonFilterExample() {
-  const [filter, setFilter] = React.useState(['<=x<=', 'population', 100000, 200000]);
+  const [filter, setFilter] = useState(['<=x<=', 'population', 100000, 200000]);
 
   return <>
     <ComparisonFilter onFilterChange={setFilter} filter={filter} />
     {JSON.stringify(filter)}
   </>;
 
+}
+
+<ComparisonFilterExample />
+```
+
+This demonstrates the usage of the `ComparisonFilter` with `GeoStylerContext`.
+
+```jsx
+import React, { useState } from 'react';
+import { ComparisonFilter, GeoStylerContext } from 'geostyler';
+
+function ComparisonFilterExample() {
+  const [myContext, setMyContext] = useState({
+    composition: {
+      ComparisonFilter: {
+        operatorNameMappingFunction: (n) => 'foo'
+      }
+    }
+  });
+  const [filter, setFilter] = useState(['<=x<=', 'population', 100000, 200000]);
+
+  return (
+    <GeoStylerContext.Provider value={myContext}>
+      <ComparisonFilter onFilterChange={setFilter} filter={filter} />
+      {JSON.stringify(filter)}
+    </GeoStylerContext.Provider>
+  );
 }
 
 <ComparisonFilterExample />

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -52,6 +52,7 @@ import _cloneDeep from 'lodash/cloneDeep';
 import _isEmpty from 'lodash/isEmpty';
 import _isString from 'lodash/isString';
 import { JSONSchema4TypeName } from 'json-schema';
+import { useGeoStylerComposition } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 type ValidationResult = {
   isValid: boolean;
@@ -164,26 +165,32 @@ const operatorsMap: Record<JSONSchema4TypeName, ComparisonOperator[]> = {
  *   - A combo to select the operator
  *   - An input field for the value
  */
-export const ComparisonFilter: React.FC<ComparisonFilterProps> = ({
-  attributeNameFilter = () => true,
-  attributeNameMappingFunction = n => n,
-  filter = ['==', '', null],
-  hideAttributeType = false,
-  internalDataDef,
-  microUI = false,
-  onFilterChange,
-  operatorLabel,
-  operatorNameMappingFunction = n => n,
-  operatorPlaceholderString,
-  operatorTitleMappingFunction = t => t,
-  operatorValidationHelpString,
-  showOperatorTitles = true,
-  validators = {
-    attribute: attributeName => !_isEmpty(attributeName),
-    operator: operatorName => !_isEmpty(operatorName),
-    value: ComparisonFilterDefaultValidator
-  }
-}) => {
+export const ComparisonFilter: React.FC<ComparisonFilterProps> = (props) => {
+
+  const composition = useGeoStylerComposition('ComparisonFilter', {});
+
+  const composed = {...props, ...composition};
+
+  const {
+    attributeNameFilter = () => true,
+    attributeNameMappingFunction = n => n,
+    filter = ['==', '', null],
+    hideAttributeType = false,
+    internalDataDef,
+    microUI = false,
+    onFilterChange,
+    operatorLabel,
+    operatorNameMappingFunction = n => n,
+    operatorPlaceholderString,
+    operatorTitleMappingFunction = t => t,
+    operatorValidationHelpString,
+    showOperatorTitles = true,
+    validators = {
+      attribute: attributeName => !_isEmpty(attributeName),
+      operator: operatorName => !_isEmpty(operatorName),
+      value: ComparisonFilterDefaultValidator
+    }
+  } = composed;
 
   /**
    * Handler function, which is executed, when to underlying filter attribute changes.


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This makes use of the `GeoStylerContext` in the `<ComparisonFilter>`.

![geostyler-comparisonfilter-composition](https://github.com/geostyler/geostyler/assets/12186477/888ecd3d-c020-4e26-b4f3-190cfcfb48d2)

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

