### PR TITLE
fix: replace monaco CDN loader with npm package

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -26,3 +26,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 declare module '@ungap/url-search-params';
+declare module 'monaco-editor/esm/vs/editor/editor.worker?worker';
+declare module 'monaco-editor/esm/vs/language/json/json.worker?worker';
+declare module 'monaco-editor/esm/vs/language/css/css.worker?worker';
+declare module 'monaco-editor/esm/vs/language/html/html.worker?worker';
+declare module 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -33,7 +33,32 @@ import React, {
   useState
 } from 'react';
 
-import Editor, { useMonaco } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+import Editor, { loader } from '@monaco-editor/react';
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
+import cssWorker from 'monaco-editor/esm/vs/language/css/css.worker?worker';
+import htmlWorker from 'monaco-editor/esm/vs/language/html/html.worker?worker';
+import tsWorker from 'monaco-editor/esm/vs/language/typescript/ts.worker?worker';
+
+self.MonacoEnvironment = {
+  getWorker(_, label) {
+    if (label === 'json') {
+      return new jsonWorker();
+    }
+    if (label === 'css' || label === 'scss' || label === 'less') {
+      return new cssWorker();
+    }
+    if (label === 'html' || label === 'handlebars' || label === 'razor') {
+      return new htmlWorker();
+    }
+    if (label === 'typescript' || label === 'javascript') {
+      return new tsWorker();
+    }
+    return new editorWorker();
+  },
+};
+
 
 import 'blob';
 import {
@@ -163,7 +188,6 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   const [hasError, setHasError] = useState<boolean>(false);
   const previousStyle = usePrevious(style);
   const previouseParser = usePrevious(activeParser);
-  const monaco = useMonaco();
 
   useEffect(() => {
     if (writeStyleResult?.output) {
@@ -179,17 +203,16 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   }, [writeStyleResult, activeParser]);
 
   useEffect(() => {
-    if (monaco) {
-      monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-        validate: true,
-        schemas: [{
-          uri: SCHEMAURI,
-          fileMatch: [MODELPATH],
-          schema
-        }]
-      });
-    }
-  }, [monaco]);
+    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+      validate: true,
+      schemas: [{
+        uri: SCHEMAURI,
+        fileMatch: [MODELPATH],
+        schema
+      }]
+    });
+    loader.config({ monaco });
+  }, []);
 
   const updateValueFromStyle = useCallback((s: GsStyle) => {
     setHasError(false);


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This makes use of the monaco loader and configs provided via npm. By default, the editor requests those via http requests to a CDN. Now, everything is included in the build, so no more requests will be sent.

See also https://github.com/suren-atoyan/monaco-react#use-monaco-editor-as-an-npm-package.

Fixes https://github.com/geostyler/geostyler/issues/2345

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

