### PR TITLE
Add 'data' to GeoStylerContext and introduce `useGeoStylerData` hook

### DIFF
--- a/src/Component/CardStyle/CardStyle.tsx
+++ b/src/Component/CardStyle/CardStyle.tsx
@@ -41,8 +41,6 @@ import {
   isIconSymbolizer
 } from 'geostyler-style';
 
-import { VectorData } from 'geostyler-data';
-
 import './CardStyle.less';
 import { Breadcrumb, Crumb } from '../Breadcrumb/Breadcrumb';
 import { StyleOverview } from '../StyleOverview/StyleOverview';
@@ -54,10 +52,7 @@ import { RuleGenerator } from '../RuleGenerator/RuleGenerator';
 import { BulkEditor } from '../BulkEditor/BulkEditor';
 import { IconSelector } from '../Symbolizer/IconSelector/IconSelector';
 import { Renderer } from '../Renderer/Renderer/Renderer';
-import {
-  useGeoStylerData,
-  useGeoStylerLocale
-} from '../../context/GeoStylerContext/GeoStylerContext';
+import { useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
 
 export interface CardStyleProps {
   /** The geoStylerStyle object */
@@ -93,7 +88,6 @@ export const CardStyle: React.FC<CardStyleProps> = ({
     path: [defaultCrumb]
   };
   const [currentView, setCurrentView] = useState<CardView>(defaultView);
-  const data = useGeoStylerData();
 
   const getPathForView = (viewName: string, indices: number[]): Crumb[] => {
     switch (viewName) {
@@ -321,7 +315,6 @@ export const CardStyle: React.FC<CardStyleProps> = ({
       {
         currentView.view === CLASSIFICATIONVIEW && (
           <RuleGenerator
-            data={data as VectorData}
             onRulesChange={onRulesChange}
           />
         )

--- a/src/Component/CardStyle/CardStyle.tsx
+++ b/src/Component/CardStyle/CardStyle.tsx
@@ -41,9 +41,7 @@ import {
   isIconSymbolizer
 } from 'geostyler-style';
 
-import {
-  Data, VectorData
-} from 'geostyler-data';
+import { VectorData } from 'geostyler-data';
 
 import './CardStyle.less';
 import { Breadcrumb, Crumb } from '../Breadcrumb/Breadcrumb';
@@ -56,13 +54,14 @@ import { RuleGenerator } from '../RuleGenerator/RuleGenerator';
 import { BulkEditor } from '../BulkEditor/BulkEditor';
 import { IconSelector } from '../Symbolizer/IconSelector/IconSelector';
 import { Renderer } from '../Renderer/Renderer/Renderer';
-import { useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
+import {
+  useGeoStylerData,
+  useGeoStylerLocale
+} from '../../context/GeoStylerContext/GeoStylerContext';
 
 export interface CardStyleProps {
   /** The geoStylerStyle object */
   style?: GsStyle;
-  /** Reference to internal data object (holding schema and example features) */
-  data?: Data;
   /** The callback function that is triggered when the state changes */
   onStyleChange?: (style: GsStyle) => void;
 }
@@ -83,7 +82,6 @@ const ICONLIBRARIESVIEW = CardViewUtil.ICONLIBRARIESVIEW;
 
 export const CardStyle: React.FC<CardStyleProps> = ({
   style = { name: 'My Style', rules: [] },
-  data,
   onStyleChange
 }) => {
 
@@ -95,6 +93,7 @@ export const CardStyle: React.FC<CardStyleProps> = ({
     path: [defaultCrumb]
   };
   const [currentView, setCurrentView] = useState<CardView>(defaultView);
+  const data = useGeoStylerData();
 
   const getPathForView = (viewName: string, indices: number[]): Crumb[] => {
     switch (viewName) {
@@ -272,7 +271,6 @@ export const CardStyle: React.FC<CardStyleProps> = ({
         currentView.view === STYLEVIEW && (
           <StyleOverview
             style={style}
-            data={data}
             onStyleChange={onStyleChange}
             onChangeView={changeView}
           />
@@ -282,7 +280,6 @@ export const CardStyle: React.FC<CardStyleProps> = ({
         currentView.view === RULEVIEW && (
           <RuleOverview
             rule={style.rules[currentView.path[currentView.path.length - 1].indices[0]]}
-            data={data}
             onRuleChange={onRuleChange}
             onChangeView={onRuleChangeView}
           />
@@ -297,7 +294,6 @@ export const CardStyle: React.FC<CardStyleProps> = ({
                   .rules[currentView.path[currentView.path.length - 1].indices[0]]
                   .symbolizers[currentView.path[currentView.path.length - 1].indices[1]]
               ]}
-              data={data}
             />
             <Editor
               symbolizer={
@@ -306,7 +302,6 @@ export const CardStyle: React.FC<CardStyleProps> = ({
                   .symbolizers[currentView.path[currentView.path.length - 1].indices[1]]
               }
               onSymbolizerChange={onSymbolizerChange}
-              internalDataDef={data}
             />
           </>
         )
@@ -320,14 +315,13 @@ export const CardStyle: React.FC<CardStyleProps> = ({
                 .filter
             }
             onFilterChange={onFilterChange}
-            internalDataDef={data}
           />
         )
       }
       {
         currentView.view === CLASSIFICATIONVIEW && (
           <RuleGenerator
-            internalDataDef={data as VectorData}
+            data={data as VectorData}
             onRulesChange={onRulesChange}
           />
         )

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.spec.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.spec.tsx
@@ -30,6 +30,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { AttributeCombo } from './AttributeCombo';
 import TestUtil from '../../../Util/TestUtil';
+import { GeoStylerContext } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 describe('AttributeCombo', () => {
 
@@ -46,7 +47,11 @@ describe('AttributeCombo', () => {
 
   it('calls attribute filter function for each property', () => {
     const dummyFilterFn = jest.fn();
-    render(<AttributeCombo attributeNameFilter={dummyFilterFn} />);
+    render(
+      <GeoStylerContext.Provider value={{data: dummyData}}>
+        <AttributeCombo attributeNameFilter={dummyFilterFn} />
+      </GeoStylerContext.Provider>
+    );
     const numberOfOProps = Object.keys(dummyData.schema.properties).length;
     expect(dummyFilterFn).toHaveBeenCalledTimes(numberOfOProps);
   });

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.spec.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.spec.tsx
@@ -46,10 +46,7 @@ describe('AttributeCombo', () => {
 
   it('calls attribute filter function for each property', () => {
     const dummyFilterFn = jest.fn();
-    render(<AttributeCombo
-      attributeNameFilter={dummyFilterFn}
-      internalDataDef={dummyData}
-    />);
+    render(<AttributeCombo attributeNameFilter={dummyFilterFn} />);
     const numberOfOProps = Object.keys(dummyData.schema.properties).length;
     expect(dummyFilterFn).toHaveBeenCalledTimes(numberOfOProps);
   });

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -29,8 +29,10 @@
 import React, { useLayoutEffect, useRef, useState } from 'react';
 
 import { Select, Form, Input } from 'antd';
-import { Data } from 'geostyler-data';
-import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
+import {
+  useGeoStylerData,
+  useGeoStylerLocale
+} from '../../../context/GeoStylerContext/GeoStylerContext';
 
 const Option = Select.Option;
 
@@ -46,8 +48,6 @@ export interface AttributeComboProps {
   attributeNameMappingFunction?: (originalAttributeName: string) => string;
   /** Validation status */
   validateStatus?: 'success' | 'warning' | 'error' | 'validating';
-  /** Reference to internal data object (holding schema and example features) */
-  internalDataDef?: Data;
   /** Callback function for onChange */
   onAttributeChange?: ((newAttrName: string) => void);
   /** Value set to the field */
@@ -64,12 +64,12 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
   attributeNameFilter = () => true,
   attributeNameMappingFunction =n => n,
   validateStatus = 'success',
-  internalDataDef,
   onAttributeChange,
   size
 }) => {
 
   const locale = useGeoStylerLocale('AttributeCombo');
+  const data = useGeoStylerData();
 
   const [inputSelectionStart, setInputSelectionStart] = useState<number>();
   const [inputSelectionEnd, setInputSelectionEnd] = useState<number>();
@@ -84,8 +84,8 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
 
   let options: Object[] = [];
 
-  if (internalDataDef) {
-    const attrDefs = internalDataDef.schema.properties;
+  if (data) {
+    const attrDefs = data.schema.properties;
 
     // create sth like ['foo', 'bar', 'kalle'];
     const attrNames = [];
@@ -120,7 +120,7 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
         help={helpTxt}
       >
         {
-          internalDataDef ?
+          data ?
             <Select
               value={value}
               onChange={onAttributeChange}

--- a/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
+++ b/src/Component/Filter/FilterEditorWindow/FilterEditorWindow.tsx
@@ -28,8 +28,6 @@
 
 import React from 'react';
 
-import { VectorData } from 'geostyler-data';
-
 import './FilterEditorWindow.less';
 import { Modal, ModalProps } from 'antd';
 
@@ -41,8 +39,6 @@ import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerC
 export interface FilterEditorWindowProps extends Partial<ModalProps> {
   /** The filter to edit */
   filter?: Filter;
-  /** Layer metadata in the GeoStyler VectorData format */
-  internalDataDef?: VectorData;
   /** The callback method that is triggered when the filter window closes */
   onClose?: () => void;
   /** The callback method that is triggered when the state changes */
@@ -50,7 +46,6 @@ export interface FilterEditorWindowProps extends Partial<ModalProps> {
 }
 
 export const FilterEditorWindow: React.FC<FilterEditorWindowProps> = ({
-  internalDataDef,
   onClose,
   filter,
   onFilterChange,
@@ -70,7 +65,6 @@ export const FilterEditorWindow: React.FC<FilterEditorWindowProps> = ({
       {...passThroughProps}
     >
       <FilterTree
-        internalDataDef={internalDataDef}
         filter={filter}
         onFilterChange={onFilterChange}
       />

--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -55,10 +55,6 @@ import {
 
 import './FilterTree.less';
 
-import {
-  Data as Data
-} from 'geostyler-data';
-
 import { ComparisonFilter } from '../ComparisonFilter/ComparisonFilter';
 
 import {
@@ -75,8 +71,6 @@ import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerC
 export interface FilterTreeProps {
   /** The filter to edit */
   filter?: Filter;
-  /** Reference to internal data object (holding schema and example features) */
-  internalDataDef?: Data;
   /** Callback function for onFilterChange */
   onFilterChange?: ((compFilter: Filter) => void);
 }
@@ -90,7 +84,6 @@ export interface FilterTreeProps {
  */
 export const FilterTree: React.FC<FilterTreeProps & Partial<TreeProps>> = ({
   filter: rootFilter = ['==', '', null],
-  internalDataDef,
   onFilterChange,
   ...passThroughProps
 }) => {
@@ -260,7 +253,6 @@ export const FilterTree: React.FC<FilterTreeProps & Partial<TreeProps>> = ({
         <span className="node-title">
           <ComparisonFilter
             microUI={true}
-            internalDataDef={internalDataDef}
             filter={filter}
             onFilterChange={f => onComparisonFilterChange(f, position)}
           />

--- a/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
@@ -70,7 +70,7 @@ describe('TextFilterField', () => {
   describe('AutoComplete', () => {
 
     it('renders as Autocomplete if data is passed and attribute is selected', () => {
-      const field = render(<TextFilterField selectedAttribute="bar" internalDataDef={dummyData} />);
+      const field = render(<TextFilterField selectedAttribute="bar" />);
       const autocomplete = field.queryByRole('combobox');
       const textInput = document.querySelector('.ant-input');
       expect(autocomplete).toBeInTheDocument();
@@ -82,7 +82,6 @@ describe('TextFilterField', () => {
       const field = render(<TextFilterField
         onValueChange={onChangeMock}
         selectedAttribute="bar"
-        internalDataDef={dummyData}
       />);
       const input = await field.findByRole('combobox');
       await act(async() => {

--- a/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.spec.tsx
@@ -30,6 +30,7 @@ import React from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { TextFilterField } from './TextFilterField';
 import TestUtil from '../../../Util/TestUtil';
+import { GeoStylerContext } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 describe('TextFilterField', () => {
 
@@ -70,7 +71,11 @@ describe('TextFilterField', () => {
   describe('AutoComplete', () => {
 
     it('renders as Autocomplete if data is passed and attribute is selected', () => {
-      const field = render(<TextFilterField selectedAttribute="bar" />);
+      const field = render(
+        <GeoStylerContext.Provider value={{data: dummyData}}>
+          <TextFilterField selectedAttribute="bar" />
+        </GeoStylerContext.Provider>
+      );
       const autocomplete = field.queryByRole('combobox');
       const textInput = document.querySelector('.ant-input');
       expect(autocomplete).toBeInTheDocument();
@@ -79,10 +84,14 @@ describe('TextFilterField', () => {
 
     it('calls onValueChange of props', async() => {
       const onChangeMock = jest.fn();
-      const field = render(<TextFilterField
-        onValueChange={onChangeMock}
-        selectedAttribute="bar"
-      />);
+      const field = render(
+        <GeoStylerContext.Provider value={{data: dummyData}}>
+          <TextFilterField
+            onValueChange={onChangeMock}
+            selectedAttribute="bar"
+          />
+        </GeoStylerContext.Provider>
+      );
       const input = await field.findByRole('combobox');
       await act(async() => {
         fireEvent.mouseDown(input);

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -29,13 +29,15 @@
 import React, { useLayoutEffect, useRef, useState } from 'react';
 
 import { Input, Form, AutoComplete, InputRef } from 'antd';
-import { Data } from 'geostyler-data';
 
 import _get from 'lodash/get';
 import { Feature } from 'geojson';
 
 import './TextFilterField.less';
-import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
+import {
+  useGeoStylerData,
+  useGeoStylerLocale
+} from '../../../context/GeoStylerContext/GeoStylerContext';
 
 export interface TextFilterFieldProps {
   /** Label for this field */
@@ -46,8 +48,6 @@ export interface TextFilterFieldProps {
   value?: string | undefined;
   /** Validation status */
   validateStatus?: 'success' | 'warning' | 'error' | 'validating';
-  /** Reference to internal data object (holding schema and example features) */
-  internalDataDef?: Data;
   /** Callback function for onChange */
   onValueChange?: (newValue: string) => void;
   /** The selected attribute name */
@@ -61,12 +61,11 @@ export interface TextFilterFieldProps {
 export const TextFilterField: React.FC<TextFilterFieldProps> = ({
   value,
   validateStatus = 'success',
-  internalDataDef,
   onValueChange,
   selectedAttribute,
   size
 }) => {
-
+  const data = useGeoStylerData();
   const locale = useGeoStylerLocale('TextFilterField');
 
   const inputRef = useRef<InputRef>();
@@ -99,8 +98,8 @@ export const TextFilterField: React.FC<TextFilterFieldProps> = ({
   const helpTxt = validateStatus !== 'success' ? locale.help : null;
 
   let sampleValues: string[] = [];
-  if (internalDataDef && 'exampleFeatures' in internalDataDef) {
-    const features = internalDataDef?.exampleFeatures?.features;
+  if (data && 'exampleFeatures' in data) {
+    const features = data?.exampleFeatures?.features;
     features.forEach((feature: Feature) => {
       const sampleValue = _get(feature, `properties[${selectedAttribute}]`);
       if (sampleValue && sampleValues.indexOf(sampleValue) === -1) {

--- a/src/Component/PreviewMap/PreviewMap.tsx
+++ b/src/Component/PreviewMap/PreviewMap.tsx
@@ -34,8 +34,6 @@ import OlSourceVector from 'ol/source/Vector';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
 import { Projection, ProjectionLike } from 'ol/proj';
 import OlFeature from 'ol/Feature';
-import OlLayerTile from 'ol/layer/Tile';
-import OlSourceOSM from 'ol/source/OSM';
 import {
   get as getProjection,
 } from 'ol/proj';
@@ -46,7 +44,7 @@ import proj4 from 'proj4';
 import { isEmpty } from 'ol/extent';
 
 import { Style } from 'geostyler-style';
-import { Data, VectorData } from 'geostyler-data';
+import { VectorData } from 'geostyler-data';
 import OlStyleParser from 'geostyler-openlayers-parser';
 
 import GeometryUtil from '../../Util/GeometryUtil';
@@ -54,19 +52,13 @@ import GeometryUtil from '../../Util/GeometryUtil';
 import './PreviewMap.less';
 import { StandardLonghandProperties } from 'csstype';
 import { isString } from 'lodash';
+import { useGeoStylerData } from '../../context/GeoStylerContext/GeoStylerContext';
 
-// default props
-export interface PreviewMapDefaultProps {
+export interface PreviewMapProps {
   /** The projection of the data to visualize */
-  dataProjection: ProjectionLike;
+  dataProjection?: ProjectionLike;
   /** The height of the map */
-  mapHeight: StandardLonghandProperties['height'];
-}
-
-// non default props
-export interface PreviewMapProps extends Partial<PreviewMapDefaultProps> {
-  /** The data to visualize */
-  data?: Data;
+  mapHeight?: StandardLonghandProperties['height'];
   /** The GeoStyler Style to preview */
   style: Style;
   /** A custom map used for rendering */
@@ -81,13 +73,14 @@ export interface PreviewMapProps extends Partial<PreviewMapDefaultProps> {
 export const PreviewMap: React.FC<PreviewMapProps> = ({
   dataProjection = 'EPSG:4326',
   mapHeight = 267,
-  data,
   style,
   map: mapProp,
   onMapDidMount
 }) => {
 
   const containerRef = useRef();
+
+  const data = useGeoStylerData();
 
   /** the vector layer for the passed features */
   const dataLayerRef = useRef<OlLayerVector<any>>(new OlLayerVector({
@@ -100,9 +93,6 @@ export const PreviewMap: React.FC<PreviewMapProps> = ({
     new OlMap({
       controls: [],
       layers: [
-        new OlLayerTile({
-          source: new OlSourceOSM()
-        }),
         dataLayerRef.current
       ]
     })

--- a/src/Component/Renderer/OlRenderer/OlRenderer.tsx
+++ b/src/Component/Renderer/OlRenderer/OlRenderer.tsx
@@ -44,15 +44,14 @@ import { Symbolizer, SymbolizerKind } from 'geostyler-style';
 import './OlRenderer.less';
 
 import 'ol/ol.css';
-import { Data } from 'geostyler-data';
 
 import _isEqual from 'lodash/isEqual';
 import _get from 'lodash/get';
 import _uniqueId from 'lodash/uniqueId';
+import { useGeoStylerData } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 // non default props
 export interface OlRendererProps {
-  data?: Data;
   symbolizers: Symbolizer[];
   symbolizerKind?: SymbolizerKind;
   onClick?: (symbolizers: Symbolizer[], event: any) => void;
@@ -62,7 +61,6 @@ export interface OlRendererProps {
  * Symbolizer Renderer UI.
  */
 export const OlRenderer: React.FC<OlRendererProps> = ({
-  data,
   onClick,
   symbolizerKind,
   symbolizers
@@ -72,6 +70,7 @@ export const OlRenderer: React.FC<OlRendererProps> = ({
   const map = useRef<OlMap>();
   const layer = useRef<OlLayerVector<any>>();
   const [ mapId ] = useState(_uniqueId('map_'));
+  const data = useGeoStylerData();
 
   const getSampleGeomFromSymbolizer = useCallback(() => {
     const kind: SymbolizerKind = symbolizerKind || _get(symbolizers, '[0].kind');

--- a/src/Component/RuleCard/RuleCard.tsx
+++ b/src/Component/RuleCard/RuleCard.tsx
@@ -38,10 +38,9 @@ import './RuleCard.less';
 import { Renderer } from '../Renderer/Renderer/Renderer';
 import FilterUtil from '../../Util/FilterUtil';
 import DataUtil from '../../Util/DataUtil';
-import { Data } from 'geostyler-data';
 import { Divider, Card, Typography } from 'antd';
 import { BlockOutlined, FilterFilled, MinusOutlined } from '@ant-design/icons';
-import { useGeoStylerComposition } from '../../context/GeoStylerContext/GeoStylerContext';
+import { useGeoStylerComposition, useGeoStylerData } from '../../context/GeoStylerContext/GeoStylerContext';
 const { Text } = Typography;
 
 export interface RuleComposableProps {
@@ -70,8 +69,6 @@ export interface RuleCardInternalProps {
   rule: GsRule;
   /** The number of features that are also matched by other rules. */
   duplicates?: number;
-  /** Reference to internal data object (holding schema and example features). */
-  data?: Data;
   /** The callback when the card was clicked. */
   onClick?: () => void;
 }
@@ -80,14 +77,14 @@ export type RuleCardProps = RuleCardInternalProps & RuleComposableProps;
 
 export const RuleCard: React.FC<RuleCardProps> = (props) => {
 
-  const composition = useGeoStylerComposition('Rule');
+  const data = useGeoStylerData();
 
-  const composed = { ...props, ...composition };
+  const composition = useGeoStylerComposition('Rule');
+  const composed = {...props, ...composition};
   const {
     rule,
     duplicates,
     onClick,
-    data,
     amountField,
     duplicateField,
     filterField,
@@ -115,7 +112,6 @@ export const RuleCard: React.FC<RuleCardProps> = (props) => {
     >
       <Renderer
         symbolizers={rule.symbolizers}
-        data={data}
       />
       <Divider type='vertical' />
       <div className='gs-rule-card-content'>

--- a/src/Component/RuleFieldContainer/RuleFieldContainer.tsx
+++ b/src/Component/RuleFieldContainer/RuleFieldContainer.tsx
@@ -38,7 +38,6 @@ import { MinScaleDenominator } from '../ScaleDenominator/MinScaleDenominator';
 import { MaxScaleDenominator } from '../ScaleDenominator/MaxScaleDenominator';
 import { Renderer } from '../Renderer/Renderer/Renderer';
 import { Expression, Symbolizer } from 'geostyler-style';
-import { Data } from 'geostyler-data';
 import { useGeoStylerComposition, useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
 import { RuleComposableProps } from '../RuleCard/RuleCard';
 
@@ -61,8 +60,6 @@ export interface RuleFieldContainerInternalProps {
   maxScale?: Expression<number>;
   /** The symbolizers of the rule */
   symbolizers?: Symbolizer[];
-  /** Reference to internal data object (holding schema and example features). */
-  data?: Data;
 }
 
 export type RuleFieldContainerProps = RuleFieldContainerInternalProps & RuleFieldContainerComposableProps;
@@ -73,7 +70,6 @@ export const RuleFieldContainer: React.FC<RuleFieldContainerProps> = (props) => 
 
   const composed = { ...props, ...composition };
   const {
-    data,
     maxScale,
     maxScaleField,
     minScale,
@@ -126,10 +122,7 @@ export const RuleFieldContainer: React.FC<RuleFieldContainerProps> = (props) => 
         </Form>
       </div>
       <Divider type="vertical" />
-      <Renderer
-        symbolizers={symbolizers}
-        data={data}
-      />
+      <Renderer symbolizers={symbolizers} />
     </FieldContainer >
   );
 

--- a/src/Component/RuleGenerator/RuleGenerator.example.md
+++ b/src/Component/RuleGenerator/RuleGenerator.example.md
@@ -142,7 +142,7 @@ const RuleGeneratorExample = ({}) => {
 
   return (
     <div>
-      <RuleGenerator internalDataDef={data} onRulesChange={setRules} />
+      <RuleGenerator data={data} onRulesChange={setRules} />
       <RuleTable rules={rules} />
     </div>
   );

--- a/src/Component/RuleGenerator/RuleGenerator.spec.tsx
+++ b/src/Component/RuleGenerator/RuleGenerator.spec.tsx
@@ -38,7 +38,7 @@ describe('RuleGenerator', () => {
 
   const dummyData: Data = TestUtil.getDummyGsData();
   const props: RuleGeneratorProps = {
-    internalDataDef: dummyData
+    data: dummyData
   };
 
   it('is defined', () => {

--- a/src/Component/RuleGenerator/RuleGenerator.tsx
+++ b/src/Component/RuleGenerator/RuleGenerator.tsx
@@ -45,7 +45,11 @@ import { ColorsPreview } from './ColorsPreview/ColorsPreview';
 import { ClassificationCombo, ClassificationMethod } from './ClassificationCombo/ClassificationCombo';
 import _get from 'lodash/get';
 import { PlusSquareOutlined } from '@ant-design/icons';
-import { useGeoStylerComposition, useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
+import {
+  useGeoStylerComposition,
+  useGeoStylerData,
+  useGeoStylerLocale
+} from '../../context/GeoStylerContext/GeoStylerContext';
 
 export type LevelOfMeasurement = 'nominal' | 'ordinal' | 'cardinal';
 
@@ -59,7 +63,6 @@ export interface RuleGeneratorComposableProps {
 }
 
 export interface RuleGeneratorInternalProps {
-  internalDataDef: VectorData;
   onRulesChange?: (rules: Rule[]) => void;
 }
 
@@ -67,10 +70,10 @@ export type RuleGeneratorProps = RuleGeneratorInternalProps & RuleGeneratorCompo
 
 export const RuleGenerator: React.FC<RuleGeneratorProps> = (props) => {
 
+  const data = useGeoStylerData() as VectorData;
   const composition = useGeoStylerComposition('RuleGenerator');
   const composed = {...props, ...composition};
   const {
-    internalDataDef,
     onRulesChange,
     colorSpaces = ['hsl', 'hsv', 'hsi', 'lab', 'lch', 'hcl', 'rgb'], // rgba, cmyk and gl crash
     colorRamps = {
@@ -85,7 +88,7 @@ export const RuleGenerator: React.FC<RuleGeneratorProps> = (props) => {
   const minNrClasses = 2;
 
   const [symbolizerKind, setSymbolizerKind] = useState<SymbolizerKind>(
-    RuleGeneratorUtil.guessSymbolizerFromData(internalDataDef)
+    RuleGeneratorUtil.guessSymbolizerFromData(data)
   );
   const [wellKnownName, setWellKnownName] = useState<WellKnownName>('circle');
   const [colorRamp, setColorRamp] = useState<string>(colorRamps && colorRamps.GeoStyler ? 'GeoStyler' : undefined);
@@ -100,13 +103,13 @@ export const RuleGenerator: React.FC<RuleGeneratorProps> = (props) => {
 
   const onAttributeChange = (newAttributeName: string) => {
     try {
-      const newAttributeType = _get(internalDataDef, `schema.properties[${newAttributeName}].type`);
+      const newAttributeType = _get(data, `schema.properties[${newAttributeName}].type`);
       let newClassficationMethod = classificationMethod;
       if (newAttributeType === 'string' && classificationMethod === 'kmeans') {
         newClassficationMethod = undefined;
       }
 
-      const newDistinctValues = RuleGeneratorUtil.getDistinctValues(internalDataDef, newAttributeName) || [];
+      const newDistinctValues = RuleGeneratorUtil.getDistinctValues(data, newAttributeName) || [];
       setAttributeName(newAttributeName);
       setAttributeType(newAttributeType);
       setDistinctValues(newDistinctValues);
@@ -144,7 +147,7 @@ export const RuleGenerator: React.FC<RuleGeneratorProps> = (props) => {
         attributeName,
         classificationMethod,
         colors: colorRamps[colorRamp],
-        data: internalDataDef,
+        data,
         levelOfMeasurement,
         numberOfRules,
         symbolizerKind,
@@ -174,7 +177,6 @@ export const RuleGenerator: React.FC<RuleGeneratorProps> = (props) => {
       <Form layout="vertical">
         <AttributeCombo
           value={attributeName}
-          internalDataDef={internalDataDef}
           onAttributeChange={onAttributeChange}
           validateStatus={attributeName ? 'success' : 'warning'}
         />

--- a/src/Component/RuleGenerator/RuleGeneratorWindow.spec.tsx
+++ b/src/Component/RuleGenerator/RuleGeneratorWindow.spec.tsx
@@ -27,26 +27,18 @@
  */
 import React from 'react';
 import {
-  RuleGeneratorWindow,
-  RuleGeneratorWindowProps
+  RuleGeneratorWindow
 } from './RuleGeneratorWindow';
-import TestUtil from '../../Util/TestUtil';
-import { Data } from 'geostyler-data';
 import { render } from '@testing-library/react';
 
 describe('RuleGeneratorWindow', () => {
-
-  const dummyData: Data = TestUtil.getDummyGsData();
-  const props: RuleGeneratorWindowProps = {
-    internalDataDef: dummyData
-  };
 
   it('is defined', () => {
     expect(RuleGeneratorWindow).toBeDefined();
   });
 
   it('renders correctly', () => {
-    const ruleGeneratorWindow = render(<RuleGeneratorWindow {...props} />);
+    const ruleGeneratorWindow = render(<RuleGeneratorWindow />);
     expect(ruleGeneratorWindow.container).toBeInTheDocument();
   });
 

--- a/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
+++ b/src/Component/RuleGenerator/RuleGeneratorWindow.tsx
@@ -33,8 +33,6 @@ import {
   Rule
 } from 'geostyler-style';
 
-import { VectorData } from 'geostyler-data';
-
 import './RuleGeneratorWindow.less';
 import { Modal, ModalProps } from 'antd';
 
@@ -44,9 +42,7 @@ import _isEqual from 'lodash/isEqual';
 import _isFinite from 'lodash/isFinite';
 import { useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
 
-// non default props
 export interface RuleGeneratorWindowProps extends Partial<ModalProps> {
-  internalDataDef: VectorData;
   onClose?: () => void;
   onRulesChange?: (rules: Rule[]) => void;
   colorRamps?: {
@@ -57,7 +53,6 @@ export interface RuleGeneratorWindowProps extends Partial<ModalProps> {
 }
 
 export const RuleGeneratorWindow: React.FC<RuleGeneratorWindowProps> = ({
-  internalDataDef,
   onClose,
   onRulesChange,
   ...passThroughProps
@@ -76,7 +71,6 @@ export const RuleGeneratorWindow: React.FC<RuleGeneratorWindowProps> = ({
       {...passThroughProps}
     >
       <RuleGenerator
-        internalDataDef={internalDataDef}
         onRulesChange={onRulesChange}
       />
     </Modal>

--- a/src/Component/RuleOverview/RuleOverview.tsx
+++ b/src/Component/RuleOverview/RuleOverview.tsx
@@ -35,7 +35,6 @@ import {
 } from 'geostyler-style';
 
 import './RuleOverview.less';
-import { Data } from 'geostyler-data';
 
 import { RuleFieldContainer } from '../RuleFieldContainer/RuleFieldContainer';
 import { Divider } from 'antd';
@@ -52,8 +51,6 @@ export interface RuleOverviewInternalProps {
   onRuleChange?: (rule: GsRule) => void;
   /** The callback when a view change (request) was triggered. */
   onChangeView?: (view: string, indices: number[]) => void;
-  /** Reference to internal data object (holding schema and example features). */
-  data?: Data;
   /** A GeoStyler-Style object. */
   rule: GsRule;
 }
@@ -66,7 +63,6 @@ export const RuleOverview: React.FC<RuleOverviewProps> = (props) => {
 
   const composed = { ...props, ...composition };
   const {
-    data,
     onChangeView = () => { },
     onRuleChange = () => { },
     rule,
@@ -123,13 +119,11 @@ export const RuleOverview: React.FC<RuleOverviewProps> = (props) => {
         onMinScaleChange={onMinScaleChange}
         onMaxScaleChange={onMaxScaleChange}
         symbolizers={rule.symbolizers}
-        data={data}
       />
       <Symbolizers
         symbolizers={rule.symbolizers}
         onEditSymbolizerClick={onEditSymbolizerClick}
         onSymbolizersChange={onSymbolizersChange}
-        data={data}
       />
       {
         filterField?.visibility === false ? null : (

--- a/src/Component/RuleTable/RuleTable.spec.tsx
+++ b/src/Component/RuleTable/RuleTable.spec.tsx
@@ -33,6 +33,7 @@ import { RuleTable } from './RuleTable';
 import TestUtil from '../../Util/TestUtil';
 import { Rule } from 'geostyler-style';
 import { Data } from 'geostyler-data';
+import { GeoStylerContext } from '../../context/GeoStylerContext/GeoStylerContext';
 
 describe('RuleTable', () => {
   let dummyRules: Rule[];
@@ -71,10 +72,11 @@ describe('RuleTable', () => {
   beforeEach(() => {
     dummyRules = TestUtil.getTwoRulesStyle().rules;
     ruleTable = render(
-      <RuleTable
-        rules={dummyRules}
-        data={data}
-      />
+      <GeoStylerContext.Provider value={{data}}>
+        <RuleTable
+          rules={dummyRules}
+        />
+      </GeoStylerContext.Provider>
     );
   });
 
@@ -82,20 +84,20 @@ describe('RuleTable', () => {
     expect(RuleTable).toBeDefined();
   });
 
-  test('… renders', async() => {
+  test('… renders', () => {
     expect(ruleTable.container).toBeInTheDocument();
   });
 
   describe('SymbolizerRenderer', () => {
-    it('… renders a symbolizer for every rule', async() => {
-      const symbolizerRenderer = await ruleTable.container.querySelectorAll('.gs-symbolizer-olrenderer');
+    it('… renders a symbolizer for every rule', () => {
+      const symbolizerRenderer = ruleTable.container.querySelectorAll('.gs-symbolizer-olrenderer');
       expect(symbolizerRenderer).toHaveLength(2);
     });
   });
 
   describe('NameRenderer', () => {
-    it('… renders the name for every rule', async() => {
-      const nameRenderers = await ruleTable.container.querySelectorAll<HTMLInputElement>('input[name=name-renderer]');
+    it('… renders the name for every rule', () => {
+      const nameRenderers = ruleTable.container.querySelectorAll<HTMLInputElement>('input[name=name-renderer]');
       nameRenderers.forEach((nameRenderer, index) => {
         expect(nameRenderers[index].value).toBe(dummyRules[index].name);
       });
@@ -103,32 +105,32 @@ describe('RuleTable', () => {
   });
 
   describe('FilterRenderer', () => {
-    it('… renders the filter for every rule', async() => {
+    it('… renders the filter for every rule', () => {
       const rulesWithFilter = TestUtil.getTwoRulesStyle().rules;
       rulesWithFilter[0].filter = ['==', 'name', 'Peter'];
       rulesWithFilter[1].filter = TestUtil.getDummyGsFilter();
       ruleTable.rerender(<RuleTable
         rules={rulesWithFilter}
-        data={data}
       />);
-      const filterRenderers = await ruleTable.container.querySelectorAll<HTMLInputElement>('input[name=filter-renderer]');
+      const filterRenderers = ruleTable.container.querySelectorAll<HTMLInputElement>('input[name=filter-renderer]');
       expect(filterRenderers[0].value).toBe('name = \'Peter\'');
       expect(filterRenderers[1].value).toBe('state = \'germany\' AND (population >= 100000 OR population < 200000) AND NOT ( name = \'Schalke\' )');
     });
   });
 
   describe('MinScaleRenderer', () => {
-    it('… renders the minScale for every rule', async() => {
+    it('… renders the minScale for every rule', () => {
       const rulesWithMinScale = TestUtil.getTwoRulesStyle().rules;
       rulesWithMinScale[0].scaleDenominator = {
         min: 12,
         max: 24
       };
-      ruleTable.rerender(<RuleTable
-        rules={rulesWithMinScale}
-        data={data}
-      />);
-      const minScaleRenderers = await ruleTable.container.querySelectorAll<HTMLInputElement>('input[name=min-scale-renderer]');
+      ruleTable.rerender(
+        <GeoStylerContext.Provider value={{data}}>
+          <RuleTable rules={rulesWithMinScale} />
+        </GeoStylerContext.Provider>
+      );
+      const minScaleRenderers = ruleTable.container.querySelectorAll<HTMLInputElement>('input[name=min-scale-renderer]');
       minScaleRenderers.forEach((nameRenderer, index) => {
         const expected = rulesWithMinScale[index].scaleDenominator?.min
           ? `1:${rulesWithMinScale[index]?.scaleDenominator?.min}`
@@ -139,17 +141,18 @@ describe('RuleTable', () => {
   });
 
   describe('MaxScaleRenderer', () => {
-    it('… renders the maxScale for every rule', async() => {
+    it('… renders the maxScale for every rule', () => {
       const rulesWithMaxScale = TestUtil.getTwoRulesStyle().rules;
       rulesWithMaxScale[0].scaleDenominator = {
         min: 12,
         max: 24
       };
-      ruleTable.rerender(<RuleTable
-        rules={rulesWithMaxScale}
-        data={data}
-      />);
-      const maxScaleRenderers = await ruleTable.container.querySelectorAll<HTMLInputElement>('input[name=max-scale-renderer]');
+      ruleTable.rerender(
+        <GeoStylerContext.Provider value={{data}}>
+          <RuleTable rules={rulesWithMaxScale} />
+        </GeoStylerContext.Provider>
+      );
+      const maxScaleRenderers = ruleTable.container.querySelectorAll<HTMLInputElement>('input[name=max-scale-renderer]');
       maxScaleRenderers.forEach((nameRenderer, index) => {
         const expected = rulesWithMaxScale[index].scaleDenominator?.max
           ? `1:${rulesWithMaxScale[index]?.scaleDenominator?.max}`
@@ -160,21 +163,22 @@ describe('RuleTable', () => {
   });
 
   describe('AmountRenderer', () => {
-    it('… returns the count of features in the FeatureCollection', async() => {
-      const amountRenderers = await ruleTable.container.querySelectorAll<HTMLInputElement>('.amount-renderer');
+    it('… returns the count of features in the FeatureCollection', () => {
+      const amountRenderers = ruleTable.container.querySelectorAll<HTMLInputElement>('.amount-renderer');
       expect(amountRenderers.length).toBe(2);
       expect(amountRenderers[0].innerHTML).toBe('2');
       expect(amountRenderers[1].innerHTML).toBe('2');
     });
-    it('… returns the count of the matching features when filter and data present', async() => {
+    it('… returns the count of the matching features when filter and data present', () => {
       const rulesWithFilter = TestUtil.getTwoRulesStyle().rules;
       rulesWithFilter[0].filter = ['==', 'name', 'Peter'];
       rulesWithFilter[1].filter = TestUtil.getDummyGsFilter();
-      ruleTable.rerender(<RuleTable
-        rules={rulesWithFilter}
-        data={data}
-      />);
-      const amountRenderers = await ruleTable.container.querySelectorAll<HTMLInputElement>('.amount-renderer');
+      ruleTable.rerender(
+        <GeoStylerContext.Provider value={{data}}>
+          <RuleTable rules={rulesWithFilter} />
+        </GeoStylerContext.Provider>
+      );
+      const amountRenderers = ruleTable.container.querySelectorAll<HTMLInputElement>('.amount-renderer');
       expect(amountRenderers).toHaveLength(2);
       expect(amountRenderers[0].innerHTML).toBe('1');
       expect(amountRenderers[1].innerHTML).toBe('0');
@@ -182,15 +186,16 @@ describe('RuleTable', () => {
   });
 
   describe('DuplicatesRenderer', () => {
-    it('… returns duplicates when data and rules are present', async() => {
+    it('… returns duplicates when data and rules are present', () => {
       const rulesWithFilter = TestUtil.getTwoRulesStyle().rules;
       rulesWithFilter[0].filter = ['==', 'name', 'Peter'];
       rulesWithFilter[1].filter = ['!=', 'name', 'Hilde'];
-      ruleTable.rerender(<RuleTable
-        rules={rulesWithFilter}
-        data={data}
-      />);
-      const duplicatesRenderers = await ruleTable.container.querySelectorAll<HTMLInputElement>('.duplicates-renderer');
+      ruleTable.rerender(
+        <GeoStylerContext.Provider value={{data}}>
+          <RuleTable rules={rulesWithFilter} />
+        </GeoStylerContext.Provider>
+      );
+      const duplicatesRenderers = ruleTable.container.querySelectorAll<HTMLInputElement>('.duplicates-renderer');
       expect(duplicatesRenderers).toHaveLength(2);
       expect(duplicatesRenderers[0].innerHTML).toBe('1');
       expect(duplicatesRenderers[1].innerHTML).toBe('1');
@@ -198,19 +203,19 @@ describe('RuleTable', () => {
   });
 
   describe('RuleOrderRenderer', () => {
-    it('… renders', async() => {
-      const upButtons = await ruleTable.getAllByTitle('Move rule one position up');
-      const downButtons = await ruleTable.getAllByTitle('Move rule one position down');
+    it('… renders', () => {
+      const upButtons = ruleTable.getAllByTitle('Move rule one position up');
+      const downButtons = ruleTable.getAllByTitle('Move rule one position down');
       expect(upButtons).toHaveLength(2);
       expect(downButtons).toHaveLength(2);
     });
-    it('… disables up button for first row', async() => {
-      const upButtons = await ruleTable.getAllByTitle('Move rule one position up');
+    it('… disables up button for first row', () => {
+      const upButtons = ruleTable.getAllByTitle('Move rule one position up');
       expect(upButtons).toHaveLength(2);
       expect(upButtons[0]).toHaveAttribute('disabled');
     });
-    it('… disables down button for last row', async() => {
-      const downButtons = await ruleTable.getAllByTitle('Move rule one position down');
+    it('… disables down button for last row', () => {
+      const downButtons = ruleTable.getAllByTitle('Move rule one position down');
       expect(downButtons).toHaveLength(2);
       expect(downButtons[downButtons.length - 1]).toHaveAttribute('disabled');
     });

--- a/src/Component/Rules/Rules.tsx
+++ b/src/Component/Rules/Rules.tsx
@@ -38,7 +38,6 @@ import { arrayMove, SortableContext } from '@dnd-kit/sortable';
 
 import FilterUtil, { CountResult } from '../../Util/FilterUtil';
 import DataUtil from '../../Util/DataUtil';
-import { Data } from 'geostyler-data';
 import { Button, Switch, Divider } from 'antd';
 
 import _cloneDeep from 'lodash/cloneDeep';
@@ -48,7 +47,11 @@ import { RuleCard } from '../RuleCard/RuleCard';
 import { useDragDropSensors } from '../../hook/UseDragDropSensors';
 import { SortableItem } from '../SortableItem/SortableItem';
 import { RemovableItem } from '../RemovableItem/RemovableItem';
-import { useGeoStylerComposition, useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
+import {
+  useGeoStylerComposition,
+  useGeoStylerData,
+  useGeoStylerLocale
+} from '../../context/GeoStylerContext/GeoStylerContext';
 
 import './Rules.less';
 
@@ -63,8 +66,6 @@ export interface RulesInternalProps {
   showDuplicates?: boolean;
   /** List of rules to display in rule table */
   rules: GsRule[];
-  /** Reference to internal data object (holding schema and example features) */
-  data?: Data;
   /** The callback function that is triggered when the rules change */
   onRulesChange?: (rules: GsRule[]) => void;
   /** The callback function that is triggered when the classification button was clicked */
@@ -79,11 +80,11 @@ export type RulesProps = RulesInternalProps & RulesComposableProps;
 
 export const Rules: React.FC<RulesProps> = (props) => {
 
-  const composition = useGeoStylerComposition('Rules');
+  const data = useGeoStylerData();
 
-  const composed = { ...props, ...composition };
+  const composition = useGeoStylerComposition('Rules');
+  const composed = {...props, ...composition};
   const {
-    data,
     disableClassification,
     onClassificationClick,
     onEditRuleClick,
@@ -182,7 +183,6 @@ export const Rules: React.FC<RulesProps> = (props) => {
       <RuleCard
         key={_uniqueId('rule')}
         rule={rule}
-        data={data}
         duplicates={ruleDuplicates}
         onClick={() => {
           if (!multiEditActive) {

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -46,10 +46,6 @@ import {
   WellKnownName as GsWellKnownName
 } from 'geostyler-style';
 
-import {
-  Data, VectorData
-} from 'geostyler-data';
-
 import { NameField } from '../NameField/NameField';
 import { BulkEditModals } from '../Symbolizer/BulkEditModals/BulkEditModals';
 import SymbolizerUtil from '../../Util/SymbolizerUtil';
@@ -57,7 +53,11 @@ import { RuleTable } from '../RuleTable/RuleTable';
 import { RuleGeneratorWindow } from '../RuleGenerator/RuleGeneratorWindow';
 import { CopyOutlined, MenuUnfoldOutlined, MinusOutlined, PlusOutlined } from '@ant-design/icons';
 import { ItemType } from 'antd/lib/menu/hooks/useItems';
-import { useGeoStylerComposition, useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
+import {
+  useGeoStylerComposition,
+  useGeoStylerData,
+  useGeoStylerLocale
+} from '../../context/GeoStylerContext/GeoStylerContext';
 
 import './Style.less';
 
@@ -69,8 +69,6 @@ export interface StyleComposableProps {
 export interface StyleInternalProps {
   /** The geoStylerStyle object */
   style?: GsStyle;
-  /** Reference to internal data object (holding schema and example features) */
-  data?: Data;
   /** The callback function that is triggered when the state changes */
   onStyleChange?: (style: GsStyle) => void;
 }
@@ -78,6 +76,8 @@ export interface StyleInternalProps {
 export type StyleProps = StyleInternalProps & StyleComposableProps;
 
 export const Style: React.FC<StyleProps> = (props) => {
+
+  const data = useGeoStylerData();
 
   const composition = useGeoStylerComposition('Style');
   const composed = { ...props, composition };
@@ -87,7 +87,6 @@ export const Style: React.FC<StyleProps> = (props) => {
       name: 'My Style',
       rules: []
     },
-    data,
     onStyleChange
   } = composed;
 
@@ -398,7 +397,6 @@ export const Style: React.FC<StyleProps> = (props) => {
       </div>
       <RuleGeneratorWindow
         open={ruleGeneratorWindowVisible}
-        internalDataDef={data as VectorData}
         onClose={onRuleGeneratorWindowClose}
         onRulesChange={onRulesChange}
       />
@@ -409,7 +407,6 @@ export const Style: React.FC<StyleProps> = (props) => {
           selectedRowKeys,
           onChange: onRulesSelectionChange
         }}
-        data={data}
         footer={createFooter}
       />
       <BulkEditModals

--- a/src/Component/StyleOverview/StyleOverview.tsx
+++ b/src/Component/StyleOverview/StyleOverview.tsx
@@ -29,35 +29,34 @@
 
 import React from 'react';
 
+import _cloneDeep from 'lodash/cloneDeep';
+
+import { Divider } from 'antd';
+
 import {
   Rule as GsRule,
   Style as GsStyle
 } from 'geostyler-style';
 
-import './StyleOverview.less';
-import { Data } from 'geostyler-data';
 import { StyleFieldContainer } from '../StyleFieldContainer/StyleFieldContainer';
 import { Rules } from '../Rules/Rules';
 
-import _cloneDeep from 'lodash/cloneDeep';
-import { Divider } from 'antd';
 import CardViewUtil from '../../Util/CardViewUtil';
 import { useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
+
+import './StyleOverview.less';
 
 export interface StyleOverviewProps {
   /** The callback when the style changed. */
   onStyleChange?: (style: GsStyle) => void;
   /** The callback when a view change (request) was triggered. */
   onChangeView?: (view: string, indices: number[]) => void;
-  /** Reference to internal data object (holding schema and example features). */
-  data?: Data;
   /** A GeoStyler-Style object. */
   style: GsStyle;
 }
 
 export const StyleOverview: React.FC<StyleOverviewProps> = ({
   style,
-  data,
   onStyleChange = () => { },
   onChangeView = () => { }
 }) => {
@@ -98,7 +97,6 @@ export const StyleOverview: React.FC<StyleOverviewProps> = ({
       />
       <Rules
         rules={style.rules}
-        data={data}
         onRulesChange={onRulesChange}
         onEditRuleClick={onEditRule}
         onClassificationClick={onClassificationClick}

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -44,7 +44,6 @@ import VisibilityField from '../Field/VisibilityField/VisibilityField';
 import './Editor.less';
 
 import 'ol/ol.css';
-import { Data } from 'geostyler-data';
 
 import _cloneDeep from 'lodash/cloneDeep';
 
@@ -52,9 +51,7 @@ import { KindField } from '../Field/KindField/KindField';
 import { IconEditor } from '../IconEditor/IconEditor';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
 
-
 import { RasterEditor } from '../RasterEditor/RasterEditor';
-import DataUtil from '../../../Util/DataUtil';
 import { Form } from 'antd';
 
 import { useGeoStylerComposition, useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
@@ -82,7 +79,6 @@ export interface EditorComposableProps {
 
 export interface EditorInternalProps {
   symbolizer: Symbolizer;
-  internalDataDef?: Data;
   onSymbolizerChange?: (symbolizer: Symbolizer) => void;
 }
 
@@ -94,7 +90,6 @@ export const Editor: React.FC<EditorProps> = (props) => {
   const composed = { ...props, ...composition };
   const {
     symbolizer,
-    internalDataDef,
     onSymbolizerChange,
     fillEditor,
     iconEditor,
@@ -144,9 +139,6 @@ export const Editor: React.FC<EditorProps> = (props) => {
         return textEditor?.visibility === false ? null : (
           <TextEditor
             symbolizer={symbolizer}
-            internalDataDef={
-              internalDataDef && DataUtil.isVector(internalDataDef) ? internalDataDef : undefined
-            }
             onSymbolizerChange={onSymbolizerChange}
           />
         );
@@ -154,9 +146,6 @@ export const Editor: React.FC<EditorProps> = (props) => {
         return rasterEditor?.visibility === false ? null : (
           <RasterEditor
             symbolizer={symbolizer}
-            internalDataDef={
-              internalDataDef && DataUtil.isRaster(internalDataDef) ? internalDataDef : undefined
-            }
             onSymbolizerChange={onSymbolizerChange}
           />
         );

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -36,7 +36,6 @@ import {
 import './MultiEditor.less';
 
 import 'ol/ol.css';
-import { Data } from 'geostyler-data';
 
 import { Tabs } from 'antd';
 import { Editor } from '../Editor/Editor';
@@ -49,7 +48,6 @@ import _isEqual from 'lodash/isEqual';
 import { Tab } from 'rc-tabs/lib/interface';
 
 export interface MultiEditorProps {
-  internalDataDef?: Data;
   editorProps?: any;
   symbolizers: Symbolizer[];
   onSymbolizersChange?: (symbolizers: Symbolizer[]) => void;
@@ -57,7 +55,6 @@ export interface MultiEditorProps {
 }
 
 export const MultiEditor: React.FC<MultiEditorProps> = ({
-  internalDataDef,
   editorProps,
   symbolizers,
   onSymbolizersChange,
@@ -118,7 +115,6 @@ export const MultiEditor: React.FC<MultiEditorProps> = ({
           onSymbolizerChange={(sym: Symbolizer) => {
             onSymbolizerChange(sym, idx);
           }}
-          internalDataDef={internalDataDef}
           iconLibraries={iconLibraries}
           {...editorProps}
         />

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.example.md
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.example.md
@@ -92,7 +92,6 @@ class PropTextEditorExample extends React.Component {
     return (
       <PropTextEditor
         symbolizer={symbolizer}
-        internalDataDef={data}
         onSymbolizerChange={this.onSymbolizerChange}
       />
     );

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.spec.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.spec.tsx
@@ -31,15 +31,12 @@ import { act, render, fireEvent } from '@testing-library/react';
 
 import { TextSymbolizer } from 'geostyler-style';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
-import TestUtil from '../../../Util/TestUtil';
 
 describe('PropTextEditor', () => {
 
   let dummySymbolizer = SymbolizerUtil.generateSymbolizer('Text') as TextSymbolizer;
-  let dummyData = TestUtil.getDummyGsData();
   const props: PropTextEditorProps = {
     symbolizer: dummySymbolizer,
-    internalDataDef: dummyData,
     onSymbolizerChange: jest.fn()
   };
 

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
@@ -28,6 +28,8 @@
 
 import React from 'react';
 
+import { Form } from 'antd';
+
 import _cloneDeep from 'lodash/cloneDeep';
 import _isEqual from 'lodash/isEqual';
 
@@ -43,17 +45,12 @@ import {OffsetField} from '../Field/OffsetField/OffsetField';
 import {OpacityField} from '../Field/OpacityField/OpacityField';
 import {RotateField} from '../Field/RotateField/RotateField';
 import {WidthField} from '../Field/WidthField/WidthField';
-import { Data } from 'geostyler-data';
+import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 import './PropTextEditor.less';
 
-import { Form } from 'antd';
-import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
-
-// non default props
 export interface PropTextEditorProps {
   symbolizer: TextSymbolizer;
-  internalDataDef?: Data;
   onSymbolizerChange?: (changedSymb: Symbolizer) => void;
 }
 
@@ -64,7 +61,6 @@ export interface PropTextEditorProps {
  */
 export const PropTextEditor: React.FC<PropTextEditorProps> = ({
   symbolizer,
-  internalDataDef,
   onSymbolizerChange
 }) => {
 
@@ -192,7 +188,6 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
       >
         <AttributeCombo
           value={symbolizer.label ? formatLabel(symbolizer.label as string) : undefined}
-          internalDataDef={internalDataDef}
           onAttributeChange={onLabelChange}
         />
       </Form.Item>

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -39,7 +39,6 @@ import {
 import { Form } from 'antd';
 import { OpacityField, OpacityFieldProps } from '../Field/OpacityField/OpacityField';
 import { RasterChannelEditor } from '../RasterChannelEditor/RasterChannelEditor';
-import { Data } from 'geostyler-data';
 import { ContrastEnhancementField } from '../Field/ContrastEnhancementField/ContrastEnhancementField';
 import { GammaField, GammaFieldProps } from '../Field/GammaField/GammaField';
 import DataUtil from '../../../Util/DataUtil';
@@ -54,6 +53,7 @@ import {
   InputConfig,
   useGeoStylerComposition,
   useGeoStylerLocale,
+  useGeoStylerData,
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
 
@@ -79,7 +79,6 @@ export interface RasterEditorInternalProps {
   contrastEnhancementTypes?: ContrastEnhancement['enhancementType'][];
   symbolizer: RasterSymbolizer;
   onSymbolizerChange?: (changedSymb: Symbolizer) => void;
-  internalDataDef?: Data;
 }
 
 type ShowDisplay = 'symbolizer' | 'colorMapEditor' | 'rasterChannelEditor';
@@ -88,10 +87,9 @@ export type RasterEditorProps = RasterEditorInternalProps & RasterEditorComposab
 
 export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
 
-  const composition = useGeoStylerComposition('RasterEditor');
-  // const colorMapComposition = useGeoStylerComposition('ColorMapEditor');
-  // const rasterChannelComposition = useGeoStylerComposition('RasterChannelEditor');
+  const data = useGeoStylerData();
 
+  const composition = useGeoStylerComposition('RasterEditor');
   const composed = { ...props, ...composition };
   const {
     colorMapEditor,
@@ -99,7 +97,6 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
     contrastEnhancementField,
     contrastEnhancementTypes,
     gammaValueField,
-    internalDataDef,
     onSymbolizerChange,
     opacityField,
     rasterChannelEditor,
@@ -174,8 +171,8 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
   } = symbolizer;
 
   let sourceChannelNames: string[];
-  if (internalDataDef && DataUtil.isRaster(internalDataDef)) {
-    sourceChannelNames = Object.keys(internalDataDef.rasterBandInfo);
+  if (data && DataUtil.isRaster(data)) {
+    sourceChannelNames = Object.keys(data.rasterBandInfo);
   }
 
   const toggleViewButtonLayout = {

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
@@ -33,8 +33,6 @@ import { Symbolizer } from 'geostyler-style';
 import { MultiEditor } from '../MultiEditor/MultiEditor';
 import { IconLibrary } from '../IconSelector/IconSelector';
 
-import { Data } from 'geostyler-data';
-
 import './SymbolizerEditorWindow.less';
 import { Modal, ModalProps } from 'antd';
 
@@ -45,7 +43,6 @@ import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerC
 // non default props
 export interface SymbolizerEditorWindowProps extends Partial<ModalProps> {
   symbolizers: Symbolizer[];
-  internalDataDef?: Data;
   onClose?: () => void;
   onSymbolizersChange?: (symbolizers: Symbolizer[]) => void;
   iconLibraries?: IconLibrary[];
@@ -56,7 +53,6 @@ export interface SymbolizerEditorWindowProps extends Partial<ModalProps> {
 
 export const SymbolizerEditorWindow: React.FC<SymbolizerEditorWindowProps> = ({
   symbolizers,
-  internalDataDef,
   onClose,
   onSymbolizersChange,
   iconLibraries,
@@ -77,7 +73,6 @@ export const SymbolizerEditorWindow: React.FC<SymbolizerEditorWindowProps> = ({
       {...passThroughProps}
     >
       <MultiEditor
-        internalDataDef={internalDataDef}
         symbolizers={symbolizers}
         onSymbolizersChange={onSymbolizersChange}
         iconLibraries={iconLibraries}

--- a/src/Component/Symbolizer/TextEditor/TextEditor.example.md
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.example.md
@@ -75,7 +75,6 @@ class TextEditorExample extends React.Component {
       <TextEditor
         symbolizer={symbolizer}
         onSymbolizerChange={this.onSymbolizerChange}
-        internalDataDef={this.data}
       />
     );
   }

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -27,10 +27,14 @@
  */
 
 import React from 'react';
+
 import {
   Mentions,
   Form
 } from 'antd';
+
+import _cloneDeep from 'lodash/cloneDeep';
+import _isEqual from 'lodash/isEqual';
 
 import {
   Symbolizer,
@@ -43,21 +47,17 @@ import { WidthField, WidthFieldProps } from '../Field/WidthField/WidthField';
 import { FontPicker } from '../Field/FontPicker/FontPicker';
 import { OffsetField, OffsetFieldProps } from '../Field/OffsetField/OffsetField';
 import { RotateField, RotateFieldProps } from '../Field/RotateField/RotateField';
-
-import _cloneDeep from 'lodash/cloneDeep';
-import _isEqual from 'lodash/isEqual';
-
-import './TextEditor.less';
-
-import { VectorData } from 'geostyler-data';
+import { SizeFieldProps } from '../Field/SizeField/SizeField';
 
 import {
   InputConfig,
   useGeoStylerComposition,
+  useGeoStylerData,
   useGeoStylerLocale,
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
-import { SizeFieldProps } from '../Field/SizeField/SizeField';
+
+import './TextEditor.less';
 
 export interface TextEditorComposableProps {
   templateField?: InputConfig<string>;
@@ -78,7 +78,6 @@ export interface TextEditorComposableProps {
 export interface TextEditorInternalProps {
   symbolizer: TextSymbolizer;
   onSymbolizerChange?: (changedSymb: Symbolizer) => void;
-  internalDataDef?: VectorData;
 }
 
 export type TextEditorProps = TextEditorInternalProps & TextEditorComposableProps;
@@ -90,6 +89,8 @@ export type TextEditorProps = TextEditorInternalProps & TextEditorComposableProp
  */
 export const TextEditor: React.FC<TextEditorProps> = (props) => {
 
+  const data = useGeoStylerData();
+
   const composition = useGeoStylerComposition('TextEditor');
   const composed = { ...props, ...composition };
   const {
@@ -97,7 +98,6 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
     fontField,
     haloColorField,
     haloWidthField,
-    internalDataDef,
     offsetXField,
     offsetYField,
     onSymbolizerChange,
@@ -222,7 +222,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
     offsetX = offset[0] as number;
     offsetY = offset[1] as number;
   }
-  const properties = internalDataDef && internalDataDef.schema ? Object.keys(internalDataDef.schema.properties) : [];
+  const properties = data && data.schema ? Object.keys(data.schema.properties) : [];
 
   return (
     <div className="gs-text-symbolizer-editor" >

--- a/src/Component/SymbolizerCard/SymbolizerCard.tsx
+++ b/src/Component/SymbolizerCard/SymbolizerCard.tsx
@@ -32,31 +32,22 @@ import React from 'react';
 import {
   Symbolizer as GsSymbolizer
 } from 'geostyler-style';
-import { Data } from 'geostyler-data';
 
 import './SymbolizerCard.less';
 
 import { Card } from 'antd';
 import { Renderer } from '../Renderer/Renderer/Renderer';
 
-// default props
-interface SymbolizerCardDefaultProps {
+export interface SymbolizerCardProps {
   /** The callback when the symbolizer was clicked. */
   onSymbolizerClick?: (symbolizer: GsSymbolizer) => void;
-}
-
-// non default props
-export interface SymbolizerCardProps extends Partial<SymbolizerCardDefaultProps> {
   /** A GeoStyler-Style object. */
   symbolizer: GsSymbolizer;
-  /** Reference to internal data object (holding schema and example features) */
-  data?: Data;
 }
 
 export const SymbolizerCard = ({
   symbolizer,
-  onSymbolizerClick = () => { },
-  data
+  onSymbolizerClick = () => { }
 }: SymbolizerCardProps) => {
 
   const onCardClick = () => {
@@ -69,10 +60,7 @@ export const SymbolizerCard = ({
       hoverable={true}
       onClick={onCardClick}
     >
-      <Renderer
-        data={data}
-        symbolizers={[symbolizer]}
-      />
+      <Renderer symbolizers={[symbolizer]} />
     </Card>
   );
 };

--- a/src/Component/Symbolizers/Symbolizers.tsx
+++ b/src/Component/Symbolizers/Symbolizers.tsx
@@ -48,7 +48,6 @@ import SymbolizerUtil from '../../Util/SymbolizerUtil';
 import { SortableItem } from '../SortableItem/SortableItem';
 import { useDragDropSensors } from '../../hook/UseDragDropSensors';
 import { RemovableItem } from '../RemovableItem/RemovableItem';
-import { Data } from 'geostyler-data';
 import { useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
 
 export interface SymbolizersProps {
@@ -58,15 +57,12 @@ export interface SymbolizersProps {
   onEditSymbolizerClick?: (symbolizerId: number) => void;
   /** List of symbolizers to display */
   symbolizers: GsSymbolizer[];
-  /** Reference to internal data object (holding schema and example features). */
-  data?: Data;
 }
 
 export const Symbolizers: React.FC<SymbolizersProps> = ({
   symbolizers,
   onSymbolizersChange = () => { },
-  onEditSymbolizerClick = () => { },
-  data
+  onEditSymbolizerClick = () => { }
 }) => {
 
   const locale = useGeoStylerLocale('Symbolizers');
@@ -97,7 +93,6 @@ export const Symbolizers: React.FC<SymbolizersProps> = ({
         onSymbolizerClick={() => {
           onEditSymbolizerClick(idx);
         }}
-        data={data}
       />
     );
   });

--- a/src/context/GeoStylerContext/GeoStylerContext.tsx
+++ b/src/context/GeoStylerContext/GeoStylerContext.tsx
@@ -22,6 +22,7 @@ import { RuleGeneratorComposableProps } from '../../Component/RuleGenerator/Rule
 import { StyleComposableProps } from '../../Component/Style/Style';
 import UnsupportedPropertiesUtil, { SymbolizerName } from '../../Util/UnsupportedPropertiesUtil';
 import en_US from '../../locale/en_US';
+import { Data as GeoStylerData } from 'geostyler-data';
 
 export type InputConfig<T> = {
   visibility?: boolean;
@@ -59,13 +60,14 @@ export interface GeoStylerContextInterface {
   composition?: CompositionContext;
   locale?: GeoStylerLocale;
   unsupportedProperties?: UnsupportedPropertiesContext;
+  data?: GeoStylerData;
 };
 
 export const GeoStylerContext = React.createContext<GeoStylerContextInterface>({});
 
 export const useGeoStylerContext = (): GeoStylerContextInterface => {
   const ctx = useContext(GeoStylerContext);
-  return structuredClone(ctx);
+  return ctx;
 };
 
 export const useGeoStylerComposition = <T extends keyof CompositionContext>(
@@ -75,12 +77,17 @@ export const useGeoStylerComposition = <T extends keyof CompositionContext>(
   if (!ctx.composition || !ctx.composition[key]) {
     return {} as CompositionContext[T];
   }
-  return structuredClone(ctx.composition[key]);
+  return ctx.composition[key];
 };
 
 export const useGeoStylerLocale = <T extends keyof GeoStylerLocale>(key: T): GeoStylerLocale[T] => {
   const ctx = useContext(GeoStylerContext);
   return ctx.locale ? ctx.locale[key] : en_US[key];
+};
+
+export const useGeoStylerData = (): GeoStylerData => {
+  const ctx = useContext(GeoStylerContext);
+  return ctx.data;
 };
 
 export const useGeoStylerUnsupportedProperties = <T extends Symbolizer>(symbolizer: T) => {


### PR DESCRIPTION
## Description
This adds the 'data' prop to the `GeoStylerContext` and introduces the corresponding `useGeoStylerData` hook. (fixes #2174)

 - It removes the `data` / `internalDataDef` prop from all components that not used it directly but just passed it to child components.
- It remove the deprecated `Preview` component from the `Symbolizer` folder.
- It removes the default backgroundlayer from the map in the `PreviewMap` component (fixes #2229)

:exclamation: As this removes the `data` / `internalDataDef` prop from several components and removes the `Preview` compnent this is a breaking change


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

