### PR TITLE
Add `onActiveParserChange` to `CodeEditor`

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -86,6 +86,8 @@ export interface CodeEditorProps {
   defaultParser?: StyleParser;
   /** The callback method that is triggered when the state changes */
   onStyleChange?: (rule: GsStyle) => void;
+  /** Callback method when the activeParser has change via dropdown. */
+  onActiveParserChange?: (activeParser: StyleParser) => void;
 }
 
 type EditorLanguage = 'xml' | 'json' | 'plaintext';
@@ -144,6 +146,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   defaultParser,
   delay = 500,
   onStyleChange = () => undefined,
+  onActiveParserChange = () => undefined,
   parsers = [],
   showCopyButton = false,
   showSaveButton = false,
@@ -235,6 +238,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
 
   const onParserSelect = (selection: string) => {
     const parser = parsers.find((p: any) => p.title === selection);
+    onActiveParserChange(parser);
     setActiveParser(parser);
   };
 

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -86,7 +86,7 @@ export interface CodeEditorProps {
   defaultParser?: StyleParser;
   /** The callback method that is triggered when the state changes */
   onStyleChange?: (rule: GsStyle) => void;
-  /** Callback method when the activeParser has change via dropdown. */
+  /** Callback method when the activeParser has changed via dropdown. */
   onActiveParserChange?: (activeParser: StyleParser) => void;
 }
 


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description
This adds the `onActiveParserChange` prop to the `CodeEditor`.

Fixes #2292 

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

