### PR TITLE
fix: set ColorPicker to full width

### DIFF
--- a/src/Component/Symbolizer/Field/ColorField/ColorField.less
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.less
@@ -40,3 +40,11 @@
     display: none;
   }
 }
+
+.gs-color-field {
+  display: flex;
+
+  button {
+    flex: 1;
+  }
+}


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This sets the color picker to full width in order to be consistent with other input fields.

![image](https://github.com/geostyler/geostyler/assets/12186477/74ccddb9-a379-43a4-8e85-2c02f606f675)

Popup remains small:

![image](https://github.com/geostyler/geostyler/assets/12186477/f734c63b-6696-4293-b3fd-72ad8ac0ad9c)


closes https://github.com/geostyler/geostyler/issues/2290

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

