### PR TITLE
chore(deps): move antd and @ant-design/icons to regular dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "13.1.1",
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@ant-design/icons": "^5.0.1",
         "@babel/polyfill": "^7.12.1",
         "@dnd-kit/core": "^6.0.8",
         "@dnd-kit/sortable": "^7.0.2",
@@ -20,6 +21,7 @@
         "@types/geojson": "^7946.0.10",
         "@types/lodash": "^4.14.194",
         "@ungap/url-search-params": "^0.2.2",
+        "antd": "^5.11.2",
         "blob": "^0.1.0",
         "chroma-js": "^2.4.2",
         "color": "^4.2.3",
@@ -40,7 +42,6 @@
         "typescript-json-schema": "^0.60.0"
       },
       "devDependencies": {
-        "@ant-design/icons": "^5.0.1",
         "@babel/core": "^7.21.8",
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
@@ -71,7 +72,6 @@
         "@typescript-eslint/eslint-plugin-tslint": "^5.59.5",
         "@typescript-eslint/parser": "^5.59.5",
         "@vitejs/plugin-react": "4.0.4",
-        "antd": "^5.4.7",
         "ast-types": "^0.14.2",
         "babel-jest": "^29.5.0",
         "buffer": "^6.0.3",
@@ -112,10 +112,8 @@
         "url": "https://opencollective.com/geostyler"
       },
       "peerDependencies": {
-        "@ant-design/icons": "5.x",
         "@types/react": ">=16.x",
         "@types/react-dom": ">=16.x",
-        "antd": "5.x",
         "ol": ">=6.x",
         "react": ">=16.x",
         "react-dom": ">=16.x"
@@ -153,16 +151,14 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.0.0.tgz",
       "integrity": "sha512-iVm/9PfGCbC0dSMBrz7oiEXZaaGH7ceU40OJEfKmyuzR9R5CRimJYPlRiFtMQGQcbNMea/ePcoIebi4ASGYXtg==",
-      "dev": true,
       "dependencies": {
         "@ctrl/tinycolor": "^3.4.0"
       }
     },
     "node_modules/@ant-design/cssinjs": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.17.0.tgz",
-      "integrity": "sha512-MgGCZ6sfD3yQB0XW0hN4jgixMxApTlDYyct+pc7fRZNO4CaqWWm/9iXkkljNR27lyWLZmm+XiDfcIOo1bnrnMA==",
-      "dev": true,
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.17.2.tgz",
+      "integrity": "sha512-vu7lnfEx4Mf8MPzZxn506Zen3Nt4fRr2uutwvdCuTCN5IiU0lDdQ0tiJ24/rmB8+pefwjluYsbyzbQSbgfJy+A==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
@@ -181,7 +177,6 @@
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.2.6.tgz",
       "integrity": "sha512-4wn0WShF43TrggskBJPRqCD0fcHbzTYjnaoskdiJrVHg86yxoZ8ZUqsXvyn4WUqehRiFKnaclOhqk9w4Ui2KVw==",
-      "dev": true,
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
         "@ant-design/icons-svg": "^4.3.0",
@@ -200,14 +195,12 @@
     "node_modules/@ant-design/icons-svg": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.3.1.tgz",
-      "integrity": "sha512-4QBZg8ccyC6LPIRii7A0bZUk3+lEDCLnhB+FVsflGdcWPPmV+j3fire4AwwoqHV/BibgvBmR9ZIo4s867smv+g==",
-      "dev": true
+      "integrity": "sha512-4QBZg8ccyC6LPIRii7A0bZUk3+lEDCLnhB+FVsflGdcWPPmV+j3fire4AwwoqHV/BibgvBmR9ZIo4s867smv+g=="
     },
     "node_modules/@ant-design/react-slick": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.0.2.tgz",
       "integrity": "sha512-Wj8onxL/T8KQLFFiCA4t8eIRGpRR+UPgOdac2sYzonv+i0n3kXHmvHLLiOYL655DQx2Umii9Y9nNgL7ssu5haQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.10.4",
         "classnames": "^2.2.5",
@@ -2038,10 +2031,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.11.tgz",
-      "integrity": "sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==",
-      "dev": true,
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2052,8 +2044,7 @@
     "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.22.5",
@@ -2639,7 +2630,6 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
       "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       }
@@ -2696,14 +2686,12 @@
     "node_modules/@emotion/hash": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
-      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==",
-      "dev": true
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@emotion/unitless": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-      "dev": true
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.18.20",
@@ -4479,7 +4467,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-1.4.1.tgz",
       "integrity": "sha512-vh5EWqnsayZa/JwUznqDaPJz39jznx/YDbyBuVJntv735tKXKwEUZZb2jYEldOg+NKWZwtALjGMrNeGBmqFoEw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@ctrl/tinycolor": "^3.6.0",
@@ -4495,7 +4482,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.4.0.tgz",
       "integrity": "sha512-kFcNxg9oLRMoL3qki0OMxK+7g5mypjgaaJp/pkOis/6rVxma9nJBF/8kCIuTYHUQNr0ii7MxqE33wirPZLJQ2w==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "rc-util": "^5.27.0"
@@ -4509,7 +4495,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rc-component/mini-decimal/-/mini-decimal-1.1.0.tgz",
       "integrity": "sha512-jS4E7T9Li2GuYwI6PyiVXmxTiM6b07rlD9Ge8uGZSCz3WlzcG5ZK7g5bbuKNeZ9pgUuPK/5guV781ujdVpm4HQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0"
       },
@@ -4521,7 +4506,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-1.1.0.tgz",
       "integrity": "sha512-QjrOsDXQusNwGZPf4/qRQasg7UFEj06XiCJ8iuiq/Io7CrHrgVi6Uuetw60WAMG1799v+aM8kyc+1L/GBbHSlw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "classnames": "^2.3.2",
@@ -4539,7 +4523,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
       "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "classnames": "^2.3.2",
@@ -4554,10 +4537,9 @@
       }
     },
     "node_modules/@rc-component/tour": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.8.1.tgz",
-      "integrity": "sha512-CsrQnfKgNArxx2j1RNHVLZgVA+rLrEj06lIsl4KSynMqADsqz8eKvVkr0F3p9PA10948M6WEEZt5a/FGAbGR2A==",
-      "dev": true,
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.10.0.tgz",
+      "integrity": "sha512-voV0BKaTJbewB9LLgAHQ7tAGG7rgDkKQkZo82xw2gIk542hY+o7zwoqdN16oHhIKk7eG/xi+mdXrONT62Dt57A==",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "@rc-component/portal": "^1.0.0-9",
@@ -4574,18 +4556,16 @@
       }
     },
     "node_modules/@rc-component/trigger": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-1.15.6.tgz",
-      "integrity": "sha512-Tl19KaGsShf4yzqxumsXVT4c7j0l20Dxe5hgP5S0HmxyhCg3oKen28ntGavRCIPW7cl7wgsGotntqcIokgDHzg==",
-      "dev": true,
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-1.18.2.tgz",
+      "integrity": "sha512-jRLYgFgjLEPq3MvS87fIhcfuywFSRDaDrYw1FLku7Cm4esszvzTbA0JBsyacAyLrK9rF3TiHFcvoEDMzoD3CTA==",
       "dependencies": {
-        "@babel/runtime": "^7.18.3",
+        "@babel/runtime": "^7.23.2",
         "@rc-component/portal": "^1.1.0",
         "classnames": "^2.3.2",
-        "rc-align": "^4.0.0",
         "rc-motion": "^2.0.0",
         "rc-resize-observer": "^1.3.1",
-        "rc-util": "^5.33.0"
+        "rc-util": "^5.38.0"
       },
       "engines": {
         "node": ">=8.x"
@@ -6976,58 +6956,57 @@
       "dev": true
     },
     "node_modules/antd": {
-      "version": "5.8.6",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.8.6.tgz",
-      "integrity": "sha512-DQdHJSq7AH303NgAUZcMRrWqwRYLT9LjesrfhB9xwwi3ooWTMAnS0LrL2NIYHvXZQy1kV0C4mMSiSbBqEKatLA==",
-      "dev": true,
+      "version": "5.11.2",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.11.2.tgz",
+      "integrity": "sha512-7/yqmfXpShHH0MJQOgv3vX9PUFwctyBm/G5L0i/S4AQy20ON6ZZ2UkjmWxgwg3vq2CEHKyVGTHozpH9WwDizgw==",
       "dependencies": {
         "@ant-design/colors": "^7.0.0",
-        "@ant-design/cssinjs": "^1.16.0",
-        "@ant-design/icons": "^5.2.2",
-        "@ant-design/react-slick": "~1.0.0",
+        "@ant-design/cssinjs": "^1.17.2",
+        "@ant-design/icons": "^5.2.6",
+        "@ant-design/react-slick": "~1.0.2",
         "@babel/runtime": "^7.18.3",
-        "@ctrl/tinycolor": "^3.6.0",
-        "@rc-component/color-picker": "~1.4.0",
-        "@rc-component/mutate-observer": "^1.0.0",
-        "@rc-component/tour": "~1.8.1",
-        "@rc-component/trigger": "^1.15.0",
-        "classnames": "^2.2.6",
-        "copy-to-clipboard": "^3.2.0",
+        "@ctrl/tinycolor": "^3.6.1",
+        "@rc-component/color-picker": "~1.4.1",
+        "@rc-component/mutate-observer": "^1.1.0",
+        "@rc-component/tour": "~1.10.0",
+        "@rc-component/trigger": "^1.18.2",
+        "classnames": "^2.3.2",
+        "copy-to-clipboard": "^3.3.3",
         "dayjs": "^1.11.1",
         "qrcode.react": "^3.1.0",
-        "rc-cascader": "~3.14.0",
+        "rc-cascader": "~3.20.0",
         "rc-checkbox": "~3.1.0",
-        "rc-collapse": "~3.7.0",
-        "rc-dialog": "~9.1.0",
-        "rc-drawer": "~6.2.0",
+        "rc-collapse": "~3.7.1",
+        "rc-dialog": "~9.3.4",
+        "rc-drawer": "~6.5.2",
         "rc-dropdown": "~4.1.0",
-        "rc-field-form": "~1.36.0",
-        "rc-image": "~7.1.0",
-        "rc-input": "~1.1.0",
-        "rc-input-number": "~8.0.2",
-        "rc-mentions": "~2.5.0",
-        "rc-menu": "~9.10.0",
-        "rc-motion": "^2.7.3",
-        "rc-notification": "~5.1.1",
-        "rc-pagination": "~3.6.0",
-        "rc-picker": "~3.13.0",
-        "rc-progress": "~3.4.1",
+        "rc-field-form": "~1.40.0",
+        "rc-image": "~7.3.2",
+        "rc-input": "~1.3.6",
+        "rc-input-number": "~8.4.0",
+        "rc-mentions": "~2.9.1",
+        "rc-menu": "~9.12.2",
+        "rc-motion": "^2.9.0",
+        "rc-notification": "~5.3.0",
+        "rc-pagination": "~3.7.0",
+        "rc-picker": "~3.14.6",
+        "rc-progress": "~3.5.1",
         "rc-rate": "~2.12.0",
-        "rc-resize-observer": "^1.2.0",
-        "rc-segmented": "~2.2.0",
-        "rc-select": "~14.7.1",
-        "rc-slider": "~10.2.1",
+        "rc-resize-observer": "^1.4.0",
+        "rc-segmented": "~2.2.2",
+        "rc-select": "~14.10.0",
+        "rc-slider": "~10.4.0",
         "rc-steps": "~6.0.1",
         "rc-switch": "~4.1.0",
-        "rc-table": "~7.32.1",
-        "rc-tabs": "~12.9.0",
-        "rc-textarea": "~1.3.3",
-        "rc-tooltip": "~6.0.0",
-        "rc-tree": "~5.7.6",
-        "rc-tree-select": "~5.11.0",
-        "rc-upload": "~4.3.0",
-        "rc-util": "^5.37.0",
-        "scroll-into-view-if-needed": "^3.0.3",
+        "rc-table": "~7.36.0",
+        "rc-tabs": "~12.13.1",
+        "rc-textarea": "~1.5.3",
+        "rc-tooltip": "~6.1.2",
+        "rc-tree": "~5.8.2",
+        "rc-tree-select": "~5.15.0",
+        "rc-upload": "~4.3.5",
+        "rc-util": "^5.38.1",
+        "scroll-into-view-if-needed": "^3.1.0",
         "throttle-debounce": "^5.0.0"
       },
       "funding": {
@@ -7128,8 +7107,7 @@
     "node_modules/array-tree-filter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-tree-filter/-/array-tree-filter-2.1.0.tgz",
-      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw==",
-      "dev": true
+      "integrity": "sha512-4ROwICNlNw/Hqa9v+rk5h22KjmzB1JGTMVKP2AKJBOCgb0yL0ASf0+YvCcLNNwquOHNX48jkeZIJ3a+oOQqKcw=="
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -7261,8 +7239,7 @@
     "node_modules/async-validator": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/async-validator/-/async-validator-4.2.5.tgz",
-      "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg==",
-      "dev": true
+      "integrity": "sha512-7HhHjtERjqlNbZtqNqy2rckN/SpOOlmDliet+lP7k+eKZEjPk3DgyeU9lIXLdeLz0uBbbVp+9Qdow9wJWgwwfg=="
     },
     "node_modules/asynciterator.prototype": {
       "version": "1.0.0",
@@ -8241,8 +8218,7 @@
     "node_modules/classnames": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
-      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "dev": true
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -8546,10 +8522,9 @@
       "dev": true
     },
     "node_modules/compute-scroll-into-view": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.0.3.tgz",
-      "integrity": "sha512-nadqwNxghAGTamwIqQSG433W6OADZx2vCo3UXHNrzTRHK/htu+7+L0zhjEoaeaQVNAi3YgqWDv8+tzf0hRfR+A==",
-      "dev": true
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.0.tgz",
+      "integrity": "sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -8771,7 +8746,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
       "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "dev": true,
       "dependencies": {
         "toggle-selection": "^1.0.6"
       }
@@ -9175,10 +9149,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.9",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
-      "integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==",
-      "dev": true
+      "version": "1.11.10",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
+      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -9585,12 +9558,6 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true
-    },
-    "node_modules/dom-align": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.4.tgz",
-      "integrity": "sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw==",
       "dev": true
     },
     "node_modules/dom-serializer": {
@@ -15584,7 +15551,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
       "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
-      "dev": true,
       "dependencies": {
         "string-convert": "^0.2.0"
       }
@@ -17798,6 +17764,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/npm/node_modules/buffer": {
       "version": "6.0.3",
       "dev": true,
@@ -18245,7 +18220,7 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.3.3",
+      "version": "10.2.7",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -18253,8 +18228,8 @@
         "foreground-child": "^3.1.0",
         "jackspeak": "^2.0.3",
         "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "minipass": "^5.0.0 || ^6.0.2",
+        "path-scurry": "^1.7.0"
       },
       "bin": {
         "glob": "dist/cjs/src/bin.js"
@@ -18264,15 +18239,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/glob/node_modules/minipass": {
-      "version": "7.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
@@ -18792,15 +18758,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/npm/node_modules/minipass": {
@@ -19731,12 +19688,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/npm/node_modules/semver/node_modules/lru-cache/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/set-blocking": {
       "version": "2.0.0",
@@ -21547,7 +21498,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.1.0.tgz",
       "integrity": "sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==",
-      "dev": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -21693,35 +21643,17 @@
         "rc": "cli.js"
       }
     },
-    "node_modules/rc-align": {
-      "version": "4.0.15",
-      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.15.tgz",
-      "integrity": "sha512-wqJtVH60pka/nOX7/IspElA8gjPNQKIx/ZqJ6heATCkXpe1Zg4cPVrMD2vC96wjsFFL8WsmhPbx9tdMo1qqlIA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "dom-align": "^1.7.0",
-        "rc-util": "^5.26.0",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/rc-cascader": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.14.1.tgz",
-      "integrity": "sha512-fCsgjLIQqYZMhFj9UT+x2ZW4uobx7OP5yivcn6Xto5fuxHaldphsryzCeUVmreQOHEo0RP+032Ip9RDzrKVKJA==",
-      "dev": true,
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.20.0.tgz",
+      "integrity": "sha512-lkT9EEwOcYdjZ/jvhLoXGzprK1sijT3/Tp4BLxQQcHDZkkOzzwYQC9HgmKoJz0K7CukMfgvO9KqHeBdgE+pELw==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "array-tree-filter": "^2.1.0",
         "classnames": "^2.3.1",
-        "rc-select": "~14.7.0",
-        "rc-tree": "~5.7.0",
-        "rc-util": "^5.35.0"
+        "rc-select": "~14.10.0",
+        "rc-tree": "~5.8.1",
+        "rc-util": "^5.37.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -21732,7 +21664,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.1.0.tgz",
       "integrity": "sha512-PAwpJFnBa3Ei+5pyqMMXdcKYKNBMS+TvSDiLdDnARnMJHC8ESxwPfm4Ao1gJiKtWLdmGfigascnCpwrHFgoOBQ==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.3.2",
@@ -21747,7 +21678,6 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.7.1.tgz",
       "integrity": "sha512-N/7ejyiTf3XElNJBBpxqnZBUuMsQWEOPjB2QkfNvZ/Ca54eAvJXuOD1EGbCWCk2m7v/MSxku7mRpdeaLOCd4Gg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -21760,10 +21690,9 @@
       }
     },
     "node_modules/rc-dialog": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.1.0.tgz",
-      "integrity": "sha512-5ry+JABAWEbaKyYsmITtrJbZbJys8CtMyzV8Xn4LYuXMeUx5XVHNyJRoqLFE4AzBuXXzOWeaC49cg+XkxK6kHA==",
-      "dev": true,
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.3.4.tgz",
+      "integrity": "sha512-975X3018GhR+EjZFbxA2Z57SX5rnu0G0/OxFgMMvZK4/hQWEm3MHaNvP4wXpxYDoJsp+xUvVW+GB9CMMCm81jA==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/portal": "^1.0.0-8",
@@ -21777,16 +21706,15 @@
       }
     },
     "node_modules/rc-drawer": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-6.2.0.tgz",
-      "integrity": "sha512-spPkZ3WvP0U0vy5dyzSwlUJ/+vLFtjP/cTwSwejhQRoDBaexSZHsBhELoCZcEggI7LQ7typmtG30lAue2HEhvA==",
-      "dev": true,
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-6.5.2.tgz",
+      "integrity": "sha512-QckxAnQNdhh4vtmKN0ZwDf3iakO83W9eZcSKWYYTDv4qcD2fHhRAZJJ/OE6v2ZlQ2kSqCJX5gYssF4HJFvsEPQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/portal": "^1.1.1",
         "classnames": "^2.2.6",
         "rc-motion": "^2.6.1",
-        "rc-util": "^5.21.2"
+        "rc-util": "^5.36.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -21797,7 +21725,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.1.0.tgz",
       "integrity": "sha512-VZjMunpBdlVzYpEdJSaV7WM7O0jf8uyDjirxXLZRNZ+tAC+NzD3PXPEtliFwGzVwBBdCmGuSqiS9DWcOLxQ9tw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@rc-component/trigger": "^1.7.0",
@@ -21810,10 +21737,9 @@
       }
     },
     "node_modules/rc-field-form": {
-      "version": "1.36.2",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.36.2.tgz",
-      "integrity": "sha512-tCF/JjUsnxW80Gk4E4ZH74ONsaQMxVTRtui6XhQB8DJc4FHWLLa5pP8zwhxtPKC5NaO0QZ0Cv79JggDubn6n2g==",
-      "dev": true,
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-1.40.0.tgz",
+      "integrity": "sha512-OM3N01X2BYFGJDJcwpk9/BBtlwgveE7eh2SQAKIxVCt9KVWlODYJ9ypTHQdxchfDbeJKJKxMBFXlLAmyvlgPHg==",
       "dependencies": {
         "@babel/runtime": "^7.18.0",
         "async-validator": "^4.1.0",
@@ -21828,15 +21754,14 @@
       }
     },
     "node_modules/rc-image": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.1.3.tgz",
-      "integrity": "sha512-foMl1rcit1F0+vgxE5kf0c8TygQcHhILsOohQUL+JMUbzOo3OBFRcehJudYbqbCTArzCecS8nA1irUU9vvgQbg==",
-      "dev": true,
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.3.2.tgz",
+      "integrity": "sha512-ICEF6SWv9YKhDXxy1vrXcmf0TVvEcQWIww5Yg+f+mn7e4oGX7FNP4+FExwMjNO5UHBEuWrigbGhlCgI6yZZ1jg==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "@rc-component/portal": "^1.0.2",
         "classnames": "^2.2.6",
-        "rc-dialog": "~9.1.0",
+        "rc-dialog": "~9.3.4",
         "rc-motion": "^2.6.2",
         "rc-util": "^5.34.1"
       },
@@ -21846,10 +21771,9 @@
       }
     },
     "node_modules/rc-input": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.1.1.tgz",
-      "integrity": "sha512-NTR1Z4em681L8/ewb2KR80RykSmN8I2mzqzJDCoUmTrV1BB9Hk5d7ha4TnfgdEPPL148N+603sW2LExSXk1IbA==",
-      "dev": true,
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.3.6.tgz",
+      "integrity": "sha512-/HjTaKi8/Ts4zNbYaB5oWCquxFyFQO4Co1MnMgoCeGJlpe7k8Eir2HN0a0F9IHDmmo+GYiGgPpz7w/d/krzsJA==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -21861,15 +21785,14 @@
       }
     },
     "node_modules/rc-input-number": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-8.0.4.tgz",
-      "integrity": "sha512-TP+G5b7mZtbwXJ/YEZXF/OgbEZ6iqD4+RSuxZJ8VGKGXDcdt0FKIvpFoNQr/knspdFC4OxA0OfsWfFWfN4XSyA==",
-      "dev": true,
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-8.4.0.tgz",
+      "integrity": "sha512-B6rziPOLRmeP7kcS5qbdC5hXvvDHYKV4vUxmahevYx2E6crS2bRi0xLDjhJ0E1HtOWo8rTmaE2EBJAkTCZOLdA==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/mini-decimal": "^1.0.1",
         "classnames": "^2.2.5",
-        "rc-input": "~1.1.0",
+        "rc-input": "~1.3.5",
         "rc-util": "^5.28.0"
       },
       "peerDependencies": {
@@ -21878,18 +21801,17 @@
       }
     },
     "node_modules/rc-mentions": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.5.0.tgz",
-      "integrity": "sha512-rERXsbUTNVrb5T/iDC0ki/SRGWJnOVraDy6O25Us3FSpuUZ3uq2TPZB4fRk0Hss5kyiEPzz2sprhkI4b+F4jUw==",
-      "dev": true,
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.9.1.tgz",
+      "integrity": "sha512-cZuElWr/5Ws0PXx1uxobxfYh4mqUw2FitfabR62YnWgm+WAfDyXZXqZg5DxXW+M1cgVvntrQgDDd9LrihrXzew==",
       "dependencies": {
         "@babel/runtime": "^7.22.5",
         "@rc-component/trigger": "^1.5.0",
         "classnames": "^2.2.6",
-        "rc-input": "~1.1.0",
-        "rc-menu": "~9.10.0",
-        "rc-textarea": "~1.3.0",
-        "rc-util": "^5.22.5"
+        "rc-input": "~1.3.5",
+        "rc-menu": "~9.12.0",
+        "rc-textarea": "~1.5.0",
+        "rc-util": "^5.34.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -21897,13 +21819,12 @@
       }
     },
     "node_modules/rc-menu": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.10.0.tgz",
-      "integrity": "sha512-g27kpXaAoJh/fkPZF65/d4V+w4DhDeqomBdPcGnkFAcJnEM4o21TnVccrBUoDedLKzC7wJRw1Q7VTqEsfEufmw==",
-      "dev": true,
+      "version": "9.12.2",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.12.2.tgz",
+      "integrity": "sha512-NzloFH2pRUYmQ3S/YbJAvRkgCZaLvq0sRa5rgJtuIHLfPPprNHNyepeSlT64+dbVqI4qRWL44VN0lUCldCbbfg==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^1.6.2",
+        "@rc-component/trigger": "^1.17.0",
         "classnames": "2.x",
         "rc-motion": "^2.4.3",
         "rc-overflow": "^1.3.1",
@@ -21915,10 +21836,9 @@
       }
     },
     "node_modules/rc-motion": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.8.0.tgz",
-      "integrity": "sha512-9gWWzlPvx/IJANj+t+ArqLCQ43rCWYLpOUe6+WJSAGb+b+fqBcfx81qPhg6b+ewa6g3mGNDhkTpBrVrCC4gcXA==",
-      "dev": true,
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.0.tgz",
+      "integrity": "sha512-XIU2+xLkdIr1/h6ohPZXyPBMvOmuyFZQ/T0xnawz+Rh+gh4FINcnZmMT5UTIj6hgI0VLDjTaPeRd+smJeSPqiQ==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -21930,14 +21850,13 @@
       }
     },
     "node_modules/rc-notification": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.1.1.tgz",
-      "integrity": "sha512-BPnded/WmWFE57ubqhVCgRSuedfQQNeSOYqdwppyr2B/Wt909gYFKyWAkFJVXuppAjsOGop05a93UaxjmUFdkg==",
-      "dev": true,
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.3.0.tgz",
+      "integrity": "sha512-WCf0uCOkZ3HGfF0p1H4Sgt7aWfipxORWTPp7o6prA3vxwtWhtug3GfpYls1pnBp4WA+j8vGIi5c2/hQRpGzPcQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "rc-motion": "^2.6.0",
+        "rc-motion": "^2.9.0",
         "rc-util": "^5.20.1"
       },
       "engines": {
@@ -21952,7 +21871,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.3.2.tgz",
       "integrity": "sha512-nsUm78jkYAoPygDAcGZeC2VwIg/IBGSodtOY3pMof4W3M9qRJgqaDYm03ZayHlde3I6ipliAxbN0RUcGf5KOzw==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -21965,10 +21883,9 @@
       }
     },
     "node_modules/rc-pagination": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-3.6.1.tgz",
-      "integrity": "sha512-R/sUnKKXx1Nm4kZfUKS3YKa7yEPF1ZkVB/AynQaHt+nMER7h9wPTfliDJFdYo+RM/nk2JD4Yc5QpUq8fIQHeug==",
-      "dev": true,
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-3.7.0.tgz",
+      "integrity": "sha512-IxSzKapd13L91/195o1TPkKnCNw8gIR25UP1GCW/7c7n/slhld4npu2j2PB9IWjXm4SssaAaSAt2lscYog7wzg==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
@@ -21980,10 +21897,9 @@
       }
     },
     "node_modules/rc-picker": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-3.13.1.tgz",
-      "integrity": "sha512-211SrinX5IXZ9FMMDUMyPLuGOdfftUtd8zj4lqudpFxlMdtgV5+hXUJMBKb26xmDsleOm5iySK6KIHgiaI+U4w==",
-      "dev": true,
+      "version": "3.14.6",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-3.14.6.tgz",
+      "integrity": "sha512-AdKKW0AqMwZsKvIpwUWDUnpuGKZVrbxVTZTNjcO+pViGkjC1EBcjMgxVe8tomOEaIHJL5Gd13vS8Rr3zzxWmag==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/trigger": "^1.5.0",
@@ -22017,10 +21933,9 @@
       }
     },
     "node_modules/rc-progress": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.4.2.tgz",
-      "integrity": "sha512-iAGhwWU+tsayP+Jkl9T4+6rHeQTG9kDz8JAHZk4XtQOcYN5fj9H34NXNEdRdZx94VUDHMqCb1yOIvi8eJRh67w==",
-      "dev": true,
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.5.1.tgz",
+      "integrity": "sha512-V6Amx6SbLRwPin/oD+k1vbPrO8+9Qf8zW1T8A7o83HdNafEVvAxPV5YsgtKFP+Ud5HghLj33zKOcEHrcrUGkfw==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6",
@@ -22035,7 +21950,6 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.12.0.tgz",
       "integrity": "sha512-g092v5iZCdVzbjdn28FzvWebK2IutoVoiTeqoLTj9WM7SjA/gOJIw5/JFZMRyJYYVe1jLAU2UhAfstIpCNRozg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
@@ -22050,14 +21964,13 @@
       }
     },
     "node_modules/rc-resize-observer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.3.1.tgz",
-      "integrity": "sha512-iFUdt3NNhflbY3mwySv5CA1TC06zdJ+pfo0oc27xpf4PIOvfZwZGtD9Kz41wGYqC4SLio93RVAirSSpYlV/uYg==",
-      "dev": true,
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.0.tgz",
+      "integrity": "sha512-PnMVyRid9JLxFavTjeDXEXo65HCRqbmLBw9xX9gfC4BZiSzbLXKzW3jPz+J0P71pLbD5tBMTT+mkstV5gD0c9Q==",
       "dependencies": {
         "@babel/runtime": "^7.20.7",
         "classnames": "^2.2.1",
-        "rc-util": "^5.27.0",
+        "rc-util": "^5.38.0",
         "resize-observer-polyfill": "^1.5.1"
       },
       "peerDependencies": {
@@ -22069,7 +21982,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.2.2.tgz",
       "integrity": "sha512-Mq52M96QdHMsNdE/042ibT5vkcGcD5jxKp7HgPC2SRofpia99P5fkfHy1pEaajLMF/kj0+2Lkq1UZRvqzo9mSA==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -22082,10 +21994,9 @@
       }
     },
     "node_modules/rc-select": {
-      "version": "14.7.4",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.7.4.tgz",
-      "integrity": "sha512-qRUpvMVXFy6rdHe+qzHXAqyQAfhErC/oY8dcRtoRjoz0lz2Nx3J+lLL5AnEbjnwlS+/kQTJUZ/65WyCwWwcLwQ==",
-      "dev": true,
+      "version": "14.10.0",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.10.0.tgz",
+      "integrity": "sha512-TsIJTYafTTapCA32LLNpx/AD6ntepR1TG8jEVx35NiAAWCPymhUfuca8kRcUNd3WIGVMDcMKn9kkphoxEz+6Ag==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "@rc-component/trigger": "^1.5.0",
@@ -22104,10 +22015,9 @@
       }
     },
     "node_modules/rc-slider": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.2.1.tgz",
-      "integrity": "sha512-l355C/65iV4UFp7mXq5xBTNX2/tF2g74VWiTVlTpNp+6vjE/xaHHNiQq5Af+Uu28uUiqCuH/QXs5HfADL9KJ/A==",
-      "dev": true,
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-10.4.0.tgz",
+      "integrity": "sha512-ZlpWjFhOlEf0w4Ng31avFBkXNNBj60NAcTPaIoiCxBkJ29wOtHSPMqv9PZeEoqmx64bpJkgK7kPa47HG4LPzww==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
@@ -22125,7 +22035,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-6.0.1.tgz",
       "integrity": "sha512-lKHL+Sny0SeHkQKKDJlAjV5oZ8DwCdS2hFhAkIjuQt1/pB81M0cA0ErVFdHq9+jmPmFw1vJB2F5NBzFXLJxV+g==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.7",
         "classnames": "^2.2.3",
@@ -22143,7 +22052,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-4.1.0.tgz",
       "integrity": "sha512-TI8ufP2Az9oEbvyCeVE4+90PDSljGyuwix3fV58p7HV2o4wBnVToEyomJRVyTaZeqNPAp+vqeo4Wnj5u0ZZQBg==",
-      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0",
         "classnames": "^2.2.1",
@@ -22155,16 +22063,16 @@
       }
     },
     "node_modules/rc-table": {
-      "version": "7.32.3",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.32.3.tgz",
-      "integrity": "sha512-MqjrI/ibuGg7NEyFsux0dM5GK+3er1gTiZofAkifr2bHf/Sa1nUqXXFmSrYXSOjwpx0xyBnJ3GrHFCIqC/eOzw==",
-      "dev": true,
+      "version": "7.36.0",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.36.0.tgz",
+      "integrity": "sha512-3xVcdCC5OLeOOhaCg+5Lps2oPreM/GWXmUXWTSX4p6vF7F76ABM4dfPpMJ9Dnf5yGRyh+8pe7FRyhRVnWw2H/w==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
-        "@rc-component/context": "^1.3.0",
+        "@rc-component/context": "^1.4.0",
         "classnames": "^2.2.5",
         "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.27.1"
+        "rc-util": "^5.37.0",
+        "rc-virtual-list": "^3.11.1"
       },
       "engines": {
         "node": ">=8.x"
@@ -22175,18 +22083,17 @@
       }
     },
     "node_modules/rc-tabs": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-12.9.0.tgz",
-      "integrity": "sha512-2HnVowgMVrq0DfQtyu4mCd9E6pXlWNdM6VaDvOOHMsLYqPmpY+7zBqUC6YrrQ9xYXHciTS0e7TtjOHIvpVCHLQ==",
-      "dev": true,
+      "version": "12.13.1",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-12.13.1.tgz",
+      "integrity": "sha512-83u3l2QkO0UznCzdBLEk9WnNcT+imtmDmMT993sUUEOGnNQAmqOdev0XjeqrcvsAMe9CDpAWDFd7L/RZw+LVJQ==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
         "rc-dropdown": "~4.1.0",
-        "rc-menu": "~9.10.0",
+        "rc-menu": "~9.12.0",
         "rc-motion": "^2.6.2",
         "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.16.0"
+        "rc-util": "^5.34.1"
       },
       "engines": {
         "node": ">=8.x"
@@ -22197,14 +22104,13 @@
       }
     },
     "node_modules/rc-textarea": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.3.4.tgz",
-      "integrity": "sha512-wn0YjTpvcVolcfXa0HtzL+jgV2QcwtfB29RwNAKj8hMgZOju1V24M3TfEDjABeQEAQbUGbjMbISREOX/YSVKhg==",
-      "dev": true,
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.5.3.tgz",
+      "integrity": "sha512-oH682ghHx++stFNYrosPRBfwsypywrTXpaD0/5Z8MPkUOnyOQUaY9ueL9tMu6BP1LfsuYQ1VLpg5OtshViLNgA==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
-        "rc-input": "~1.1.0",
+        "rc-input": "~1.3.5",
         "rc-resize-observer": "^1.0.0",
         "rc-util": "^5.27.0"
       },
@@ -22214,13 +22120,12 @@
       }
     },
     "node_modules/rc-tooltip": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.0.1.tgz",
-      "integrity": "sha512-MdvPlsD1fDSxKp9+HjXrc/CxLmA/s11QYIh1R7aExxfodKP7CZA++DG1AjrW80F8IUdHYcR43HAm0Y2BYPelHA==",
-      "dev": true,
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.1.2.tgz",
+      "integrity": "sha512-89zwvybvCxGJu3+gGF8w5AXd4HHk6hIN7K0vZbkzjilVaEAIWPqc1fcyeUeP71n3VCcw7pTL9LyFupFbrx8gHw==",
       "dependencies": {
         "@babel/runtime": "^7.11.2",
-        "@rc-component/trigger": "^1.0.4",
+        "@rc-component/trigger": "^1.18.0",
         "classnames": "^2.3.1"
       },
       "peerDependencies": {
@@ -22229,10 +22134,9 @@
       }
     },
     "node_modules/rc-tree": {
-      "version": "5.7.10",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.7.10.tgz",
-      "integrity": "sha512-n4UkMQY3bzvJUNnbw6e3YI7sy2kE9c9vAYbSt94qAhcPKtMOThONNr1LIaFB/M5XeFYYrWVbvRVoT8k38eFuSQ==",
-      "dev": true,
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.8.2.tgz",
+      "integrity": "sha512-xH/fcgLHWTLmrSuNphU8XAqV7CdaOQgm4KywlLGNoTMhDAcNR3GVNP6cZzb0GrKmIZ9yae+QLot/cAgUdPRMzg==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -22249,15 +22153,14 @@
       }
     },
     "node_modules/rc-tree-select": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.11.2.tgz",
-      "integrity": "sha512-ujRFO3pcjSg8R4ndXX2oiNcCu+RgO9ZPcd23CZy18Khm+nRsfWWS3Su7qB0iuoJgzAJ5LK7b6Dio0t7IQDGs9g==",
-      "dev": true,
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.15.0.tgz",
+      "integrity": "sha512-YJHfdO6azFnR0/JuNBZLDptGE4/RGfVeHAafUIYcm2T3RBkL1O8aVqiHvwIyLzdK59ry0NLrByd+3TkfpRM+9Q==",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
-        "rc-select": "~14.7.0",
-        "rc-tree": "~5.7.0",
+        "rc-select": "~14.10.0",
+        "rc-tree": "~5.8.1",
         "rc-util": "^5.16.1"
       },
       "peerDependencies": {
@@ -22266,10 +22169,9 @@
       }
     },
     "node_modules/rc-upload": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.3.4.tgz",
-      "integrity": "sha512-uVbtHFGNjHG/RyAfm9fluXB6pvArAGyAx8z7XzXXyorEgVIWj6mOlriuDm0XowDHYz4ycNK0nE0oP3cbFnzxiQ==",
-      "dev": true,
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.3.5.tgz",
+      "integrity": "sha512-EHlKJbhkgFSQHliTj9v/2K5aEuFwfUQgZARzD7AmAPOneZEPiCNF3n6PEWIuqz9h7oq6FuXgdR67sC5BWFxJbA==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "classnames": "^2.2.5",
@@ -22281,13 +22183,12 @@
       }
     },
     "node_modules/rc-util": {
-      "version": "5.37.0",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.37.0.tgz",
-      "integrity": "sha512-cPMV8DzaHI1KDaS7XPRXAf4J7mtBqjvjikLpQieaeOO7+cEbqY2j7Kso/T0R0OiEZTNcLS/8Zl9YrlXiO9UbjQ==",
-      "dev": true,
+      "version": "5.38.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.38.1.tgz",
+      "integrity": "sha512-e4ZMs7q9XqwTuhIK7zBIVFltUtMSjphuPPQXHoHlzRzNdOwUxDejo0Zls5HYaJfRKNURcsS/ceKVULlhjBrxng==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "react-is": "^16.12.0"
+        "react-is": "^18.2.0"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
@@ -22295,16 +22196,14 @@
       }
     },
     "node_modules/rc-util/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/rc-virtual-list": {
-      "version": "3.10.5",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.10.5.tgz",
-      "integrity": "sha512-Vc89TL3JHfRlLVQXVj5Hmv0dIflgwmHDcbjt9lrZjOG3wNUDkTF5zci8kFDU/CzdmmqgKu+CUktEpT10VUKYSQ==",
-      "dev": true,
+      "version": "3.11.3",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.11.3.tgz",
+      "integrity": "sha512-tu5UtrMk/AXonHwHxUogdXAWynaXsrx1i6dsgg+lOo/KJSF8oBAcprh1z5J3xgnPJD5hXxTL58F8s8onokdt0Q==",
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "classnames": "^2.2.6",
@@ -23566,8 +23465,7 @@
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "dev": true
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.4",
@@ -23949,10 +23847,9 @@
       "dev": true
     },
     "node_modules/scroll-into-view-if-needed": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.0.10.tgz",
-      "integrity": "sha512-t44QCeDKAPf1mtQH3fYpWz8IM/DyvHLjs8wUvvwMYxk5moOqCzrMSxK6HQVD0QVmVjXFavoFIPRVrMuJPKAvtg==",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-3.1.0.tgz",
+      "integrity": "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==",
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
@@ -24956,8 +24853,7 @@
     "node_modules/string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
-      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A==",
-      "dev": true
+      "integrity": "sha512-u/1tdPl4yQnPBjnVrmdLo9gtuLvELKsAoRapekWggdiQNvvvum+jYF329d84NAa660KQw7pB2n36KrIKVoXa3A=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -25179,8 +25075,7 @@
     "node_modules/stylis": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.0.tgz",
-      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==",
-      "dev": true
+      "integrity": "sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -25444,7 +25339,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
       "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==",
-      "dev": true,
       "engines": {
         "node": ">=12.22"
       }
@@ -25577,8 +25471,7 @@
     "node_modules/toggle-selection": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
-      "dev": true
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "build": "tsc && vite build && npm run build-dist && npm run build-styleguide"
   },
   "dependencies": {
+    "@ant-design/icons": "^5.0.1",
     "@babel/polyfill": "^7.12.1",
     "@dnd-kit/core": "^6.0.8",
     "@dnd-kit/sortable": "^7.0.2",
@@ -62,6 +63,7 @@
     "@types/geojson": "^7946.0.10",
     "@types/lodash": "^4.14.194",
     "@ungap/url-search-params": "^0.2.2",
+    "antd": "^5.11.2",
     "blob": "^0.1.0",
     "chroma-js": "^2.4.2",
     "color": "^4.2.3",
@@ -82,7 +84,6 @@
     "typescript-json-schema": "^0.60.0"
   },
   "devDependencies": {
-    "@ant-design/icons": "^5.0.1",
     "@babel/core": "^7.21.8",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
@@ -113,7 +114,6 @@
     "@typescript-eslint/eslint-plugin-tslint": "^5.59.5",
     "@typescript-eslint/parser": "^5.59.5",
     "@vitejs/plugin-react": "4.0.4",
-    "antd": "^5.4.7",
     "ast-types": "^0.14.2",
     "babel-jest": "^29.5.0",
     "buffer": "^6.0.3",
@@ -148,10 +148,8 @@
     "whatwg-fetch": "^3.6.2"
   },
   "peerDependencies": {
-    "@ant-design/icons": "5.x",
     "@types/react": ">=16.x",
     "@types/react-dom": ">=16.x",
-    "antd": "5.x",
     "ol": ">=6.x",
     "react": ">=16.x",
     "react-dom": ">=16.x"


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This moves `antd` and `@ant-design/icons` from peerDependencies to regular dependencies. Since there is no actual exchange between instances (e.g. components) from an wrapping application to GeoStyler, there is no actual need to declare `antd` as peerDependency. This rather limits the possibilities of GeoStyler to be used in applications, as versions of antd have to match, if the wrapping application also uses antd.

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

