### PR TITLE
Fix OlRenderer

### DIFF
--- a/src/Component/Renderer/OlRenderer/OlRenderer.tsx
+++ b/src/Component/Renderer/OlRenderer/OlRenderer.tsx
@@ -159,7 +159,7 @@ export const OlRenderer: React.FC<OlRendererProps> = ({
       name: 'WrapperStyle4Symbolizer',
       rules: [{
         name: 'WrapperRule4Symbolizer',
-        symbolizers: newSymbolizers
+        symbolizers: structuredClone(newSymbolizers)
       }]
     };
     // parser style to OL style

--- a/src/Component/RuleTable/RuleTable.example.md
+++ b/src/Component/RuleTable/RuleTable.example.md
@@ -35,30 +35,21 @@ import React, { useState } from 'react';
 import { RuleTable } from 'geostyler';
 
 function RuleTableExample() {
-  const [style, setStyle] = useState({
-    name: "Demo Style",
-    rules: [
-      {
-        name: "Rule 1",
-        symbolizers: [
-          {
-            kind: "Mark",
-            wellKnownName: "circle"
-          }
-        ]
-      }
-    ]
-  });
+  const [rules, setRules] = useState([{
+    name: "Rule 1",
+    symbolizers: [{
+      kind: "Mark",
+      wellKnownName: "circle"
+    }]
+  }]);
 
-  const onRulesChange = (rules) => {
-    const newStyle = JSON.parse(JSON.stringify(style));
-    newStyle.rules = rules;
-    setStyle(newStyle);
+  const onRulesChange = (newRules) => {
+    setRules(newRules);
   };
 
   return (
     <RuleTable
-      rules={style.rules}
+      rules={rules}
       onRulesChange={onRulesChange}
     />
   );

--- a/src/Component/RuleTable/RuleTable.tsx
+++ b/src/Component/RuleTable/RuleTable.tsx
@@ -105,7 +105,7 @@ export const RuleTable: React.FC<RuleTableProps> = (props) => {
     nameField,
     onRulesChange,
     rendererType = 'OpenLayers',
-    rules: rulesProp,
+    rules,
     // The composableProps include the antd table props
     ...antdTableProps
   } = composed;
@@ -116,7 +116,6 @@ export const RuleTable: React.FC<RuleTableProps> = (props) => {
   const [symbolizerEditorVisible, setSymbolizerEditorVisible] = useState<boolean>();
   const [filterEditorVisible, setFilterEditorVisible] = useState<boolean>();
   const [hasError, setHasError] = useState<boolean>();
-  const [rules, setRules] = useState<GsRule[]>();
   const [counts, setCounts] = useState<number[]>();
   const [duplicates, setDuplicates] = useState<number[]>();
 
@@ -130,7 +129,7 @@ export const RuleTable: React.FC<RuleTableProps> = (props) => {
     let countsAndDuplicates: CountResult = {};
     try {
       if (data && DataUtil.isVector(data)) {
-        countsAndDuplicates = FilterUtil.calculateCountAndDuplicates(rulesProp, data);
+        countsAndDuplicates = FilterUtil.calculateCountAndDuplicates(rules, data);
       } else {
         countsAndDuplicates = {};
       }
@@ -138,10 +137,9 @@ export const RuleTable: React.FC<RuleTableProps> = (props) => {
       setHasError(true);
       // make sure to update state when checks/calculation fails
     }
-    setRules(rulesProp);
     setCounts(countsAndDuplicates?.counts);
     setDuplicates(countsAndDuplicates?.duplicates);
-  }, [rulesProp, data]);
+  }, [rules, data]);
 
   const ruleRecords = rules?.map((rule: GsRule, index: number): RuleRecord => {
     return {
@@ -352,7 +350,8 @@ export const RuleTable: React.FC<RuleTableProps> = (props) => {
     title: (
       <Tooltip title={locale.symbolizersColumnTitle}>
         <BgColorsOutlined />
-      </Tooltip>),
+      </Tooltip>
+    ),
     dataIndex: 'symbolizers',
     render: symbolizerRenderer
   }];

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.example.md
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.example.md
@@ -79,19 +79,13 @@ class SymbolizerEditorWindowExample extends React.Component {
 
     return (
       <div>
-        <Button
-          onClick={this.onButtonClick}
-        >Show SymbolizerEditorWindow</Button>
-        {
-          showWindow &&
-          <SymbolizerEditorWindow
-            symbolizers={symbolizers}
-            onSymbolizersChange={this.onSymbolizersChange}
-            onClose={this.onClose}
-            x={1000}
-            y={53500}
-          />
-        }
+        <Button onClick={this.onButtonClick}>Show SymbolizerEditorWindow</Button>
+        <SymbolizerEditorWindow
+          open={showWindow}
+          symbolizers={symbolizers}
+          onSymbolizersChange={this.onSymbolizersChange}
+          onClose={this.onClose}
+        />
       </div>
     );
   }


### PR DESCRIPTION
## Description
This fixes a strange behaviour when using a geostyler function in a symbolizer property with the `RuleTable` component. The source of this behaviour was this bug: https://github.com/geostyler/geostyler-openlayers-parser/issues/740

To make sure the parser won't affect the passed style at all i added a `structuredClone` to the `OlRenderer`.

This also includes some minor refactoring.

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

