### PR TITLE
feat: replace checkbox with switch for boolean fields

### DIFF
--- a/src/Component/ExpressionInput/BooleanExpressionInput/BooelanExpressionInput.spec.tsx
+++ b/src/Component/ExpressionInput/BooleanExpressionInput/BooelanExpressionInput.spec.tsx
@@ -48,13 +48,13 @@ describe('BooleanExpressionInput', () => {
     expect(booleanExpressionInput.container).toBeInTheDocument();
   });
 
-  it('renders Checkbox if value is a number', async () => {
+  it('renders Switch if value is a number', async () => {
     const booleanExpressionInput = render(<BooleanExpressionInput
       value={booleanValue}
     />);
     expect(booleanExpressionInput.container).toBeInTheDocument();
     expect(document.body.querySelectorAll('.gs-function-ui').length).toBe(0);
-    expect(document.body.querySelectorAll('.ant-checkbox').length).toBe(1);
+    expect(document.body.querySelectorAll('.ant-switch').length).toBe(1);
   });
 
   it('renders FunctionUI if value is a function', async () => {
@@ -63,7 +63,7 @@ describe('BooleanExpressionInput', () => {
     />);
     expect(booleanExpressionInput.container).toBeInTheDocument();
     expect(document.body.querySelectorAll('.gs-function-ui').length).toBe(1);
-    expect(document.body.querySelectorAll('.ant-checkbox').length).toBe(0);
+    expect(document.body.querySelectorAll('.ant-switch').length).toBe(0);
   });
 
 });

--- a/src/Component/ExpressionInput/BooleanExpressionInput/BooleanExpressionInput.tsx
+++ b/src/Component/ExpressionInput/BooleanExpressionInput/BooleanExpressionInput.tsx
@@ -30,8 +30,8 @@ import React from 'react';
 
 import {
   Button,
-  Checkbox,
-  CheckboxProps
+  Switch,
+  SwitchProps
 } from 'antd';
 import { FunctionUI, FunctionUIProps } from '../../FunctionUI/FunctionUI';
 import {
@@ -45,9 +45,10 @@ import './BooleanExpressionInput.less';
 
 export interface BooleanExpressionInputProps {
   value?: Expression<boolean>;
-  checkboxProps?: Omit<CheckboxProps, 'value' | 'onChange' | 'className'>;
+  switchProps?: Omit<SwitchProps, 'checked' | 'onChange' | 'className'>;
   functionUiProps?: FunctionUIProps<GeoStylerBooleanFunction>;
-  label?: string;
+  labelOn?: string;
+  labelOff?: string;
   onChange?: (newValue: Expression<boolean>) => void;
   onCancel?: (type: 'boolean') => void;
   className?: string;
@@ -57,9 +58,10 @@ export const BooleanExpressionInput: React.FC<BooleanExpressionInputProps> = ({
   onChange,
   onCancel,
   value,
-  label,
+  labelOn,
+  labelOff,
   className,
-  checkboxProps,
+  switchProps,
   functionUiProps
 }) => {
 
@@ -82,15 +84,15 @@ export const BooleanExpressionInput: React.FC<BooleanExpressionInputProps> = ({
   }
   return (
     <span className={finalClassName}>
-      <Checkbox
+      <Switch
         checked={value}
-        onChange={(evt) => {
-          onChange?.(evt.target.checked);
+        onChange={(checked) => {
+          onChange?.(checked);
         }}
-        {...checkboxProps}
-      >
-        {label}
-      </Checkbox>
+        checkedChildren={<span>{labelOn}</span>}
+        unCheckedChildren={<span>{labelOff}</span>}
+        {...switchProps}
+      />
       <Button
         icon={<FunctionOutlined />}
         onClick={() => {

--- a/src/Component/FunctionUI/FunctionUI.tsx
+++ b/src/Component/FunctionUI/FunctionUI.tsx
@@ -141,7 +141,8 @@ export const FunctionUI = <T extends GeoStylerFunction>({
             onChange={(val) => {
               updateFunctionArg(val, index);
             }}
-            label={cfg.label}
+            labelOn={cfg.label}
+            labelOff={cfg.label}
           />
         </div>
       );

--- a/src/Component/Symbolizer/Field/VisibilityField/VisibilityField.tsx
+++ b/src/Component/Symbolizer/Field/VisibilityField/VisibilityField.tsx
@@ -32,8 +32,9 @@ import BooleanExpressionInput, { type BooleanExpressionInputProps }
 import { Expression } from 'geostyler-style';
 
 import './VisibilityField.less';
+import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStylerContext';
 
-type InputProps = BooleanExpressionInputProps['checkboxProps'];
+type InputProps = BooleanExpressionInputProps['switchProps'];
 
 export interface VisibilityFieldProps extends InputProps {
   visibility?: Expression<boolean>;
@@ -49,6 +50,8 @@ export const VisibilityField: React.FC<VisibilityFieldProps> = ({
   ...inputBooleanProps
 }) => {
 
+  const locale = useGeoStylerLocale('VisibilityField');
+
   function onCancel() {
     onChange(true);
   }
@@ -59,7 +62,9 @@ export const VisibilityField: React.FC<VisibilityFieldProps> = ({
       value={visibility === undefined ? true : visibility}
       onChange={onChange}
       onCancel={onCancel}
-      checkboxProps={{...inputBooleanProps}}
+      switchProps={{...inputBooleanProps}}
+      labelOn={locale.on}
+      labelOff={locale.off}
     />
   );
 };

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -438,6 +438,10 @@ const de_DE: GeoStylerLocale = {
   FunctionNameCombo: {
     placeholder: '… GeoStylerFunction wählen'
   },
+  VisibilityField: {
+    on: 'an',
+    off: 'aus',
+  },
   ...antd_de_DE
 };
 

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -437,6 +437,10 @@ const en_US: GeoStylerLocale = {
   FunctionNameCombo: {
     placeholder: '… choose GeoStylerFunction'
   },
+  VisibilityField: {
+    on: 'on',
+    off: 'off',
+  },
   ...antd_en_US
 };
 

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -438,6 +438,10 @@ const es_ES: GeoStylerLocale = {
   FunctionNameCombo: {
     placeholder: '… elija GeoStylerFunction'
   },
+  VisibilityField: {
+    on: 'TODO(es_ES):on',
+    off: 'TODO(es_ES):off',
+  },
   ...antd_es_ES
 };
 

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -438,6 +438,10 @@ const fr_FR: GeoStylerLocale = {
   FunctionNameCombo: {
     placeholder: '… choisissez GeoStylerFunction'
   },
+  VisibilityField: {
+    on: 'TODO(fr_FR):on',
+    off: 'TODO(fr_FR):off',
+  },
   ...antd_fr_FR
 };
 

--- a/src/locale/hr_HR.ts
+++ b/src/locale/hr_HR.ts
@@ -437,6 +437,10 @@ const hr_HR: GeoStylerLocale = {
   FunctionNameCombo: {
     placeholder: '… odaberite GeoStylerFunction'
   },
+  VisibilityField: {
+    on: 'TODO(hr_HR):on',
+    off: 'TODO(hr_HR):off',
+  },
   ...antd_hr_HR
 };
 export default hr_HR;

--- a/src/locale/locale.ts
+++ b/src/locale/locale.ts
@@ -411,4 +411,8 @@ export default interface GeoStylerLocale {
   FunctionNameCombo: {
     placeholder: string;
   };
+  VisibilityField: {
+    on: string;
+    off: string;
+  };
 };

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -438,6 +438,10 @@ const zh_CN: GeoStylerLocale = {
   FunctionNameCombo: {
     placeholder: '… 选择GeoStylerFunction'
   },
+  VisibilityField: {
+    on: 'TODO(zh_CN):on',
+    off: 'TODO(zh_CN):off',
+  },
   ...antd_zh_CN
 };
 


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

The checkbox in `<BooleanExpressionInput` was replaced with a switch.

BREAKING CHANGE: Following props of  `<BooleanExpressionInput>` changed: `label` was replaced with `labelOn` and `labelOff`. `checkboxProps` was renamed to `switchProps` and now accepts the properties of antd `<Switch>`.

Boolean `Visibility` in Editors:

![image](https://github.com/geostyler/geostyler/assets/12186477/b7b9f1c3-83b5-45fe-9746-300d1c744af3)

Boolean `global` in ExpressionInput:

![image](https://github.com/geostyler/geostyler/assets/12186477/b7ab05c3-36f9-474c-a02f-8b9fbf9dfa1a)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

