### PR TITLE
feat: add editor visibility field to composition

### DIFF
--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -29,7 +29,6 @@
 import React from 'react';
 
 import {
-  Expression,
   Symbolizer,
   SymbolizerKind
 } from 'geostyler-style';
@@ -38,8 +37,6 @@ import { MarkEditor } from '../MarkEditor/MarkEditor';
 import { LineEditor } from '../LineEditor/LineEditor';
 import { FillEditor } from '../FillEditor/FillEditor';
 import { TextEditor } from '../TextEditor/TextEditor';
-
-import VisibilityField from '../Field/VisibilityField/VisibilityField';
 
 import './Editor.less';
 
@@ -54,7 +51,10 @@ import SymbolizerUtil from '../../../Util/SymbolizerUtil';
 import { RasterEditor } from '../RasterEditor/RasterEditor';
 import { Form } from 'antd';
 
-import { useGeoStylerComposition, useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
+import {
+  useGeoStylerComposition,
+  useGeoStylerLocale
+} from '../../../context/GeoStylerContext/GeoStylerContext';
 
 export interface EditorComposableProps {
   markEditor?: {
@@ -159,12 +159,6 @@ export const Editor: React.FC<EditorProps> = (props) => {
     onSymbolizerChange(newSymbolizer);
   };
 
-  const onVisibilityFieldChange = (visibility: Expression<boolean>) => {
-    const newSymbolizer = _cloneDeep(symbolizer);
-    newSymbolizer.visibility = visibility;
-    onSymbolizerChange(newSymbolizer);
-  };
-
   const symbolizerKinds: SymbolizerKind[] = ['Mark', 'Fill', 'Icon', 'Line', 'Text', 'Raster'];
   const filteredSymbolizerKinds = symbolizerKinds
     .filter(kind => {
@@ -201,14 +195,6 @@ export const Editor: React.FC<EditorProps> = (props) => {
             kind={symbolizer.kind}
             onChange={onKindFieldChange}
             symbolizerKinds={filteredSymbolizerKinds}
-          />
-        </Form.Item>
-        <Form.Item
-          label={locale.visibilityFieldLabel}
-        >
-          <VisibilityField
-            visibility={symbolizer.visibility}
-            onChange={onVisibilityFieldChange}
           />
         </Form.Item>
         {getUiForSymbolizer()}

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -57,6 +57,7 @@ import {
   useGeoStylerLocale,
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
+import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
 
 const Panel = Collapse.Panel;
 
@@ -71,6 +72,8 @@ export interface FillEditorComposableProps {
     visibility?: boolean;
   };
   outlineWidthField?: InputConfig<WidthFieldProps['value']>;
+  // TODO add support for default values in VisibilityField
+  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
   // TODO add support for graphicFill
 }
 
@@ -94,6 +97,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
     outlineDasharrayField,
     outlineOpacityField,
     outlineWidthField,
+    visibilityField,
     symbolizer
   } = composed;
 
@@ -168,6 +172,14 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
     }
   };
 
+  const onVisibilityChange = (newVisibility: FillSymbolizer['visibility']) => {
+    const symbolizerClone: FillSymbolizer = _cloneDeep(symbolizer);
+    symbolizerClone.visibility = newVisibility;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizerClone);
+    }
+  };
+
   const {
     color,
     fillOpacity,
@@ -176,13 +188,26 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
     outlineWidth,
     outlineDasharray,
     opacity,
-    outlineOpacity
+    outlineOpacity,
+    visibility
   } = symbolizer;
 
   return (
     <div className="gs-fill-symbolizer-editor" >
       <Collapse bordered={false} defaultActiveKey={['1']}>
         <Panel header="General" key="1">
+          {
+            visibilityField?.visibility === false ? null : (
+              <Form.Item
+                label={locale.visibilityLabel}
+              >
+                <VisibilityField
+                  visibility={visibility}
+                  onChange={onVisibilityChange}
+                />
+              </Form.Item>
+            )
+          }
           {
             fillColorField?.visibility === false ? null : (
               <Form.Item

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -49,6 +49,7 @@ import {
   useGeoStylerLocale,
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
+import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
 
 export interface IconEditorComposableProps {
   // TODO add support for default values in ImageField
@@ -63,6 +64,8 @@ export interface IconEditorComposableProps {
   offsetYField?: InputConfig<OffsetFieldProps['offset']>;
   rotateField?: InputConfig<RotateFieldProps['rotate']>;
   opacityField?: InputConfig<OpacityFieldProps['value']>;
+  // TODO add support for default values in VisibilityField
+  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
   iconLibraries?: IconLibrary[];
 }
 
@@ -87,6 +90,7 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
     opacityField,
     rotateField,
     sizeField,
+    visibilityField,
     symbolizer
   } = composed;
 
@@ -152,18 +156,39 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
     }
   };
 
+  const onVisibilityChange = (newVisibility: IconSymbolizer['visibility']) => {
+    const symbolizerClone: IconSymbolizer = _cloneDeep(symbolizer);
+    symbolizerClone.visibility = newVisibility;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizerClone);
+    }
+  };
+
   const {
     opacity,
     image,
     size,
     rotate,
-    offset
+    offset,
+    visibility
   } = symbolizer;
 
   const imageSrc = !_isEmpty(image) ? image : locale.imagePlaceholder;
 
   return (
     <div className="gs-icon-symbolizer-editor" >
+      {
+        visibilityField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.visibilityLabel}
+          >
+            <VisibilityField
+              visibility={visibility}
+              onChange={onVisibilityChange}
+            />
+          </Form.Item>
+        )
+      }
       {
         imageField?.visibility === false ? null : (
           <Form.Item

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -61,6 +61,7 @@ import {
   useGeoStylerLocale,
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
+import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
 
 const Panel = Collapse.Panel;
 
@@ -84,6 +85,8 @@ export interface LineEditorComposableProps {
   graphicStrokeField?: InputConfig<GraphicEditorProps['graphic']>;
   // TODO add support for default values in GraphicEditor
   graphicFillField?: InputConfig<GraphicEditorProps['graphic']>;
+  // TODO add support for default values in VisibilityField
+  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
 }
 
 export interface LineEditorInternalProps {
@@ -112,6 +115,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
     perpendicularOffsetField,
     symbolizer,
     widthField,
+    visibilityField,
   } = composed;
 
   const locale = useGeoStylerLocale('LineEditor');
@@ -200,6 +204,14 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
     }
   };
 
+  const onVisibilityChange = (newVisibility: LineSymbolizer['visibility']) => {
+    const symbolizerClone: LineSymbolizer = _cloneDeep(symbolizer);
+    symbolizerClone.visibility = newVisibility;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizerClone);
+    }
+  };
+
   const {
     color,
     width,
@@ -210,13 +222,26 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
     join,
     graphicStroke,
     perpendicularOffset,
-    graphicFill
+    graphicFill,
+    visibility
   } = _cloneDeep(symbolizer);
 
   return (
     <div className="gs-line-symbolizer-editor" >
       <Collapse bordered={false} defaultActiveKey={['1']}>
         <Panel header="General" key="1">
+          {
+            visibilityField?.visibility === false ? null : (
+              <Form.Item
+                label={locale.visibilityLabel}
+              >
+                <VisibilityField
+                  visibility={visibility}
+                  onChange={onVisibilityChange}
+                />
+              </Form.Item>
+            )
+          }
           {
             colorField?.visibility === false ? null : (
               <Form.Item

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -41,10 +41,12 @@ import { Form } from 'antd';
 import _cloneDeep from 'lodash/cloneDeep';
 
 import {
+  InputConfig,
   useGeoStylerComposition,
   useGeoStylerLocale,
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
+import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
 
 export interface MarkEditorComposableProps {
   // TODO add wellKnownNames property that specifies the supported WKNs
@@ -52,6 +54,8 @@ export interface MarkEditorComposableProps {
   wellKnownNameField?: {
     visibility?: boolean;
   };
+  // TODO add support for default values in VisibilityField
+  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
 }
 
 export interface MarkEditorInternalProps {
@@ -69,6 +73,7 @@ export const MarkEditor: React.FC<MarkEditorProps> = (props) => {
   const {
     onSymbolizerChange,
     symbolizer,
+    visibilityField,
     wellKnownNameField
   } = composed;
 
@@ -86,8 +91,28 @@ export const MarkEditor: React.FC<MarkEditorProps> = (props) => {
     }
   };
 
+  const onVisibilityChange = (newVisibility: MarkSymbolizer['visibility']) => {
+    const symbolizerClone: MarkSymbolizer = _cloneDeep(symbolizer);
+    symbolizerClone.visibility = newVisibility;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizerClone);
+    }
+  };
+
   return (
     <div className="gs-mark-symbolizer-editor" >
+      {
+        visibilityField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.visibilityLabel}
+          >
+            <VisibilityField
+              visibility={symbolizer.visibility}
+              onChange={onVisibilityChange}
+            />
+          </Form.Item>
+        )
+      }
       {
         wellKnownNameField?.visibility === false ? null : (
           <Form.Item

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -56,6 +56,7 @@ import {
   useGeoStylerData,
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
+import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
 
 export interface RasterEditorComposableProps {
   opacityField?: InputConfig<OpacityFieldProps['value']>;
@@ -73,6 +74,8 @@ export interface RasterEditorComposableProps {
   colorRamps?: {
     [name: string]: string[];
   };
+  // TODO add support for default values in VisibilityField
+  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
 }
 
 export interface RasterEditorInternalProps {
@@ -100,6 +103,7 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
     onSymbolizerChange,
     opacityField,
     rasterChannelEditor,
+    visibilityField,
     symbolizer
   } = composed;
 
@@ -163,11 +167,20 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
     }
   };
 
+  const onVisibilityChange = (newVisibility: RasterSymbolizer['visibility']) => {
+    const symbolizerClone: RasterSymbolizer = _cloneDeep(symbolizer);
+    symbolizerClone.visibility = newVisibility;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizerClone);
+    }
+  };
+
   const {
     opacity,
     contrastEnhancement,
     colorMap,
-    channelSelection
+    channelSelection,
+    visibility
   } = symbolizer;
 
   let sourceChannelNames: string[];
@@ -184,6 +197,18 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
       {
         showDisplay !== 'symbolizer' ? null : (
           <>
+            {
+              visibilityField?.visibility === false ? null : (
+                <Form.Item
+                  label={locale.visibilityLabel}
+                >
+                  <VisibilityField
+                    visibility={visibility}
+                    onChange={onVisibilityChange}
+                  />
+                </Form.Item>
+              )
+            }
             {
               opacityField?.visibility === false ? null : (
                 <Form.Item

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -58,6 +58,7 @@ import {
 } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 import './TextEditor.less';
+import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
 
 export interface TextEditorComposableProps {
   templateField?: InputConfig<string>;
@@ -73,6 +74,8 @@ export interface TextEditorComposableProps {
   rotateField?: InputConfig<RotateFieldProps['rotate']>;
   haloColorField?: InputConfig<ColorFieldProps['value']>;
   haloWidthField?: InputConfig<WidthFieldProps['value']>;
+  // TODO add support for default values in VisibilityField
+  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
 }
 
 export interface TextEditorInternalProps {
@@ -105,7 +108,8 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
     rotateField,
     sizeField,
     symbolizer,
-    templateField
+    templateField,
+    visibilityField
   } = composed;
 
   const locale = useGeoStylerLocale('TextEditor');
@@ -202,6 +206,14 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
     }
   };
 
+  const onVisibilityChange = (newVisibility: TextSymbolizer['visibility']) => {
+    const symbolizerClone: TextSymbolizer = _cloneDeep(symbolizer);
+    symbolizerClone.visibility = newVisibility;
+    if (onSymbolizerChange) {
+      onSymbolizerChange(symbolizerClone);
+    }
+  };
+
   const clonedSymbolizer = _cloneDeep(symbolizer);
 
   const {
@@ -212,7 +224,8 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
     size,
     rotate,
     haloColor,
-    haloWidth
+    haloWidth,
+    visibility
   } = clonedSymbolizer;
 
   // split the current offset
@@ -226,6 +239,18 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
 
   return (
     <div className="gs-text-symbolizer-editor" >
+      {
+        visibilityField?.visibility === false ? null : (
+          <Form.Item
+            label={locale.visibilityLabel}
+          >
+            <VisibilityField
+              visibility={visibility}
+              onChange={onVisibilityChange}
+            />
+          </Form.Item>
+        )
+      }
       {
         templateField?.visibility === false ? null : (
           <Form.Item

--- a/src/locale/de_DE.ts
+++ b/src/locale/de_DE.ts
@@ -38,7 +38,6 @@ const de_DE: GeoStylerLocale = {
   },
   Editor: {
     kindFieldLabel: 'Art',
-    visibilityFieldLabel: 'Sichtbarkeit',
     unknownSymbolizerText: 'Symbolizer unbekannt!'
   },
   RuleFieldContainer: {
@@ -162,7 +161,8 @@ const de_DE: GeoStylerLocale = {
     outlineColorLabel: 'Randfarbe',
     outlineWidthLabel: 'Randbreite',
     outlineDasharrayLabel: 'Rand-Strichmuster',
-    graphicFillTypeLabel: 'Graphic Fill Type'
+    graphicFillTypeLabel: 'Graphic Fill Type',
+    visibilityLabel: 'Sichtbarkeit'
   },
   IconEditor: {
     iconTooltipLabel: 'Öffne Galerie',
@@ -173,6 +173,7 @@ const de_DE: GeoStylerLocale = {
     opacityLabel: 'Deckkraft',
     rotateLabel: 'Drehung',
     sizeLabel: 'Größe',
+    visibilityLabel: 'Sichtbarkeit'
   },
   LineEditor: {
     capLabel: 'Verschluss',
@@ -185,9 +186,11 @@ const de_DE: GeoStylerLocale = {
     opacityLabel: 'Deckkraft',
     perpendicularOffsetLabel: 'Senkrechter Versatz',
     widthLabel: 'Breite',
+    visibilityLabel: 'Sichtbarkeit'
   },
   MarkEditor: {
-    wellKnownNameFieldLabel: 'Symbol'
+    wellKnownNameFieldLabel: 'Symbol',
+    visibilityLabel: 'Sichtbarkeit'
   },
   TextEditor: {
     fontLabel: 'Schriftart',
@@ -201,7 +204,8 @@ const de_DE: GeoStylerLocale = {
     rotateLabel: 'Drehung',
     haloColorLabel: 'Halofarbe',
     haloWidthLabel: 'Halobreite',
-    attributeNotFound: 'Attribut nicht vorhanden'
+    attributeNotFound: 'Attribut nicht vorhanden',
+    visibilityLabel: 'Sichtbarkeit'
   },
   PropTextEditor: {
     propFieldLabel: 'Feld',
@@ -229,7 +233,8 @@ const de_DE: GeoStylerLocale = {
     gammaValueLabel: 'Gamma',
     colorMapLabel: 'Farbeinstellungen',
     symbolizerLabel: 'Symbolisierung',
-    channelSelectionLabel: 'Bandauswahl'
+    channelSelectionLabel: 'Bandauswahl',
+    visibilityLabel: 'Sichtbarkeit'
   },
   RasterChannelEditor: {
     channelSelectionLabel: 'Kanäle editieren',

--- a/src/locale/en_US.ts
+++ b/src/locale/en_US.ts
@@ -37,7 +37,6 @@ const en_US: GeoStylerLocale = {
   },
   Editor: {
     kindFieldLabel: 'Kind',
-    visibilityFieldLabel: 'Visibility',
     unknownSymbolizerText: 'Symbolizer unknown!'
   },
   RuleFieldContainer: {
@@ -161,7 +160,8 @@ const en_US: GeoStylerLocale = {
     outlineColorLabel: 'Outline-Color',
     outlineWidthLabel: 'Outline-Width',
     outlineDasharrayLabel: 'Outline-Dasharray',
-    graphicFillTypeLabel: 'Graphic Fill Type'
+    graphicFillTypeLabel: 'Graphic Fill Type',
+    visibilityLabel: 'Visibility',
   },
   IconEditor: {
     iconTooltipLabel: 'Open Gallery',
@@ -172,9 +172,11 @@ const en_US: GeoStylerLocale = {
     opacityLabel: 'Opacity',
     rotateLabel: 'Rotation',
     sizeLabel: 'Size',
+    visibilityLabel: 'Visibility'
   },
   MarkEditor: {
-    wellKnownNameFieldLabel: 'Symbol'
+    wellKnownNameFieldLabel: 'Symbol',
+    visibilityLabel: 'Visibility'
   },
   LineEditor: {
     capLabel: 'Cap',
@@ -187,6 +189,7 @@ const en_US: GeoStylerLocale = {
     opacityLabel: 'Opacity',
     perpendicularOffsetLabel: 'Perpendicular Offset',
     widthLabel: 'Width',
+    visibilityLabel: 'Visibility'
   },
   TextEditor: {
     fontLabel: 'Font',
@@ -200,7 +203,8 @@ const en_US: GeoStylerLocale = {
     rotateLabel: 'Rotation',
     haloColorLabel: 'Halo-Color',
     haloWidthLabel: 'Halo-Width',
-    attributeNotFound: 'Field not found'
+    attributeNotFound: 'Field not found',
+    visibilityLabel: 'Visibility'
   },
   PropTextEditor: {
     propFieldLabel: 'Field',
@@ -228,7 +232,8 @@ const en_US: GeoStylerLocale = {
     gammaValueLabel: 'Gamma',
     colorMapLabel: 'Color Map',
     symbolizerLabel: 'Symbolizer',
-    channelSelectionLabel: 'Channel Selection'
+    channelSelectionLabel: 'Channel Selection',
+    visibilityLabel: 'Visibility'
   },
   RasterChannelEditor: {
     channelSelectionLabel: 'Edit Channels',

--- a/src/locale/es_ES.ts
+++ b/src/locale/es_ES.ts
@@ -67,7 +67,8 @@ const es_ES: GeoStylerLocale = {
     gammaValueLabel: 'TODO(es_ES):Gamma',
     colorMapLabel: 'TODO(es_ES):Color Map',
     symbolizerLabel: 'TODO(es_ES):Symbolizer',
-    channelSelectionLabel: 'TODO(es_ES):Channel Selection'
+    channelSelectionLabel: 'TODO(es_ES):Channel Selection',
+    visibilityLabel: 'Visibilidad'
   },
   RasterChannelEditor: {
     channelSelectionLabel: 'TODO(es_ES):Edit Channels',
@@ -99,8 +100,7 @@ const es_ES: GeoStylerLocale = {
   },
   Editor: {
     kindFieldLabel: 'Tipo',
-    unknownSymbolizerText: 'TODO(es_ES):Symbolizer unknown!',
-    visibilityFieldLabel: 'Visibilidad',
+    unknownSymbolizerText: 'TODO(es_ES):Symbolizer unknown!'
   },
   RuleFieldContainer: {
     nameFieldLabel: 'TODO(es_ES):Name',
@@ -223,7 +223,8 @@ const es_ES: GeoStylerLocale = {
     outlineColorLabel: 'Contorno-Color',
     outlineWidthLabel: 'Contorno-Ancho',
     outlineDasharrayLabel: 'Outline-Dasharray',
-    graphicFillTypeLabel: 'Tipo gráfico de relleno'
+    graphicFillTypeLabel: 'Tipo gráfico de relleno',
+    visibilityLabel: 'Visibilidad'
   },
   IconEditor: {
     iconTooltipLabel: 'Abrir galería',
@@ -234,6 +235,7 @@ const es_ES: GeoStylerLocale = {
     opacityLabel: 'Transparencia',
     rotateLabel: 'Rotación',
     sizeLabel: 'Tamaño',
+    visibilityLabel: 'Visibilidad'
   },
   LineEditor: {
     capLabel: 'Cap',
@@ -246,9 +248,11 @@ const es_ES: GeoStylerLocale = {
     opacityLabel: 'Transparencia',
     perpendicularOffsetLabel: 'Perpendicular Offset',
     widthLabel: 'Ancho',
+    visibilityLabel: 'Visibilidad'
   },
   MarkEditor: {
-    wellKnownNameFieldLabel: 'Simbolo'
+    wellKnownNameFieldLabel: 'Simbolo',
+    visibilityLabel: 'Visibilidad'
   },
   TextEditor: {
     fontLabel: 'Fuente',
@@ -262,7 +266,8 @@ const es_ES: GeoStylerLocale = {
     rotateLabel: 'Rotación',
     haloColorLabel: 'Halo-Color',
     haloWidthLabel: 'Halo-Ancho',
-    attributeNotFound: 'Campo no encontrado'
+    attributeNotFound: 'Campo no encontrado',
+    visibilityLabel: 'Visibilidad'
   },
   PropTextEditor: {
     propFieldLabel: 'Campo',

--- a/src/locale/fr_FR.ts
+++ b/src/locale/fr_FR.ts
@@ -38,8 +38,7 @@ const fr_FR: GeoStylerLocale = {
   },
   Editor: {
     kindFieldLabel: 'Type',
-    unknownSymbolizerText: 'Symbolisation inconnue !',
-    visibilityFieldLabel: 'Visibilité'
+    unknownSymbolizerText: 'Symbolisation inconnue !'
   },
   RuleFieldContainer: {
     nameFieldLabel: 'Nom',
@@ -162,7 +161,8 @@ const fr_FR: GeoStylerLocale = {
     outlineColorLabel: 'Couleur du contour',
     outlineWidthLabel: 'Épaisseur du contour',
     outlineDasharrayLabel: 'Tireté ou pointillé du remplissage',
-    graphicFillTypeLabel: 'Motif du remplissage'
+    graphicFillTypeLabel: 'Motif du remplissage',
+    visibilityLabel: 'Visibilité'
   },
   IconEditor: {
     iconTooltipLabel: 'Ouvrir la galerie',
@@ -173,9 +173,11 @@ const fr_FR: GeoStylerLocale = {
     opacityLabel: 'Opacité',
     rotateLabel: 'Rotation',
     sizeLabel: 'Taille',
+    visibilityLabel: 'Visibilité'
   },
   MarkEditor: {
-    wellKnownNameFieldLabel: 'Symbole'
+    wellKnownNameFieldLabel: 'Symbole',
+    visibilityLabel: 'Visibilité'
   },
   LineEditor: {
     capLabel: 'Terminaison',
@@ -188,6 +190,7 @@ const fr_FR: GeoStylerLocale = {
     opacityLabel: 'Opacité',
     perpendicularOffsetLabel: 'Décalage perpendiculaire',
     widthLabel: 'Épaisseur',
+    visibilityLabel: 'Visibilité'
   },
   TextEditor: {
     fontLabel: 'Police',
@@ -201,7 +204,8 @@ const fr_FR: GeoStylerLocale = {
     rotateLabel: 'Rotation',
     haloColorLabel: 'Couleur du halo',
     haloWidthLabel: 'Épaisseur du halo',
-    attributeNotFound: 'Champ nom trouvé'
+    attributeNotFound: 'Champ nom trouvé',
+    visibilityLabel: 'Visibilité'
   },
   PropTextEditor: {
     propFieldLabel: 'Champ',
@@ -229,7 +233,8 @@ const fr_FR: GeoStylerLocale = {
     gammaValueLabel: 'Transparence (Gamma)',
     colorMapLabel: 'Color Map',
     symbolizerLabel: 'Symbolisation',
-    channelSelectionLabel: 'Sélection des canaux'
+    channelSelectionLabel: 'Sélection des canaux',
+    visibilityLabel: 'Visibilité'
   },
   RasterChannelEditor: {
     channelSelectionLabel: 'Modifier les canaux',

--- a/src/locale/hr_HR.ts
+++ b/src/locale/hr_HR.ts
@@ -37,8 +37,7 @@ const hr_HR: GeoStylerLocale = {
   },
   Editor: {
     kindFieldLabel: 'Vrsta',
-    unknownSymbolizerText: 'Simbolizator nepoznat!',
-    visibilityFieldLabel: 'Vidljivost',
+    unknownSymbolizerText: 'Simbolizator nepoznat!'
   },
   RuleFieldContainer: {
     nameFieldLabel: 'Ime',
@@ -161,7 +160,8 @@ const hr_HR: GeoStylerLocale = {
     outlineColorLabel: 'Obrub-Boja',
     outlineWidthLabel: 'Obrub-Širina',
     outlineDasharrayLabel: 'Obrub-Crtkano',
-    graphicFillTypeLabel: 'Vrsta grafičke ispune'
+    graphicFillTypeLabel: 'Vrsta grafičke ispune',
+    visibilityLabel: 'Vidljivost'
   },
   IconEditor: {
     iconTooltipLabel: 'Otvori galeriju',
@@ -172,9 +172,11 @@ const hr_HR: GeoStylerLocale = {
     opacityLabel: 'Prozirnost',
     rotateLabel: 'Rotation',
     sizeLabel: 'Veličina',
+    visibilityLabel: 'Vidljivost'
   },
   MarkEditor: {
-    wellKnownNameFieldLabel: 'Simbol'
+    wellKnownNameFieldLabel: 'Simbol',
+    visibilityLabel: 'Vidljivost'
   },
   LineEditor: {
     capLabel: 'Gornja granica',
@@ -187,6 +189,7 @@ const hr_HR: GeoStylerLocale = {
     opacityLabel: 'Prozirnost',
     perpendicularOffsetLabel: 'Okomiti pomak',
     widthLabel: 'Širina',
+    visibilityLabel: 'Vidljivost'
   },
   TextEditor: {
     fontLabel: 'Font',
@@ -200,7 +203,8 @@ const hr_HR: GeoStylerLocale = {
     rotateLabel: 'Rotacija',
     haloColorLabel: 'Halo-Boja',
     haloWidthLabel: 'Halo-Širina',
-    attributeNotFound: 'Polje nije pronađeno'
+    attributeNotFound: 'Polje nije pronađeno',
+    visibilityLabel: 'Vidljivost'
   },
   PropTextEditor: {
     propFieldLabel: 'Polje',
@@ -228,7 +232,8 @@ const hr_HR: GeoStylerLocale = {
     gammaValueLabel: 'Gamma',
     colorMapLabel: 'Mapa boja',
     symbolizerLabel: 'Simbolizator',
-    channelSelectionLabel: 'Odabir kanala'
+    channelSelectionLabel: 'Odabir kanala',
+    visibilityLabel: 'Vidljivost'
   },
   RasterChannelEditor: {
     channelSelectionLabel: 'Uredi kanale',

--- a/src/locale/locale.ts
+++ b/src/locale/locale.ts
@@ -121,6 +121,7 @@ export default interface GeoStylerLocale {
     outlineWidthLabel: string;
     outlineDasharrayLabel: string;
     graphicFillTypeLabel: string;
+    visibilityLabel: string;
   };
   IconEditor: {
     iconTooltipLabel: string;
@@ -131,6 +132,7 @@ export default interface GeoStylerLocale {
     opacityLabel: string;
     rotateLabel: string;
     sizeLabel: string;
+    visibilityLabel: string;
   };
   LineEditor: {
     colorLabel: string;
@@ -143,9 +145,11 @@ export default interface GeoStylerLocale {
     joinLabel: string;
     graphicStrokeTypeLabel: string;
     graphicFillTypeLabel: string;
+    visibilityLabel: string;
   };
   MarkEditor: {
     wellKnownNameFieldLabel: string;
+    visibilityLabel: string;
   };
   TextEditor: {
     fontLabel: string;
@@ -160,6 +164,7 @@ export default interface GeoStylerLocale {
     haloColorLabel: string;
     haloWidthLabel: string;
     attributeNotFound: string;
+    visibilityLabel: string;
   };
   PropTextEditor: {
     fontLabel: string;
@@ -188,6 +193,7 @@ export default interface GeoStylerLocale {
     colorMapLabel: string;
     symbolizerLabel: string;
     channelSelectionLabel: string;
+    visibilityLabel: string;
   };
   RasterChannelEditor: {
     channelSelectionLabel: string;
@@ -384,7 +390,6 @@ export default interface GeoStylerLocale {
   Editor: {
     kindFieldLabel: string;
     unknownSymbolizerText: string;
-    visibilityFieldLabel: string;
   };
   AttributeCombo: {
     label: string;

--- a/src/locale/zh_CN.ts
+++ b/src/locale/zh_CN.ts
@@ -38,7 +38,6 @@ const zh_CN: GeoStylerLocale = {
   },
   Editor: {
     kindFieldLabel: '类型',
-    visibilityFieldLabel: '可见性',
     unknownSymbolizerText: '未知符号!'
   },
   RuleFieldContainer: {
@@ -162,7 +161,8 @@ const zh_CN: GeoStylerLocale = {
     outlineColorLabel: '轮廓-颜色',
     outlineWidthLabel: '轮廓-宽度',
     outlineDasharrayLabel: '轮廓-点划样式',
-    graphicFillTypeLabel: '填充样式'
+    graphicFillTypeLabel: '填充样式',
+    visibilityLabel: '可见性'
   },
   IconEditor: {
     iconTooltipLabel: '打开图库',
@@ -173,9 +173,11 @@ const zh_CN: GeoStylerLocale = {
     opacityLabel: '不透明度',
     rotateLabel: '旋转',
     sizeLabel: '尺寸',
+    visibilityLabel: '可见性'
   },
   MarkEditor: {
-    wellKnownNameFieldLabel: '符号'
+    wellKnownNameFieldLabel: '符号',
+    visibilityLabel: '可见性'
   },
   LineEditor: {
     colorLabel: '颜色',
@@ -187,7 +189,8 @@ const zh_CN: GeoStylerLocale = {
     capLabel: '端点',
     joinLabel: '角点',
     graphicStrokeTypeLabel: '画笔类型',
-    graphicFillTypeLabel: '填充类型'
+    graphicFillTypeLabel: '填充类型',
+    visibilityLabel: '可见性'
   },
   TextEditor: {
     fontLabel: '字体',
@@ -201,7 +204,8 @@ const zh_CN: GeoStylerLocale = {
     rotateLabel: '旋转',
     haloColorLabel: '光晕颜色',
     haloWidthLabel: '光晕宽度',
-    attributeNotFound: '字段未找到'
+    attributeNotFound: '字段未找到',
+    visibilityLabel: '可见性'
   },
   PropTextEditor: {
     propFieldLabel: '字段',
@@ -229,7 +233,8 @@ const zh_CN: GeoStylerLocale = {
     gammaValueLabel: 'Gamma',
     colorMapLabel: '颜色映射',
     symbolizerLabel: '符号化',
-    channelSelectionLabel: '通道选择'
+    channelSelectionLabel: '通道选择',
+    visibilityLabel: '可见性'
   },
   RasterChannelEditor: {
     channelSelectionLabel: '编辑通道',


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This moves the visibility field to the editors and adds the visibility fields to the geostyler composition context.

`visibility: false`

![image](https://github.com/geostyler/geostyler/assets/12186477/b7300f14-b81f-4d46-af1c-9e70c8463981)

`visibility: true`

![image](https://github.com/geostyler/geostyler/assets/12186477/6e6c881e-7d25-4ec0-bac7-34afd65e082f)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

