### PR TITLE
build: move @types/react* to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,7 @@
         "@types/file-saver": "^2.0.5",
         "@types/geojson": "^7946.0.10",
         "@types/lodash": "^4.14.194",
-        "@types/react": "^18.2.6",
         "@types/react-color": "^3.0.6",
-        "@types/react-dom": "^18.2.4",
         "@ungap/url-search-params": "^0.2.2",
         "blob": "^0.1.0",
         "chroma-js": "^2.4.2",
@@ -64,6 +62,8 @@
         "@types/jest": "^29.5.1",
         "@types/jest-diff": "^24.3.0",
         "@types/node": "^20.1.2",
+        "@types/react": "^18.2.6",
+        "@types/react-dom": "^18.2.4",
         "@types/webpack": "^5.28.1",
         "@typescript-eslint/eslint-plugin": "^5.59.5",
         "@typescript-eslint/eslint-plugin-tslint": "^5.59.5",
@@ -108,6 +108,8 @@
       },
       "peerDependencies": {
         "@ant-design/icons": "5.x",
+        "@types/react": "^>=16.x",
+        "@types/react-dom": ">=16.x",
         "antd": "5.x",
         "ol": ">=6.x",
         "react": ">=16.x",
@@ -5879,6 +5881,7 @@
       "version": "18.2.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.4.tgz",
       "integrity": "sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -30773,6 +30776,7 @@
       "version": "18.2.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.4.tgz",
       "integrity": "sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,7 +108,7 @@
       },
       "peerDependencies": {
         "@ant-design/icons": "5.x",
-        "@types/react": "^>=16.x",
+        "@types/react": ">=16.x",
         "@types/react-dom": ">=16.x",
         "antd": "5.x",
         "ol": ">=6.x",

--- a/package.json
+++ b/package.json
@@ -78,9 +78,7 @@
     "lodash": "^4.17.21",
     "monaco-editor": "^0.38.0",
     "react-color": "^2.19.3",
-    "typescript-json-schema": "^0.56.0",
-    "@types/react": "^>=16.x",
-    "@types/react-dom": ">=16.x"
+    "typescript-json-schema": "^0.56.0"
   },
   "devDependencies": {
     "@ant-design/icons": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -61,9 +61,7 @@
     "@types/file-saver": "^2.0.5",
     "@types/geojson": "^7946.0.10",
     "@types/lodash": "^4.14.194",
-    "@types/react": "^18.2.6",
     "@types/react-color": "^3.0.6",
-    "@types/react-dom": "^18.2.4",
     "@ungap/url-search-params": "^0.2.2",
     "blob": "^0.1.0",
     "chroma-js": "^2.4.2",
@@ -80,7 +78,9 @@
     "lodash": "^4.17.21",
     "monaco-editor": "^0.38.0",
     "react-color": "^2.19.3",
-    "typescript-json-schema": "^0.56.0"
+    "typescript-json-schema": "^0.56.0",
+    "@types/react": "^>=16.x",
+    "@types/react-dom": ">=16.x"
   },
   "devDependencies": {
     "@ant-design/icons": "^5.0.1",
@@ -106,6 +106,8 @@
     "@types/jest": "^29.5.1",
     "@types/jest-diff": "^24.3.0",
     "@types/node": "^20.1.2",
+    "@types/react": "^18.2.6",
+    "@types/react-dom": "^18.2.4",
     "@types/webpack": "^5.28.1",
     "@typescript-eslint/eslint-plugin": "^5.59.5",
     "@typescript-eslint/eslint-plugin-tslint": "^5.59.5",
@@ -147,6 +149,8 @@
   },
   "peerDependencies": {
     "@ant-design/icons": "5.x",
+    "@types/react": "^>=16.x",
+    "@types/react-dom": ">=16.x",
     "antd": "5.x",
     "ol": ">=6.x",
     "react": ">=16.x",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
   },
   "peerDependencies": {
     "@ant-design/icons": "5.x",
-    "@types/react": "^>=16.x",
+    "@types/react": ">=16.x",
     "@types/react-dom": ">=16.x",
     "antd": "5.x",
     "ol": ">=6.x",


### PR DESCRIPTION
This moves the packages `@types/react` and `@types/react-dom` from dependencies to peerDependencies.

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

