### PR TITLE
Add "GeoStylerContext" section to the docs

### DIFF
--- a/docs/geoStylerContext.md
+++ b/docs/geoStylerContext.md
@@ -1,24 +1,24 @@
-The `GeoStylerContext` lets you customize (`composition`) the GeoStyler UI aswell as it supports the underlying
+The `GeoStylerContext` lets you customize (`composition`) the GeoStyler UI as well as it supports the underlying
 components with the needed `data`, localization (`locale`) and `unsupportedProperties`.
 
 1. `data`
 
 You can provide your own geodata with the `data` property. It has to be provided as [geostyler-data](https://github.com/geostyler/geostyler-data).
-You can easily parse your existing [WFS](https://github.com/geostyler/geostyler-wfs-parser), [geojson](https://github.com/geostyler/geostyler-geojson-parser) or [shapefile](https://github.com/geostyler/geostyler-shapefile-parser) with the corresponding geostyler parsers.
+You can easily parse your existing [WFS](https://github.com/geostyler/geostyler-wfs-parser), [geojson](https://github.com/geostyler/geostyler-geojson-parser) or [shapefile](https://github.com/geostyler/geostyler-shapefile-parser) with the corresponding geostyler parsers. The data can then be used for auto-completion and auto-classification within GeoStyler.
 
 2. `locale`
 
-The default language used in the GeoStyler UI is english. To change the labels of the components you
-can use one of the existing locales exported by the GeoStyler or provide your own locale by implementing
+The default language used in the GeoStyler UI is English. To change the labels of the components you
+can use one of the existing locales exported by GeoStyler or provide your own locale by implementing
 the `GeoStylerLocale` interface.
 
 3. `composition`
 
-The `composition` lets you customize the appearance of many components of the GeoStyler. This includes
+The `composition` lets you customize the appearance of many components of GeoStyler. This includes
 all the editors and covers most of their fields. The example below shows how to disable the `RasterEditor`
 in your component. But you can also modify many of the properties of the editors. Like the visibility or
-the default values for explicit field. In general all of the components covered in the `CompositionContext`
-export "composableProps". These are the props that you can adjust and modify with the `composition` prop.
+the default values for explicit field. In general, all of the components covered in the `CompositionContext`
+export "composableProps". These are the props that you can adjust and modify with the `composition` prop. Check out the component documentation for each component respectively, to see what exactly can be composed.
 
 4. `unsupportedProperties`
 

--- a/docs/geoStylerContext.md
+++ b/docs/geoStylerContext.md
@@ -1,0 +1,78 @@
+The `GeoStylerContext` lets you customize (`composition`) the GeoStyler UI aswell as it supports the underlying
+components with the needed `data`, localization (`locale`) and `unsupportedProperties`.
+
+1. `data`
+
+You can provide your own geodata with the `data` property. It has to be provided as [geostyler-data](https://github.com/geostyler/geostyler-data).
+You can easily parse your existing [WFS](https://github.com/geostyler/geostyler-wfs-parser), [geojson](https://github.com/geostyler/geostyler-geojson-parser) or [shapefile](https://github.com/geostyler/geostyler-shapefile-parser) with the corresponding geostyler parsers.
+
+2. `locale`
+
+The default language used in the GeoStyler UI is english. To change the labels of the components you
+can use one of the existing locales exported by the GeoStyler or provide your own locale by implementing
+the `GeoStylerLocale` interface.
+
+3. `composition`
+
+The `composition` lets you customize the appearance of many components of the GeoStyler. This includes
+all the editors and covers most of their fields. The example below shows how to disable the `RasterEditor`
+in your component. But you can also modify many of the properties of the editors. Like the visibility or
+the default values for explicit field. In general all of the components covered in the `CompositionContext`
+export "composableProps". These are the props that you can adjust and modify with the `composition` prop.
+
+4. `unsupportedProperties`
+
+Here you can tell the UI to what extent the used style supports the `geostyler-style` capabilities.
+Normally you want to use the `unsupportedProperties` of one of the style-parsers. However, it is also
+possible to specify your own configuration here. The example just uses the [`unsupportedProperties` of
+the `MapboxStyleParser`](https://github.com/geostyler/geostyler-mapbox-parser/blob/master/src/MapboxStyleParser.ts#L109).
+
+
+```tsx static
+/* eslint-disable no-console */
+import React, { useState } from 'react';
+import { GeoStylerContext, GeoStylerContextInterface, Style, locale } from 'geostyler';
+import MapboxStyleParser from 'geostyler-mapbox-parser';
+import { Style as GSStyle } from 'geostyler-style';
+import { Data as GSData } from 'geostyler-data';
+
+const mapBoxParser = new MapboxStyleParser();
+
+type Props = {
+  data: GSData;
+};
+
+export const MyMapBoxPrinter: React.FC<Props> = ({
+  data
+}) => {
+  const myContext: GeoStylerContextInterface = {
+    data,
+    locale: locale.de_DE,
+    unsupportedProperties: mapBoxParser.unsupportedProperties,
+    composition: {
+      Editor: {
+        rasterEditor: {
+          visibility: false
+        }
+      }
+    }
+  };
+
+  const [style, setStyle] = useState<GSStyle>();
+
+  const onStyleChange = async (newStyle: GSStyle) => {
+    setStyle(newStyle);
+    const { output } = await mapBoxParser.writeStyle(newStyle);
+    console.log(output);
+  };
+
+  return (
+    <GeoStylerContext.Provider value={myContext}>
+      <Style
+        style={style}
+        onStyleChange={onStyleChange}
+      />
+    </GeoStylerContext.Provider>
+  );
+};
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,7 @@ export { WellKnownNameEditor } from './Component/Symbolizer/WellKnownNameEditor/
 export { WellKnownNameField } from './Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField';
 export { WidthField } from './Component/Symbolizer/Field/WidthField/WidthField';
 export { GeoStylerContext } from './context/GeoStylerContext/GeoStylerContext';
+import type { GeoStylerContextInterface } from './context/GeoStylerContext/GeoStylerContext';
 import type GeoStylerLocale from './locale/locale';
 
 export { ConfigProvider } from 'antd';
@@ -139,5 +140,6 @@ export const locale = {
 };
 
 export {
-  GeoStylerLocale
+  GeoStylerLocale,
+  GeoStylerContextInterface
 };

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -73,6 +73,10 @@ module.exports = {
     content: './docs/introduction.md',
     sectionDepth: 0
   }, {
+    name: 'GeoStylerContext',
+    content: './docs/geoStylerContext.md',
+    sectionDepth: 0
+  }, {
     name: 'Components',
     sections: [{
       name: 'BulkEditor',


### PR DESCRIPTION
## Description
This adds a "GeoStylerContext" to the docs. It also adds a missing export of the `GeoStylerContextInterface`.

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

