### PR TITLE
ci: remove styleguidist build and duplicate build step in release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Install dependencies ⏬
         run: npm ci
 
-      - name: Build artifacts 🏗️
-        run: npm run build
-
       - name: Release 🚀
         uses: cycjimmy/semantic-release-action@v3
         id: semantic

--- a/package.json
+++ b/package.json
@@ -33,14 +33,16 @@
   ],
   "homepage": "https://github.com/geostyler/geostyler",
   "scripts": {
+    "build-package": "tsc && npm run build-browser && npm run build-dist",
     "build-dist": "tsc -p ./ && copyfiles \"./src/**/*.less\" dist --up 1 && node transform-less.js",
     "build-styleguide": "styleguidist build",
+    "build-browser": "vite build",
     "browser-sample": "npx http-server . -o /public/browser.html",
     "lint": "eslint -c .eslintrc.js --ext .ts,tsx src/ && tsc --noEmit --project tsconfig.json",
     "lint:test": "npm run lint && npm run test",
     "lint:test:cleanup:build": "npm run lint && npm run test && npm run cleanup && npm run build",
     "cleanup": "rimraf dist/** && rimraf build/**",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "npm run build-package",
     "styleguide": "styleguidist server",
     "test": "jest --coverage",
     "typecheck": "tsc --noEmit",
@@ -48,7 +50,7 @@
     "test-watch": "jest --watchAll",
     "start-dev": "vite -c vite.dev.config.ts",
     "preview": "vite preview",
-    "build": "tsc && vite build && npm run build-dist && npm run build-styleguide"
+    "build": "npm run build-package && npm run build-styleguide"
   },
   "dependencies": {
     "@ant-design/icons": "^5.0.1",


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This removes the unnecessary `build` step in the release pipeline. This step is unnecessary, as we already create a build when publishing via the `prepublishOnly` script.

This also removes the building of the styleguide in the release pipeline, as it is not needed there.

This also fixes running parallel builds following the specs provided by https://docs.coveralls.io/parallel-builds

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

