### PR TITLE
feat: use GeoStylerContext composition for Editor

### DIFF
--- a/src/Component/Symbolizer/Editor/Editor.example.md
+++ b/src/Component/Symbolizer/Editor/Editor.example.md
@@ -31,42 +31,133 @@
 This demonstrates the use of `Editor`.
 
 ```jsx
-import * as React from 'react';
+import React, { useState } from 'react';
 import { Editor } from 'geostyler';
 
-class EditorExample extends React.Component {
-  constructor(props) {
-    super(props);
+function EditorExample () {
+  const [style, setStyle] = useState({
+    symbolizer: {
+      kind: 'Mark',
+      wellKnownName: 'circle'
+    }
+  });
 
-    this.state = {
-      symbolizer: {
-        kind: 'Mark',
-        wellKnownName: 'circle'
+  const onSymbolizerChange = (symbolizer) => {
+    setStyle({symbolizer});
+  };
+
+  return (
+    <Editor
+      symbolizer={style.symbolizer}
+      onSymbolizerChange={onSymbolizerChange}
+      unknownSymbolizerText="Unknown Symbolizer"
+    />
+  );
+}
+
+<EditorExample />
+```
+
+This demonstrates the use of `Editor` with `GeoStylerContext`.
+
+```jsx
+import React, { useState } from 'react';
+import { Switch } from 'antd';
+import { Editor, GeoStylerContext } from 'geostyler';
+
+function EditorExample () {
+  const [myContext, setMyContext] = useState({
+    composition: {
+      MarkEditor: {
+        visibility: true
+      },
+      FillEditor: {
+        visibility: true
+      },
+      IconEditor: {
+        visibility: true
+      },
+      LineEditor: {
+        visibility: true
+      },
+      TextEditor: {
+        visibility: true
+      },
+      RasterEditor: {
+        visibility: true
       }
-    };
+    }
+  });
 
-    this.onSymbolizerChange = this.onSymbolizerChange.bind(this);
-  }
+  const [style, setStyle] = useState({
+    symbolizer: {
+      kind: 'Mark',
+      wellKnownName: 'circle'
+    }
+  });
 
-  onSymbolizerChange(symbolizer) {
-    this.setState({
-      symbolizer: symbolizer
+  const onSymbolizerChange = (symbolizer) => {
+    setStyle({symbolizer});
+  };
+
+  const onVisibilityChange = (visibility, editor) => {
+    setMyContext(oldContext => {
+      const newContext = {...oldContext};
+      newContext.composition[editor].visibility = visibility;
+      return newContext;
     });
-  }
+  };
 
-  render() {
-    const {
-      symbolizer
-    } = this.state;
-
-    return (
-      <Editor
-        symbolizer={symbolizer}
-        onSymbolizerChange={this.onSymbolizerChange}
-        unknownSymbolizerText="Unknown Symbolizer"
-      />
-    );
-  }
+  return (
+    <div>
+      <div style={{display: 'flex', flexWrap: 'wrap', gap: '15px'}}>
+        <Switch
+          checked={myContext.composition.MarkEditor.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'MarkEditor')}}
+          checkedChildren="Mark"
+          unCheckedChildren="Mark"
+        />
+        <Switch
+          checked={myContext.composition.FillEditor.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'FillEditor')}}
+          checkedChildren="Fill"
+          unCheckedChildren="Fill"
+        />
+        <Switch
+          checked={myContext.composition.IconEditor.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'IconEditor')}}
+          checkedChildren="Icon"
+          unCheckedChildren="Icon"
+        />
+        <Switch
+          checked={myContext.composition.LineEditor.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'LineEditor')}}
+          checkedChildren="Line"
+          unCheckedChildren="Line"
+        />
+        <Switch
+          checked={myContext.composition.TextEditor.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'TextEditor')}}
+          checkedChildren="Text"
+          unCheckedChildren="Text"
+        />
+        <Switch
+          checked={myContext.composition.RasterEditor.visibility}
+          onChange={visibility => {onVisibilityChange(visibility, 'RasterEditor')}}
+          checkedChildren="Raster"
+          unCheckedChildren="Raster"
+        />
+      </div>
+      <hr/>
+      <GeoStylerContext.Provider value={myContext}>
+        <Editor
+          symbolizer={style.symbolizer}
+          onSymbolizerChange={onSymbolizerChange}
+          unknownSymbolizerText="Unknown Symbolizer"
+        />
+      </GeoStylerContext.Provider>
+    </div>
+  );
 }
 
 <EditorExample />


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This makes use of the `GeoStylerContext` for `<Editor>`.

BREAKING CHANGE: This removes the deprecated CompositionContext in favor of the new GeoStylerContext composition from Editor. This also removes the properties `iconLibraries` and `colorRamps` from Editor. Please use GeoStylerContext.composition.IconEditor.iconLibraries instead. The property `colorRamps` currently has no replacement but this will be re-added soon.

![geostyler-editor-composition](https://github.com/geostyler/geostyler/assets/12186477/df6c7f21-61ec-4ead-aed7-364c64507e07)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

