### PR TITLE
feat: use GeoStylerContext composition for RuleCard and RuleOverview

### DIFF
--- a/src/Component/RuleCard/RuleCard.example.md
+++ b/src/Component/RuleCard/RuleCard.example.md
@@ -123,13 +123,40 @@ function RuleCardExample() {
 <RuleCardExample />
 ```
 
-With amount and duplicates deactivated.
+`RuleCard` with `GeoStylerContext`.
 
 ```jsx
-import * as React from 'react';
-import { RuleCard } from 'geostyler';
+import React, { useState } from 'react';
+import { Switch } from 'antd';
+import { RuleCard, GeoStylerContext } from 'geostyler';
 
 function RuleCardExample() {
+
+  const [myContext, setMyContext] = useState({
+    composition: {
+      Rule: {
+        amount: {
+          visibility: true
+        },
+        duplicate: {
+          visibility: true
+        },
+        filter: {
+          visibility: true
+        },
+        name: {
+          visibility: true
+        },
+        minScale: {
+          visibility: true
+        },
+        maxScale: {
+          visibility: true
+        }
+      }
+    }
+  });
+
   const rule = {
     name: 'myRule',
     scaleDenominator: {
@@ -146,6 +173,7 @@ function RuleCardExample() {
       wellKnownName: 'circle'
     }]
   };
+
   const data = {
     exampleFeatures: {
       type: 'FeatureCollection',
@@ -174,14 +202,61 @@ function RuleCardExample() {
     }
   };
 
+  const onVisibilityChange = (visibility, prop) => {
+    setMyContext(oldContext => {
+      const newContext = {...oldContext};
+      newContext.composition.Rule[prop].visibility = visibility;
+      return newContext;
+    });
+  };
+
   return (
     <div style={{height: '300px'}}>
-      <RuleCard
-        rule={rule}
-        data={data}
-        showAmount={false}
-        showDuplicates={false}
-      />
+      <div style={{display: 'flex', flexWrap: 'wrap', gap: '15px'}}>
+        <Switch
+          checked={myContext.composition.Rule.amount.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'amount')}}
+          checkedChildren="Amount"
+          unCheckedChildren="Amount"
+        />
+        <Switch
+          checked={myContext.composition.Rule.duplicate.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'duplicate')}}
+          checkedChildren="Duplicate"
+          unCheckedChildren="Duplicate"
+        />
+        <Switch
+          checked={myContext.composition.Rule.filter.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'filter')}}
+          checkedChildren="Filters"
+          unCheckedChildren="Filters"
+        />
+        <Switch
+          checked={myContext.composition.Rule.name.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'name')}}
+          checkedChildren="Name"
+          unCheckedChildren="Name"
+        />
+        <Switch
+          checked={myContext.composition.Rule.minScale.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'minScale')}}
+          checkedChildren="Min. Scale"
+          unCheckedChildren="Min. Scale"
+        />
+        <Switch
+          checked={myContext.composition.Rule.maxScale.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'maxScale')}}
+          checkedChildren="Max. Scale"
+          unCheckedChildren="Max. Scale"
+        />
+      </div>
+      <hr />
+      <GeoStylerContext.Provider value={myContext}>
+        <RuleCard
+          rule={rule}
+          data={data}
+        />
+      </GeoStylerContext.Provider>
     </div>
   );
 }

--- a/src/Component/RuleCard/RuleCard.tsx
+++ b/src/Component/RuleCard/RuleCard.tsx
@@ -41,15 +41,11 @@ import DataUtil from '../../Util/DataUtil';
 import { Data } from 'geostyler-data';
 import { Divider, Card, Typography } from 'antd';
 import { BlockOutlined, FilterFilled, MinusOutlined } from '@ant-design/icons';
+import { useGeoStylerComposition } from '../../context/GeoStylerContext/GeoStylerContext';
 const { Text } = Typography;
 
 // default props
-interface RuleCardDefaultProps {
-  /** Display the number of features that match a rule */
-  showAmount: boolean;
-  /** Display the number of features that match more than one rule */
-  showDuplicates: boolean;
-}
+interface RuleCardDefaultProps {}
 
 // non default props
 export interface RuleCardProps extends Partial<RuleCardDefaultProps> {
@@ -63,14 +59,18 @@ export interface RuleCardProps extends Partial<RuleCardDefaultProps> {
   onClick?: () => void;
 }
 
-export const RuleCard = ({
-  rule,
-  duplicates,
-  onClick,
-  data,
-  showAmount = true,
-  showDuplicates = true
-}: RuleCardProps) => {
+export const RuleCard: React.FC<RuleCardProps> = (props) => {
+
+  const composition = useGeoStylerComposition('Rule', {});
+
+  const composed = {...props, ...composition};
+
+  const {
+    rule,
+    duplicates,
+    onClick,
+    data,
+  } = composed;
 
   let amount;
   if (data && DataUtil.isVector(data) && rule.filter && rule.filter.length) {
@@ -95,13 +95,25 @@ export const RuleCard = ({
       />
       <Divider type='vertical' />
       <div className='gs-rule-card-content'>
-        <h2>{rule.name}</h2>
-        <span>
-          <>1:{rule.scaleDenominator?.min || '-'} <MinusOutlined /> 1:{rule.scaleDenominator?.max || '-'}</>
-        </span>
+        {
+          composition.name?.visibility === false ? null : (
+            <h2>{rule.name}</h2>
+          )
+        }
+        {
+          composition.maxScale?.visibility === false
+            || composition.minScale?.visibility === false
+            ? null : (
+              <span>
+                <>
+                  1:{rule.scaleDenominator?.min || '-'} <MinusOutlined /> 1:{rule.scaleDenominator?.max || '-'}
+                </>
+              </span>
+            )
+        }
         <span className='gs-rule-card-content-icon-row'>
           {
-            showAmount && (
+            composition.amount?.visibility === false ? null : (
               <Text type='secondary'>
                 <span className='gs-rule-card-icon'>Σ</span>
                 {amount !== undefined ? amount : '-'}
@@ -109,7 +121,7 @@ export const RuleCard = ({
             )
           }
           {
-            showDuplicates && (
+            composition.duplicate?.visibility === false ? null : (
               <Text type='secondary'>
                 <BlockOutlined className='gs-rule-card-icon' />
                 {duplicates !== undefined ? duplicates : '-'}
@@ -117,16 +129,20 @@ export const RuleCard = ({
             )
           }
         </span>
-        <span className='gs-rule-card-cql'>
-          {
-            rule.filter?.length && (
-              <Text type='secondary'>
-                <FilterFilled className='gs-rule-card-icon' />
-              </Text>
-            )
-          }
-          <Text type='secondary'>{cql as any}</Text>
-        </span>
+        {
+          composition.filter?.visibility === false ? null : (
+            <span className='gs-rule-card-cql'>
+              {
+                rule.filter?.length && (
+                  <Text type='secondary'>
+                    <FilterFilled className='gs-rule-card-icon' />
+                  </Text>
+                )
+              }
+              <Text type='secondary'>{cql as any}</Text>
+            </span>
+          )
+        }
       </div>
     </Card>
   );

--- a/src/Component/RuleFieldContainer/RuleFieldContainer.tsx
+++ b/src/Component/RuleFieldContainer/RuleFieldContainer.tsx
@@ -43,6 +43,7 @@ import type GeoStylerLocale from '../../locale/locale';
 import en_US from '../../locale/en_US';
 import { Expression, Symbolizer } from 'geostyler-style';
 import { Data } from 'geostyler-data';
+import { useGeoStylerComposition } from '../../context/GeoStylerContext/GeoStylerContext';
 
 // default props
 interface RuleFieldContainerDefaultProps {
@@ -70,17 +71,23 @@ export interface RuleFieldContainerProps extends Partial<RuleFieldContainerDefau
   data?: Data;
 }
 
-export const RuleFieldContainer: React.FC<RuleFieldContainerProps> = ({
-  name,
-  minScale,
-  maxScale,
-  locale = en_US.Rule,
-  onNameChange = () => {},
-  onMinScaleChange = () => {},
-  onMaxScaleChange = () => {},
-  symbolizers = [],
-  data
-}) => {
+export const RuleFieldContainer: React.FC<RuleFieldContainerProps> = (props) => {
+
+  const composition = useGeoStylerComposition('Rule', {});
+
+  const composed = {...props, composition};
+
+  const {
+    name,
+    minScale,
+    maxScale,
+    locale = en_US.Rule,
+    onNameChange = () => {},
+    onMinScaleChange = () => {},
+    onMaxScaleChange = () => {},
+    symbolizers = [],
+    data
+  } = composed;
 
   return (
     <FieldContainer className="gs-rule-field-container">
@@ -88,23 +95,35 @@ export const RuleFieldContainer: React.FC<RuleFieldContainerProps> = ({
         <Form
           layout='vertical'
         >
-          <Form.Item
-            label={locale.nameFieldLabel}
-          >
-            <NameField
-              value={name}
-              onChange={onNameChange}
-              placeholder={locale.nameFieldPlaceholder}
-            />
-          </Form.Item>
-          <MinScaleDenominator
-            value={minScale}
-            onChange={onMinScaleChange}
-          />
-          <MaxScaleDenominator
-            value={maxScale}
-            onChange={onMaxScaleChange}
-          />
+          {
+            composition.name?.visibility === false ? null : (
+              <Form.Item
+                label={locale.nameFieldLabel}
+              >
+                <NameField
+                  value={name}
+                  onChange={onNameChange}
+                  placeholder={locale.nameFieldPlaceholder}
+                />
+              </Form.Item>
+            )
+          }
+          {
+            composition.minScale?.visibility === false ? null : (
+              <MinScaleDenominator
+                value={minScale}
+                onChange={onMinScaleChange}
+              />
+            )
+          }
+          {
+            composition.maxScale?.visibility === false ? null : (
+              <MaxScaleDenominator
+                value={maxScale}
+                onChange={onMaxScaleChange}
+              />
+            )
+          }
         </Form>
       </div>
       <Divider type="vertical" />

--- a/src/Component/RuleOverview/RuleOverview.example.md
+++ b/src/Component/RuleOverview/RuleOverview.example.md
@@ -31,39 +31,30 @@
 This demonstrates the usage of the `RuleOverview` component.
 
 ```jsx
-import * as React from 'react';
+import React, { useState } from 'react';
 import { RuleOverview } from 'geostyler';
 
-class RuleOverviewExample extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      rule: {
-        name: 'myRule',
-        symbolizers: [{
-          kind: 'Mark',
-          wellKnownName: 'circle'
-        }]
-      }
-    };
-  }
+function RuleOverviewExample() {
+  const [style, setStyle] = useState({
+    rule: {
+      name: 'myRule',
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'circle'
+      }]
+    }
+  });
 
-  render() {
-    const {
-      rule
-    } = this.state;
-
-    return (
-      <div>
-        <RuleOverview
-          rule={rule}
-          onRuleChange={(newRule) => {
-            this.setState({rule: newRule});
-          }}
-        />
-      </div>
-    );
-  }
+  return (
+    <div>
+      <RuleOverview
+        rule={style.rule}
+        onRuleChange={(newRule) => {
+          setStyle({rule: newRule});
+        }}
+      />
+    </div>
+  );
 }
 
 <RuleOverviewExample />
@@ -72,44 +63,124 @@ class RuleOverviewExample extends React.Component {
 Rule with filter.
 
 ```jsx
-import * as React from 'react';
+import React, { useState } from 'react';
 import { RuleOverview } from 'geostyler';
 
-class RuleOverviewExample extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      rule: {
-        name: 'myRule',
-        symbolizers: [{
-          kind: 'Mark',
-          wellKnownName: 'circle'
-        }],
-        filter: [
-          '&&',
-          ['==', 'foo', 'bar'],
-          ['!=', 'faz', 'baz']
-        ]
+function RuleOverviewExample() {
+  const [style, setStyle] = useState({
+    rule: {
+      name: 'myRule',
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'circle'
+      }],
+      filter: [
+        '&&',
+        ['==', 'foo', 'bar'],
+        ['!=', 'faz', 'baz']
+      ]
+    }
+  });
+
+  return (
+    <div>
+      <RuleOverview
+        rule={style.rule}
+        onRuleChange={(newRule) => {
+          setStyle({rule: newRule});
+        }}
+      />
+    </div>
+  );
+}
+
+<RuleOverviewExample />
+```
+
+`RuleOverview` with `GeoStylerContext`.
+
+```jsx
+import React, { useState } from 'react';
+import { Switch } from 'antd';
+import { RuleOverview, GeoStylerContext } from 'geostyler';
+
+function RuleOverviewExample() {
+  const [myContext, setMyContext] = useState({
+    composition: {
+      Rule: {
+        filter: {
+          visibility: true
+        },
+        name: {
+          visibility: true
+        },
+        minScale: {
+          visibility: true
+        },
+        maxScale: {
+          visibility: true
+        }
       }
-    };
-  }
+    }
+  });
 
-  render() {
-    const {
-      rule
-    } = this.state;
+  const [style, setStyle] = useState({
+    rule: {
+      name: 'myRule',
+      symbolizers: [{
+        kind: 'Mark',
+        wellKnownName: 'circle'
+      }]
+    }
+  });
 
-    return (
-      <div>
-        <RuleOverview
-          rule={rule}
-          onRuleChange={(newRule) => {
-            this.setState({rule: newRule});
-          }}
+  const onVisibilityChange = (visibility, prop) => {
+    setMyContext(oldContext => {
+      const newContext = {...oldContext};
+      newContext.composition.Rule[prop].visibility = visibility;
+      return newContext;
+    });
+  };
+
+  return (
+    <div>
+      <div style={{display: 'flex', flexWrap: 'wrap', gap: '15px'}}>
+        <Switch
+          checked={myContext.composition.Rule.filter.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'filter')}}
+          checkedChildren="Filters"
+          unCheckedChildren="Filters"
+        />
+        <Switch
+          checked={myContext.composition.Rule.name.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'name')}}
+          checkedChildren="Name"
+          unCheckedChildren="Name"
+        />
+        <Switch
+          checked={myContext.composition.Rule.minScale.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'minScale')}}
+          checkedChildren="Min. Scale"
+          unCheckedChildren="Min. Scale"
+        />
+        <Switch
+          checked={myContext.composition.Rule.maxScale.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'maxScale')}}
+          checkedChildren="Max. Scale"
+          unCheckedChildren="Max. Scale"
         />
       </div>
-    );
-  }
+      <hr />
+      <GeoStylerContext.Provider value={myContext}>
+        <RuleOverview
+          rule={style.rule}
+          onRuleChange={(newRule) => {
+            setStyle({rule: newRule});
+          }}
+        />
+      </GeoStylerContext.Provider>
+    </div>
+  );
 }
 
 <RuleOverviewExample />

--- a/src/Component/RuleOverview/RuleOverview.tsx
+++ b/src/Component/RuleOverview/RuleOverview.tsx
@@ -44,6 +44,7 @@ import CardViewUtil from '../../Util/CardViewUtil';
 import FilterOverview from '../FilterOverview/FilterOverview';
 import type GeoStylerLocale from '../../locale/locale';
 import en_US from '../../locale/en_US';
+import { useGeoStylerComposition } from '../../context/GeoStylerContext/GeoStylerContext';
 
 // default props
 interface RuleOverviewDefaultProps {
@@ -63,13 +64,19 @@ export interface RuleOverviewProps extends Partial<RuleOverviewDefaultProps> {
   rule: GsRule;
 }
 
-export const RuleOverview: React.FC<RuleOverviewProps> = ({
-  rule,
-  data,
-  onRuleChange = () => {},
-  onChangeView = () => {},
-  locale = en_US.RuleOverview
-}) => {
+export const RuleOverview: React.FC<RuleOverviewProps> = (props) => {
+
+  const composition = useGeoStylerComposition('Rule', {});
+
+  const composed = {...props, composition};
+
+  const {
+    rule,
+    data,
+    onRuleChange = () => {},
+    onChangeView = () => {},
+    locale = en_US.RuleOverview
+  } = composed;
 
   const onNameChange = (name: string) => {
     const newRule: GsRule = {...rule, name};
@@ -127,10 +134,14 @@ export const RuleOverview: React.FC<RuleOverviewProps> = ({
         onSymbolizersChange={onSymbolizersChange}
         data={data}
       />
-      <FilterOverview
-        filter={rule.filter}
-        onEditFilterClick={onEditFilterClick}
-      />
+      {
+        composition.filter?.visibility === false ? null : (
+          <FilterOverview
+            filter={rule.filter}
+            onEditFilterClick={onEditFilterClick}
+          />
+        )
+      }
     </div>
   );
 };


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This makes use of the `GeoStylerContext` for `<RuleCard>` and `<RuleOverview>`.

BREAKING CHANGE: This removes the properties `showAmount` and `showDuplicates` from RuleCard. Please use
GeoStylerContext.composition.Rule.amount and
GeoStylerContext.composition.Rule.duplicate instead.

![geostyler-ruleoverview-composition](https://github.com/geostyler/geostyler/assets/12186477/e0b28f29-fbcc-48f7-a428-e77498aac784)

![geostyler-rulecard-composition](https://github.com/geostyler/geostyler/assets/12186477/93b848fb-06f9-4048-87e0-eea7b95bb01a)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

