### PR TITLE
Add `lockFileMaintenance`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,10 @@
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true
     }
-  ]
+  ],
+  {
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  }
 }


### PR DESCRIPTION
## Description
This adds `lockFileMaintenance` for the renovate bot.
https://docs.renovatebot.com/key-concepts/automerge/#automerge-lock-file-maintenance

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

