### PR TITLE
Add support for unregistered projections to PreviewMap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "geostyler-wfs-parser": "^2.0.0",
         "lodash": "^4.17.21",
         "monaco-editor": "^0.38.0",
+        "proj4": "^2.9.0",
         "react-color": "^2.19.3",
         "typescript-json-schema": "^0.56.0"
       },
@@ -62,6 +63,7 @@
         "@types/jest": "^29.5.1",
         "@types/jest-diff": "^24.3.0",
         "@types/node": "^20.1.2",
+        "@types/proj4": "^2.5.2",
         "@types/react": "^18.2.6",
         "@types/react-dom": "^18.2.4",
         "@types/webpack": "^5.28.1",
@@ -5841,6 +5843,12 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
+      "dev": true
+    },
+    "node_modules/@types/proj4": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.2.tgz",
+      "integrity": "sha512-/Nmfn9p08yaYw6xo5f2b0L+2oHk2kZeOkp5v+4VCeNfq+ETlLQbmHmC97/pjDIEZy8jxwz7pdPpwNzDHM5cuJw==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -15831,6 +15839,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA=="
+    },
     "node_modules/micromark": {
       "version": "2.11.4",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
@@ -20801,6 +20814,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "node_modules/proj4": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.9.0.tgz",
+      "integrity": "sha512-BoDXEzCVnRJVZoOKA0QHTFtYoE8lUxtX1jST38DJ8U+v1ixY70Kpwi0Llu6YqSWEH2xqu4XMEBNGcgeRIEywoA==",
+      "dependencies": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.3.1"
+      }
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -26310,6 +26332,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/wkt-parser": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.3.tgz",
+      "integrity": "sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw=="
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -30735,6 +30762,12 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
+      "dev": true
+    },
+    "@types/proj4": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@types/proj4/-/proj4-2.5.2.tgz",
+      "integrity": "sha512-/Nmfn9p08yaYw6xo5f2b0L+2oHk2kZeOkp5v+4VCeNfq+ETlLQbmHmC97/pjDIEZy8jxwz7pdPpwNzDHM5cuJw==",
       "dev": true
     },
     "@types/prop-types": {
@@ -38221,6 +38254,11 @@
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true
     },
+    "mgrs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
+      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA=="
+    },
     "micromark": {
       "version": "2.11.4",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
@@ -41679,6 +41717,15 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "proj4": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.9.0.tgz",
+      "integrity": "sha512-BoDXEzCVnRJVZoOKA0QHTFtYoE8lUxtX1jST38DJ8U+v1ixY70Kpwi0Llu6YqSWEH2xqu4XMEBNGcgeRIEywoA==",
+      "requires": {
+        "mgrs": "1.0.0",
+        "wkt-parser": "^1.3.1"
+      }
     },
     "prompts": {
       "version": "2.4.2",
@@ -45723,6 +45770,11 @@
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
       }
+    },
+    "wkt-parser": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.3.tgz",
+      "integrity": "sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw=="
     },
     "word-wrap": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "geostyler-wfs-parser": "^2.0.0",
     "lodash": "^4.17.21",
     "monaco-editor": "^0.38.0",
+    "proj4": "^2.9.0",
     "react-color": "^2.19.3",
     "typescript-json-schema": "^0.56.0"
   },
@@ -104,6 +105,7 @@
     "@types/jest": "^29.5.1",
     "@types/jest-diff": "^24.3.0",
     "@types/node": "^20.1.2",
+    "@types/proj4": "^2.5.2",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "@types/webpack": "^5.28.1",

--- a/src/Component/PreviewMap/PreviewMap.example.md
+++ b/src/Component/PreviewMap/PreviewMap.example.md
@@ -31,42 +31,68 @@
 This demonstrates the usage of the `PreviewMap` component.
 
 ```jsx
-import * as React from 'react';
+import React, { useState } from 'react';
 import { PreviewMap } from 'geostyler';
 
-class PreviewMapExample extends React.Component {
-  constructor(props) {
-    super(props);
+const PreviewMapExample = () => {
+  const [style, setStyle] = useState({
+          name: "Demo Style",
+          rules: [
+            {
+              name: "Rule 1",
+              symbolizers: [
+                {
+                  kind: "Mark",
+                  wellKnownName: "circle",
+                  color: "red"
+                }
+              ]
+            }
+          ]
+        });
 
-    this.state = {
-      style: {
-        "name": "Demo Style",
-        "rules": [
-          {
-            "name": "Rule 1",
-            "symbolizers": [
-              {
-                "kind": "Mark",
-                "wellKnownName": "circle"
+  return (
+    <PreviewMap
+      style={style}
+      dataProjection="EPSG:3857"
+      data={{
+        schema: {
+          type: '',
+          properties: {}
+        },
+        exampleFeatures: {
+          type: 'FeatureCollection',
+          name: 'geojson3857',
+          features: [
+            {
+              type: 'Feature',
+              properties: { },
+              geometry: {
+                type: 'Point',
+                coordinates: [ 775420.044491838547401, 6610942.653629330918193 ]
               }
-            ]
-          }
-        ]
-      }
-    }
-  }
-
-  render() {
-    const {
-      style
-    } = this.state;
-
-    return (
-      <PreviewMap
-        style={style}
-      />
-    );
-  }
+            },
+            {
+              type: 'Feature',
+              properties: { },
+              geometry: {
+                type: 'Point',
+                coordinates: [ 775451.828557928558439, 6610064.409696962684393 ]
+              }
+            },
+            {
+              type: 'Feature',
+              properties: { },
+              geometry: {
+                type: 'Point',
+                coordinates: [ 775666.209234259324148, 6609062.071335445158184 ]
+              }
+            }
+          ]
+        }
+      }}
+    />
+  );
 }
 
 <PreviewMapExample />

--- a/src/Component/PreviewMap/PreviewMap.example.md
+++ b/src/Component/PreviewMap/PreviewMap.example.md
@@ -54,7 +54,7 @@ const PreviewMapExample = () => {
   return (
     <PreviewMap
       style={style}
-      dataProjection="EPSG:3857"
+      dataProjection="EPSG:32614"
       data={{
         schema: {
           type: '',
@@ -62,14 +62,14 @@ const PreviewMapExample = () => {
         },
         exampleFeatures: {
           type: 'FeatureCollection',
-          name: 'geojson3857',
+          name: 'geojson32614',
           features: [
             {
               type: 'Feature',
               properties: { },
               geometry: {
                 type: 'Point',
-                coordinates: [ 775420.044491838547401, 6610942.653629330918193 ]
+                coordinates: [ 785433.013395566958934, 2032298.458539120620117 ]
               }
             },
             {
@@ -77,7 +77,7 @@ const PreviewMapExample = () => {
               properties: { },
               geometry: {
                 type: 'Point',
-                coordinates: [ 775451.828557928558439, 6610064.409696962684393 ]
+                coordinates: [ 787905.450309246662073, 2030118.025881822220981 ]
               }
             },
             {
@@ -85,7 +85,7 @@ const PreviewMapExample = () => {
               properties: { },
               geometry: {
                 type: 'Point',
-                coordinates: [ 775666.209234259324148, 6609062.071335445158184 ]
+                coordinates: [ 786123.196085085393861, 2028597.680797176202759 ]
               }
             }
           ]

--- a/src/Component/PreviewMap/PreviewMap.tsx
+++ b/src/Component/PreviewMap/PreviewMap.tsx
@@ -148,7 +148,7 @@ export const PreviewMap: React.FC<PreviewMapProps> = ({
     const dataLayer = dataLayerRef.current;
     const styleParser = new OlStyleParser();
     styleParser.writeStyle(style)
-      .then(({ output: olStyles}) => {
+      .then(({ output: olStyles }) => {
         dataLayer.setStyle(olStyles);
       });
   }, [style]);
@@ -162,7 +162,7 @@ export const PreviewMap: React.FC<PreviewMapProps> = ({
     if (!data && dataLayer && map && style) {
       const geoms = GeometryUtil.getSampleGeomFromStyle(style, map.getView().getProjection());
       geoms.forEach((geometry: any) => {
-        const feature = new OlFeature({geometry});
+        const feature = new OlFeature({ geometry });
         dataLayer.getSource().addFeature(feature);
       });
       zoomToData();


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description
This enhances the `PreviewMap` example with some sample data. The sample data is in projection "EPSG:3857" to demonstrate the use of `data`  and `dataProjection`.

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

Closes #2202 

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

