### PR TITLE
feat: replace remove symbolizer button with removable tabs

### DIFF
--- a/src/Component/Rule/Rule.spec.tsx
+++ b/src/Component/Rule/Rule.spec.tsx
@@ -170,7 +170,7 @@ describe('Rule', () => {
         fireEvent.click(map);
       });
 
-      const btn = wrapper.queryByText('Add');
+      const btn = wrapper.queryAllByLabelText('Add tab')[0];
 
       await act(async () => {
         fireEvent.click(btn);

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.spec.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.spec.tsx
@@ -60,7 +60,7 @@ describe('MultiEditor', () => {
 
   it('adds a Symbolizer', async () => {
     const textEditor = render(<MultiEditor {...props} />);
-    const addButton = await textEditor.findByText(en_US.MultiEditor.add);
+    const addButton = (await textEditor.findAllByLabelText('Add tab'))[0];
     const got = [
       ...dummySymbolizers,
       {'color': '#0E1058', 'kind': 'Mark', 'wellKnownName': 'circle'}
@@ -73,7 +73,7 @@ describe('MultiEditor', () => {
 
   it('removes a Symbolizer', async () => {
     const textEditor = render(<MultiEditor {...props} />);
-    const removeButton = await textEditor.findByText(en_US.MultiEditor.remove);
+    const removeButton = (await textEditor.findAllByLabelText('remove'))[0];
     const got = [{
       kind: 'Mark',
       wellKnownName: 'circle',

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -38,7 +38,7 @@ import './MultiEditor.less';
 import 'ol/ol.css';
 import { Data } from 'geostyler-data';
 
-import { Tabs, Button } from 'antd';
+import { Tabs } from 'antd';
 import Editor from '../Editor/Editor';
 
 import { localize } from '../../LocaleWrapper/LocaleWrapper';
@@ -101,6 +101,23 @@ export const MultiEditor: React.FC<MultiEditorProps> = ({
     }
   };
 
+  const onTabEdit = (targetKey: React.MouseEvent | React.KeyboardEvent | string, action: 'add' | 'remove') => {
+    if (action === 'add') {
+      addSymbolizer();
+    } else {
+      try {
+        if (symbolizers.length === 1) {
+          return;
+        }
+        const key = parseInt(targetKey.toString(), 10);
+        removeSymbolizer(key);
+      } catch {
+        // eslint-disable-next-line no-console
+        console.log('Could not remove symbolizer. Invalid key.');
+      }
+    }
+  };
+
   const tabs: Tab[] = symbolizers.map((symbolizer: Symbolizer, idx: number) => {
     return {
       className: 'gs-symbolizer-multi-editor-tab',
@@ -108,41 +125,27 @@ export const MultiEditor: React.FC<MultiEditorProps> = ({
       closable: true,
       label: `${symbolizer.kind} (${idx})`,
       children: (
-        <>
-          <Editor
-            symbolizer={symbolizer}
-            onSymbolizerChange={(sym: Symbolizer) => {
-              onSymbolizerChange(sym, idx);
-            }}
-            internalDataDef={internalDataDef}
-            iconLibraries={iconLibraries}
-            {...editorProps}
-          />
-          {symbolizers.length === 1 ? null :
-            <Button
-              onClick={() => {
-                removeSymbolizer(idx);
-              }}
-            >
-              {locale.remove}
-            </Button>
-          }
-        </>
+        <Editor
+          symbolizer={symbolizer}
+          onSymbolizerChange={(sym: Symbolizer) => {
+            onSymbolizerChange(sym, idx);
+          }}
+          internalDataDef={internalDataDef}
+          iconLibraries={iconLibraries}
+          {...editorProps}
+        />
       )
     };
   });
 
   return (
     <Tabs
-      className="gs-symbolizer-multi-editor"
-      defaultActiveKey="0"
-      animated={false}
-      tabBarExtraContent={(
-        <Button onClick={addSymbolizer}>
-          {locale.add}
-        </Button>
-      )}
+      className='gs-symbolizer-multi-editor'
+      type='editable-card'
+      defaultActiveKey='0'
       items={tabs}
+      animated={false}
+      onEdit={onTabEdit}
       {...passThroughProps}
     />
   );


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This removes the `remove` button from a symbolizer and uses removable tabs instead. Also, the `add` button was replaced with a `+` tab.

closes https://github.com/geostyler/geostyler/issues/2149

![localhost_6060_](https://github.com/geostyler/geostyler/assets/12186477/4584a152-5eb8-4623-ae07-033d6d982326)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

