### PR TITLE
Add FunctionUI to `ColorField`

### DIFF
--- a/src/Component/BulkEditor/BulkEditor.tsx
+++ b/src/Component/BulkEditor/BulkEditor.tsx
@@ -50,7 +50,7 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
 }) => {
 
   const locale = useGeoStylerLocale('BulkEditor');
-  const [color, setColor] = useState<string>();
+  const [color, setColor] = useState<Expression<string>>();
   const [radius, setRadius] = useState<Expression<number>>();
   const [opacity, setOpacity] = useState<Expression<number>>();
   const [kind, setKind] = useState<SymbolizerKind>('Mark');
@@ -59,7 +59,7 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
 
   const symbolizerKinds: SymbolizerKind[] = ['Mark', 'Icon'];
 
-  const onColorChange = (newColor: string) => {
+  const onColorChange = (newColor: Expression<string>) => {
     setColor(newColor);
     onStylePropChange('color', newColor);
   };

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -43,7 +43,8 @@ import {
   Rule as GsRule,
   SymbolizerKind,
   Symbolizer as GsSymbolizer,
-  WellKnownName as GsWellKnownName
+  WellKnownName as GsWellKnownName,
+  Expression
 } from 'geostyler-style';
 
 import { NameField } from '../NameField/NameField';
@@ -232,7 +233,7 @@ export const Style: React.FC<StyleProps> = (props) => {
     setStyle(clonedStyle);
   };
 
-  const updateMultiColors = (color: string) => {
+  const updateMultiColors = (color: Expression<string>) => {
     updateAllSelected([{ value: color, property: 'color' }]);
   };
 

--- a/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
+++ b/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
@@ -65,7 +65,7 @@ interface BulkEditModalsDefaultProps {
 
 // non default props
 export interface BulkEditModalsProps extends Partial<BulkEditModalsDefaultProps> {
-  updateMultiColors?: (x: string) => void;
+  updateMultiColors?: (x: Expression<string>) => void;
   updateMultiSizes?: (x: Expression<number> | undefined) => void;
   updateMultiOpacities?: (x: Expression<number> | undefined) => void;
   updateMultiSymbols?: (symbol: WellKnownName | string, kind: SymbolizerKind) => void;

--- a/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
+++ b/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
@@ -35,7 +35,7 @@ import {
   InputNumber
 } from 'antd';
 
-import { ColorMap, ColorMapType, ColorMapEntry, isGeoStylerStringFunction } from 'geostyler-style';
+import { ColorMap, ColorMapType, ColorMapEntry, isGeoStylerStringFunction, Expression } from 'geostyler-style';
 import { ExtendedField } from '../Field/ExtendedField/ExtendedField';
 import { ColorMapTypeField } from '../Field/ColorMapTypeField/ColorMapTypeField';
 import { ColorField } from '../Field/ColorField/ColorField';
@@ -237,7 +237,7 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = (props) => {
     const input = (
       <ColorField
         value={record.color as string}
-        onChange={(color: string) => {
+        onChange={(color: Expression<string>) => {
           setValueForColorMapEntry(record.key, 'color', color);
         }}
       />

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.less
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.less
@@ -44,7 +44,24 @@
 .gs-color-field {
   display: flex;
 
-  button {
+  .gs-function-ui,
+  .ant-input,
+  button.color-picker-trigger {
     flex: 1;
+  }
+
+  button.function-ui-trigger {
+    display: none;
+    border-radius: 0 6px 6px 0;
+  }
+
+  &:hover {
+    button.ant-btn {
+      display: inline-block;
+    }
+
+    button.color-picker-trigger {
+      border-radius: 6px 0 0 6px;
+    }
   }
 }

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
@@ -37,11 +37,18 @@ import {
 
 import './ColorField.less';
 import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStylerContext';
+import {
+  Expression,
+  GeoStylerStringFunction,
+  isGeoStylerFunction
+} from 'geostyler-style';
+import { FunctionUI } from '../../../FunctionUI/FunctionUI';
+import { FunctionOutlined } from '@ant-design/icons';
 
-export interface ColorFieldProps extends Omit<ColorPickerProps, 'onChange'|'value'|'defaultValue'> {
-  value?: string;
-  onChange?: (color: string) => void;
-  defaultValue?: string;
+export interface ColorFieldProps extends Omit<ColorPickerProps, 'onChange' | 'value' | 'defaultValue'> {
+  value?: Expression<string>;
+  onChange?: (color: Expression<string>) => void;
+  defaultValue?: Expression<string>;
 }
 
 /**
@@ -65,6 +72,23 @@ export const ColorField: React.FC<ColorFieldProps> = ({
     }
   }, [onChange]);
 
+  function onCancel() {
+    onChange(defaultValue);
+  }
+
+  if (isGeoStylerFunction(value)) {
+    return (
+      <span className="editor-field gs-color-field">
+        <FunctionUI<GeoStylerStringFunction>
+          type='string'
+          value={value}
+          onChange={onChange}
+          onCancel={onCancel}
+        />
+      </span>
+    );
+  }
+
   let textColor;
   try {
     textColor = Color(value || defaultValue).negate().grayscale().string();
@@ -72,8 +96,14 @@ export const ColorField: React.FC<ColorFieldProps> = ({
     textColor = '#000000';
   }
 
+  const backgroundColor = !isGeoStylerFunction(value)
+    ? value
+    : !isGeoStylerFunction(defaultValue)
+      ? defaultValue
+      : '#FFFFF';
+
   const btnStyle: React.CSSProperties = {
-    backgroundColor: value || defaultValue,
+    backgroundColor,
     color: textColor
   };
 
@@ -85,10 +115,20 @@ export const ColorField: React.FC<ColorFieldProps> = ({
         onChange={onColorPickerChange}
         {...passThroughProps}
       >
-        <Button style={btnStyle}>
+        <Button style={btnStyle} className="color-picker-trigger">
           {value ? value.toString() : locale.chooseText}
         </Button>
       </ColorPicker>
+      <Button
+        className="function-ui-trigger"
+        icon={<FunctionOutlined />}
+        onClick={() => {
+          onChange?.({
+            name: 'property',
+            args: ['']
+          });
+        }}
+      />
     </span>
   );
 };


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description
This adds a button to switch between `FunctionUI` and `ColorPicker` in the `ColorField`.
![geostyler_functionui_colorfield](https://github.com/geostyler/geostyler/assets/1849416/a2839735-84c3-46cd-80b2-3bb8d90a6945)

Fixes #2293

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

