### PR TITLE
feat: add LineEditor graphicFill and graphicStroke to composition

### DIFF
--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -49,7 +49,7 @@ import { LineDashField } from '../Field/LineDashField/LineDashField';
 import { LineCapField } from '../Field/LineCapField/LineCapField';
 import { LineJoinField, LineJoinFieldProps } from '../Field/LineJoinField/LineJoinField';
 import { OffsetField, OffsetFieldProps } from '../Field/OffsetField/OffsetField';
-import { GraphicEditor } from '../GraphicEditor/GraphicEditor';
+import { GraphicEditor, GraphicEditorProps } from '../GraphicEditor/GraphicEditor';
 
 import _cloneDeep from 'lodash/cloneDeep';
 import _get from 'lodash/get';
@@ -80,8 +80,10 @@ export interface LineEditorComposableProps {
   };
   // TODO add support for default values in LineJoinField
   joinField?: InputConfig<LineJoinFieldProps['value']>;
-  // TODO add support for graphicStroke
-  // TODO add support for graphicFill
+  // TODO add support for default values in GraphicEditor
+  graphicStrokeField?: InputConfig<GraphicEditorProps['graphic']>;
+  // TODO add support for default values in GraphicEditor
+  graphicFillField?: InputConfig<GraphicEditorProps['graphic']>;
 }
 
 export interface LineEditorInternalProps {
@@ -101,6 +103,8 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
     capField,
     colorField,
     dashOffsetField,
+    graphicFillField,
+    graphicStrokeField,
     joinField,
     lineDashField,
     onSymbolizerChange,
@@ -326,24 +330,30 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
             )
           }
         </Panel>
-        <Panel header="Graphic Stroke" key="2">
-          {/* TODO allow changing graphicStroke via composition context */}
-          <GraphicEditor
-            graphic={graphicStroke}
-            onGraphicChange={onGraphicStrokeChange}
-            graphicTypeFieldLabel={locale.graphicStrokeTypeLabel}
-            graphicType={_get(graphicStroke, 'kind') as GraphicType}
-          />
-        </Panel>
-        <Panel header="Graphic Fill" key="3">
-          {/* TODO allow changing graphicFill via composition context */}
-          <GraphicEditor
-            graphic={graphicFill}
-            onGraphicChange={onGraphicFillChange}
-            graphicTypeFieldLabel={locale.graphicFillTypeLabel}
-            graphicType={_get(graphicFill, 'kind') as GraphicType}
-          />
-        </Panel>
+        {
+          graphicStrokeField?.visibility === false ? null : (
+            <Panel header="Graphic Stroke" key="2">
+              <GraphicEditor
+                graphic={graphicStroke}
+                onGraphicChange={onGraphicStrokeChange}
+                graphicTypeFieldLabel={locale.graphicStrokeTypeLabel}
+                graphicType={_get(graphicStroke, 'kind') as GraphicType}
+              />
+            </Panel>
+          )
+        }
+        {
+          graphicFillField?.visibility === false ? null : (
+            <Panel header="Graphic Fill" key="3">
+              <GraphicEditor
+                graphic={graphicFill}
+                onGraphicChange={onGraphicFillChange}
+                graphicTypeFieldLabel={locale.graphicFillTypeLabel}
+                graphicType={_get(graphicFill, 'kind') as GraphicType}
+              />
+            </Panel>
+          )
+        }
       </Collapse>
     </div>
   );


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This adds the graphicFill and graphicStroke fields of the `<LineEditor>` to the composition context.

Example with disabled graphicFill and graphicStroke fields:

![image](https://github.com/geostyler/geostyler/assets/12186477/d3d39d75-4ffe-44a6-a21a-28f7d138c9e7)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

