### PR TITLE
Move thrown error to SLDRenderer

### DIFF
--- a/src/Component/Renderer/Renderer/Renderer.tsx
+++ b/src/Component/Renderer/Renderer/Renderer.tsx
@@ -61,12 +61,6 @@ export const Renderer: React.FC<RendererProps> = (props) => {
     );
   }
   else if (rendererType === 'SLD') {
-    const sldRendererProps = rendererProps as SLDRendererProps;
-    if (!sldRendererProps.wmsBaseUrl || !sldRendererProps.layer) {
-      throw new Error(
-        '"wmsBaseUrl" or "layer" are missing in the GeoStylerContext.composition.SLDRenderer'
-      );
-    }
     renderer = (
       <SLDRenderer
         {...rendererProps as SLDRendererProps}

--- a/src/Component/Renderer/SLDRenderer/SLDRenderer.tsx
+++ b/src/Component/Renderer/SLDRenderer/SLDRenderer.tsx
@@ -75,6 +75,12 @@ export const SLDRenderer: React.FC<SLDRendererProps> = (props) => {
     symbolizers
   } = composed;
 
+  if (!composed.wmsBaseUrl || !composed.layer) {
+    throw new Error(
+      '"wmsBaseUrl" or "layer" are required as SLDRenderer props or in the GeoStylerContext.composition.SLDRenderer'
+    );
+  }
+
   const [alt, setAlt] = useState<string>();
   const [legendDataUrl, setLegendDataUrl] = useState<string>();
   const requestTimeout = useRef<any>();


### PR DESCRIPTION
This moves the check for the required properties `wmsBaseUrl` and `layer` from the `Renderer` to the `SLDRenderer` component.
This is needed as the `Renderer` is not aware of the composed properties of the `SLDRenderer`.

Fixes https://github.com/geostyler/geostyler-demo/issues/507

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

