### PR TITLE
Readd OpenLayers as default rendererType

### DIFF
--- a/src/Component/Renderer/Renderer/Renderer.example.md
+++ b/src/Component/Renderer/Renderer/Renderer.example.md
@@ -87,3 +87,72 @@ function RendererExample () {
 
 <RendererExample />
 ```
+
+This shows a Renderer with a geostyler function. When using "property" function
+it is needed to pass it via GeoStylerContext.
+
+```jsx
+import React, { useState } from 'react';
+import { InputNumber } from 'antd';
+import { Renderer, GeoStylerContext } from 'geostyler';
+
+function RendererExample () {
+
+  const [size, setSize] = useState(8);
+
+  const symbolizers = [{
+    kind: 'Mark',
+    wellKnownName: 'circle',
+    color: {
+      name: 'property',
+      args: ['color']
+    },
+    radius: {
+      name: 'min',
+      args: [{
+        name: 'property',
+        args: ['size']
+      }, 36]
+    },
+    strokeWidth: {
+      name: 'sqrt',
+      args: [{
+        name: 'property',
+        args: ['size']
+      }]
+    }
+  }];
+
+  const ctx = {
+    data: {
+      exampleFeatures: {
+        features: [{
+          properties: {
+            color: '#00ff00',
+            size
+          }
+        }]
+      }
+    }
+  };
+
+  return (
+    <div>
+      property value of "size":
+      <InputNumber
+        value={size}
+        min={0}
+        onChange={setSize}
+      />
+      <GeoStylerContext.Provider value={ctx}>
+        <Renderer
+          symbolizers={symbolizers}
+          hideEditButton={true}
+        />
+      </GeoStylerContext.Provider>
+    </div>
+  );
+}
+
+<RendererExample />
+```

--- a/src/Component/Renderer/Renderer/Renderer.tsx
+++ b/src/Component/Renderer/Renderer/Renderer.tsx
@@ -47,7 +47,7 @@ export const Renderer: React.FC<RendererProps> = (props) => {
   const composition = useGeoStylerComposition('Renderer');
   const composed = {...props, ...composition};
   let {
-    rendererType,
+    rendererType = 'OpenLayers',
     ...rendererProps
   } = composed;
 


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description
This readds the default value for the `rendererType` ("OpenLayers") of the `Renderer`. As the property is optional and there was not configure this is a bugfix.

It also adds an example of a `Renderer` with a `GeoStylerFunction`.


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

