### PR TITLE
fix: set vertical layout in BulkEditor

### DIFF
--- a/src/Component/BulkEditor/BulkEditor.less
+++ b/src/Component/BulkEditor/BulkEditor.less
@@ -1,0 +1,7 @@
+.gs-bulkeditor {
+  .gs-symbol-selection {
+    .kind-field {
+      margin-bottom: 12px;
+    }
+  }
+}

--- a/src/Component/BulkEditor/BulkEditor.tsx
+++ b/src/Component/BulkEditor/BulkEditor.tsx
@@ -28,7 +28,7 @@
 
 import React, { useState } from 'react';
 
-import { Form, Space } from 'antd';
+import { Form } from 'antd';
 
 import './BulkEditor.less';
 import { ColorField } from '../Symbolizer/Field/ColorField/ColorField';
@@ -39,6 +39,7 @@ import { Expression, SymbolizerKind, WellKnownName } from 'geostyler-style';
 import { WellKnownNameField } from '../Symbolizer/Field/WellKnownNameField/WellKnownNameField';
 import { ImageField } from '../Symbolizer/Field/ImageField/ImageField';
 import { useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
+import { getFormItemConfig } from '../../Util/FormItemUtil';
 
 export interface BulkEditorProps {
   /** The callback that is triggered, when a style property changed. */
@@ -84,9 +85,12 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
     onStylePropChange('image', newImage);
   };
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div className='gs-bulkeditor'>
       <Form.Item
+        {...itemConfig}
         label={locale.colorLabel}
       >
         <ColorField
@@ -95,6 +99,7 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.radiusLabel}
       >
         <RadiusField
@@ -103,6 +108,7 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.opacityLabel}
       >
         <OpacityField
@@ -111,43 +117,33 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.symbolLabel}
+        className='gs-symbol-selection'
       >
-        <Space.Compact
-          size="small"
-        >
-          <Form.Item
-            noStyle
-          >
-            <KindField
-              kind={kind}
-              onChange={setKind}
-              symbolizerKinds={symbolizerKinds}
+        <KindField
+          kind={kind}
+          onChange={setKind}
+          symbolizerKinds={symbolizerKinds}
+        />
+        {
+          kind === 'Mark' && (
+            <WellKnownNameField
+              wellKnownName={wellKnownName}
+              onChange={onWellKnownNameChange}
             />
-          </Form.Item>
-          <Form.Item
-            noStyle
-          >
-            {
-              kind === 'Mark' && (
-                <WellKnownNameField
-                  wellKnownName={wellKnownName}
-                  onChange={onWellKnownNameChange}
-                />
-              )
-            }
-            {
-              kind === 'Icon' && (
-                // TODO add iconLibraries config and viewhandling
-                <ImageField
-                  value={image}
-                  onChange={onImageChange}
-                  placeholder={locale.imageFieldLabel}
-                />
-              )
-            }
-          </Form.Item>
-        </Space.Compact>
+          )
+        }
+        {
+          kind === 'Icon' && (
+            // TODO add iconLibraries config and viewhandling
+            <ImageField
+              value={image}
+              onChange={onImageChange}
+              placeholder={locale.imageFieldLabel}
+            />
+          )
+        }
       </Form.Item>
     </div>
   );

--- a/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
+++ b/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
@@ -42,6 +42,7 @@ const Option = Select.Option;
 
 import './WfsParserInput.less';
 import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 type WfsVersion = RequestParams['version'];
 
@@ -167,9 +168,12 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
     });
   };
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div className="wfs-parser-input">
       <Form.Item
+        {...itemConfig}
         label={locale.urlLabel}
         validateStatus={validation?.url?.status}
         help={validation?.url?.message}
@@ -183,6 +187,7 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.typeNameLabel}
         validateStatus={validation?.typeName?.status}
         help={validation?.typeName?.message}
@@ -196,6 +201,7 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.versionLabel}
         validateStatus={validation?.version?.status}
         help={validation?.version?.message}
@@ -213,6 +219,7 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
         </Select>
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.srsNameLabel}
         validateStatus={validation?.srsName?.status}
         help={validation?.srsName?.message}
@@ -225,6 +232,7 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.featureIDLabel}
         validateStatus={validation?.featureID?.status}
         help={validation?.featureID?.message}
@@ -237,6 +245,7 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.propertyNameLabel}
         validateStatus={validation?.propertyName?.status}
         help={validation?.propertyName?.message}
@@ -251,6 +260,7 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.maxFeaturesLabel}
         validateStatus={validation?.maxFeatures?.status}
         help={validation?.maxFeatures?.message}
@@ -265,7 +275,9 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
           precision={0}
         />
       </Form.Item>
-      <Form.Item>
+      <Form.Item
+        {...itemConfig}
+      >
         <Button
           className="wfs-parser-submit-button"
           type="primary"

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -33,6 +33,7 @@ import {
   useGeoStylerData,
   useGeoStylerLocale
 } from '../../../context/GeoStylerContext/GeoStylerContext';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 const Option = Select.Option;
 
@@ -110,10 +111,12 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
   }
 
   const helpTxt = validateStatus !== 'success' ? locale.help : null;
+  const itemConfig = getFormItemConfig();
 
   return (
     <div className="gs-attribute-combo">
       <Form.Item
+        {...itemConfig}
         label={locale.label}
         colon={false}
         validateStatus={validateStatus}

--- a/src/Component/RuleFieldContainer/RuleFieldContainer.tsx
+++ b/src/Component/RuleFieldContainer/RuleFieldContainer.tsx
@@ -40,6 +40,7 @@ import { Renderer } from '../Renderer/Renderer/Renderer';
 import { Expression, Symbolizer } from 'geostyler-style';
 import { useGeoStylerComposition, useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
 import { RuleComposableProps } from '../RuleCard/RuleCard';
+import { getFormItemConfig } from '../../Util/FormItemUtil';
 
 export type RuleFieldContainerComposableProps = Pick<
   RuleComposableProps, 'maxScaleField' | 'minScaleField' | 'nameField'
@@ -83,43 +84,43 @@ export const RuleFieldContainer: React.FC<RuleFieldContainerProps> = (props) => 
   } = composed;
 
   const locale = useGeoStylerLocale('RuleFieldContainer');
+  const itemConfig = getFormItemConfig();
 
   return (
     <FieldContainer className="gs-rule-field-container">
       <div className='gs-rule-field-container-header'>
-        <Form
-          layout='vertical'
-        >
-          {
-            nameField?.visibility === false ? null : (
-              <Form.Item
-                label={locale.nameFieldLabel}
-              >
-                <NameField
-                  value={name}
-                  onChange={onNameChange}
-                  placeholder={locale.nameFieldPlaceholder}
-                />
-              </Form.Item>
-            )
-          }
-          {
-            minScaleField?.visibility === false ? null : (
-              <MinScaleDenominator
-                value={minScale}
-                onChange={onMinScaleChange}
+        {
+          nameField?.visibility === false ? null : (
+            <Form.Item
+              {...itemConfig}
+              label={locale.nameFieldLabel}
+            >
+              <NameField
+                value={name}
+                onChange={onNameChange}
+                placeholder={locale.nameFieldPlaceholder}
               />
-            )
-          }
-          {
-            maxScaleField?.visibility === false ? null : (
-              <MaxScaleDenominator
-                value={maxScale}
-                onChange={onMaxScaleChange}
-              />
-            )
-          }
-        </Form>
+            </Form.Item>
+          )
+        }
+        {
+          minScaleField?.visibility === false ? null : (
+            <MinScaleDenominator
+              value={minScale}
+              onChange={onMinScaleChange}
+              {...itemConfig}
+            />
+          )
+        }
+        {
+          maxScaleField?.visibility === false ? null : (
+            <MaxScaleDenominator
+              value={maxScale}
+              onChange={onMaxScaleChange}
+              {...itemConfig}
+            />
+          )
+        }
       </div>
       <Divider type="vertical" />
       <Renderer symbolizers={symbolizers} />

--- a/src/Component/RuleGenerator/RuleGenerator.tsx
+++ b/src/Component/RuleGenerator/RuleGenerator.tsx
@@ -50,6 +50,7 @@ import {
   useGeoStylerData,
   useGeoStylerLocale
 } from '../../context/GeoStylerContext/GeoStylerContext';
+import { getFormItemConfig } from '../../Util/FormItemUtil';
 
 export type LevelOfMeasurement = 'nominal' | 'ordinal' | 'cardinal';
 
@@ -171,146 +172,157 @@ export const RuleGenerator: React.FC<RuleGeneratorProps> = (props) => {
   }
 
   const previewColors = RuleGeneratorUtil.generateColors(colorRamps[colorRamp], numberOfRules, colorSpace);
+  const itemConfig = getFormItemConfig();
 
   return (
     <div className="gs-rule-generator" >
-      <Form layout="vertical">
-        <AttributeCombo
-          value={attributeName}
-          onAttributeChange={onAttributeChange}
-          validateStatus={attributeName ? 'success' : 'warning'}
-        />
-        <Form.Item
-          label={locale.levelOfMeasurement}
+      <AttributeCombo
+        value={attributeName}
+        onAttributeChange={onAttributeChange}
+        validateStatus={attributeName ? 'success' : 'warning'}
+      />
+      <Form.Item
+        {...itemConfig}
+        label={locale.levelOfMeasurement}
+      >
+        <Radio.Group
+          onChange={onLevelOfMeasurementChange}
+          value={levelOfMeasurement}
+          buttonStyle="solid"
         >
-          <Radio.Group
-            onChange={onLevelOfMeasurementChange}
-            value={levelOfMeasurement}
-            buttonStyle="solid"
+          <Radio.Button
+            value="nominal"
           >
-            <Radio.Button
-              value="nominal"
-            >
-              {locale.nominal}
-            </Radio.Button>
-            <Radio.Button
-              value="cardinal"
-              disabled={attributeType === 'string'}
-            >
-              {locale.cardinal}
-            </Radio.Button>
-          </Radio.Group>
-        </Form.Item>
-        {
-          levelOfMeasurement !== 'cardinal' ? null :
-            <Form.Item
-              label={locale.classification}
-            >
-              <ClassificationCombo
-                classification={classificationMethod}
-                onChange={setClassificationMethod}
+            {locale.nominal}
+          </Radio.Button>
+          <Radio.Button
+            value="cardinal"
+            disabled={attributeType === 'string'}
+          >
+            {locale.cardinal}
+          </Radio.Button>
+        </Radio.Group>
+      </Form.Item>
+      {
+        levelOfMeasurement !== 'cardinal' ? null :
+          <Form.Item
+            {...itemConfig}
+            label={locale.classification}
+          >
+            <ClassificationCombo
+              classification={classificationMethod}
+              onChange={setClassificationMethod}
+            />
+          </Form.Item>
+      }
+      <Form.Item
+        {...itemConfig}
+        label={locale.numberOfRules}
+        validateStatus={
+          classificationMethod === 'kmeans'
+            ? 'warning'
+            : numberOfRules < minNrClasses
+              ? 'error'
+              : undefined
+        }
+        help={classificationMethod === 'kmeans'
+          ? locale.numberOfRulesViaKmeans
+          : numberOfRules < minNrClasses
+            // eslint-disable-next-line max-len
+            ? `${locale.colorRampMinClassesWarningPre} ${minNrClasses} ${locale.colorRampMinClassesWarningPost}`
+            : undefined
+        }
+      >
+        <div>
+          <InputNumber<number>
+            min={minNrClasses}
+            max={100}
+            value={numberOfRules}
+            onChange={setNumberOfRules}
+          />
+          {
+            levelOfMeasurement === 'nominal' && distinctValues.length > 0 &&
+            <Tooltip title={locale.allDistinctValues}>
+              <Button
+                className="all-distinct-values-button"
+                icon={<PlusSquareOutlined />}
+                onClick={onAllDistinctClicked}
               />
-            </Form.Item>
+            </Tooltip>
+          }
+        </div>
+      </Form.Item>
+      <fieldset>
+        <legend>{locale.symbolizer}</legend>
+        <Form.Item
+          {...itemConfig}
+        >
+          <KindField
+            kind={symbolizerKind}
+            symbolizerKinds={[
+              'Fill',
+              'Mark',
+              'Line'
+            ]}
+            onChange={onSymbolizerKindChange}
+          />
+        </Form.Item>
+        {symbolizerKind !== 'Mark' ? null :
+          <Form.Item
+            {...itemConfig}
+          >
+            <WellKnownNameField
+              wellKnownName={wellKnownName}
+              onChange={setWellKnownName}
+            />
+          </Form.Item>
         }
         <Form.Item
-          label={locale.numberOfRules}
-          validateStatus={
-            classificationMethod === 'kmeans'
-              ? 'warning'
-              : numberOfRules < minNrClasses
-                ? 'error'
-                : undefined
-          }
-          help={classificationMethod === 'kmeans'
-            ? locale.numberOfRulesViaKmeans
-            : numberOfRules < minNrClasses
-              // eslint-disable-next-line max-len
-              ? `${locale.colorRampMinClassesWarningPre} ${minNrClasses} ${locale.colorRampMinClassesWarningPost}`
-              : undefined
-          }
+          {...itemConfig}
+          label={locale.colorRamp}
+          help={numberOfRules < minNrClasses ?
+            `${locale.colorRampMinClassesWarningPre} ${minNrClasses} ${locale.colorRampMinClassesWarningPost}`
+            : undefined}
         >
-          <div>
-            <InputNumber<number>
-              min={minNrClasses}
-              max={100}
-              value={numberOfRules}
-              onChange={setNumberOfRules}
-            />
-            {
-              levelOfMeasurement === 'nominal' && distinctValues.length > 0 &&
-              <Tooltip title={locale.allDistinctValues}>
-                <Button
-                  className="all-distinct-values-button"
-                  icon={<PlusSquareOutlined />}
-                  onClick={onAllDistinctClicked}
-                />
-              </Tooltip>
-            }
-          </div>
+          <ColorRampCombo
+            colorRamps={colorRamps}
+            colorRamp={colorRamp}
+            onChange={setColorRamp}
+          />
         </Form.Item>
-        <fieldset>
-          <legend>{locale.symbolizer}</legend>
-          <Form.Item>
-            <KindField
-              kind={symbolizerKind}
-              symbolizerKinds={[
-                'Fill',
-                'Mark',
-                'Line'
-              ]}
-              onChange={onSymbolizerKindChange}
-            />
-          </Form.Item>
-          {symbolizerKind !== 'Mark' ? null :
-            <Form.Item>
-              <WellKnownNameField
-                wellKnownName={wellKnownName}
-                onChange={setWellKnownName}
-              />
-            </Form.Item>
-          }
+        {colorSpaces.length > 0 ?
           <Form.Item
-            label={locale.colorRamp}
-            help={numberOfRules < minNrClasses ?
-              `${locale.colorRampMinClassesWarningPre} ${minNrClasses} ${locale.colorRampMinClassesWarningPost}`
-              : undefined}
+            {...itemConfig}
+            label={locale.colorSpace}
           >
-            <ColorRampCombo
-              colorRamps={colorRamps}
-              colorRamp={colorRamp}
-              onChange={setColorRamp}
+            <ColorSpaceCombo
+              colorSpace={colorSpace}
+              colorSpaces={colorSpaces}
+              onChange={setColorSpace}
             />
           </Form.Item>
-          {colorSpaces.length > 0 ?
-            <Form.Item
-              label={locale.colorSpace}
-            >
-              <ColorSpaceCombo
-                colorSpace={colorSpace}
-                colorSpaces={colorSpaces}
-                onChange={setColorSpace}
-              />
-            </Form.Item>
-            : null}
-          <Form.Item
-            label={locale.preview}
-          >
-            <ColorsPreview
-              colors={previewColors}
-            />
-          </Form.Item>
-        </fieldset>
-        <Form.Item>
-          <Button
-            className="gs-rule-generator-submit-button"
-            type="primary"
-            onClick={onGenerateClick}
-            disabled={numberOfRules < minNrClasses || !attributeName}
-          >
-            {locale.generateButtonText}
-          </Button>
+          : null}
+        <Form.Item
+          {...itemConfig}
+          label={locale.preview}
+        >
+          <ColorsPreview
+            colors={previewColors}
+          />
         </Form.Item>
-      </Form>
+      </fieldset>
+      <Form.Item
+        {...itemConfig}
+      >
+        <Button
+          className="gs-rule-generator-submit-button"
+          type="primary"
+          onClick={onGenerateClick}
+          disabled={numberOfRules < minNrClasses || !attributeName}
+        >
+          {locale.generateButtonText}
+        </Button>
+      </Form.Item>
     </div>
   );
 };

--- a/src/Component/StyleFieldContainer/StyleFieldContainer.tsx
+++ b/src/Component/StyleFieldContainer/StyleFieldContainer.tsx
@@ -35,6 +35,7 @@ import { Form } from 'antd';
 import { FieldContainer } from '../FieldContainer/FieldContainer';
 import { useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
 import { NameField } from '../NameField/NameField';
+import { getFormItemConfig } from '../../Util/FormItemUtil';
 
 export interface StyleFieldContainerProps {
   onNameChange?: (name: string) => void;
@@ -51,31 +52,30 @@ export const StyleFieldContainer: React.FC<StyleFieldContainerProps> = ({
 }) => {
 
   const locale = useGeoStylerLocale('StyleFieldContainer');
+  const itemConfig = getFormItemConfig();
 
   return (
     <FieldContainer className="gs-style-field-container">
-      <Form
-        layout='vertical'
+      <Form.Item
+        {...itemConfig}
+        label={locale.nameFieldLabel}
       >
-        <Form.Item
-          label={locale.nameFieldLabel}
-        >
-          <NameField
-            value={name}
-            onChange={onNameChange}
-            placeholder={locale.nameFieldPlaceholder}
-          />
-        </Form.Item>
-        <Form.Item
-          label={locale.titleFieldLabel}
-        >
-          <NameField
-            value={title}
-            onChange={onTitleChange}
-            placeholder={locale.titleFieldPlaceholder}
-          />
-        </Form.Item>
-      </Form>
+        <NameField
+          value={name}
+          onChange={onNameChange}
+          placeholder={locale.nameFieldPlaceholder}
+        />
+      </Form.Item>
+      <Form.Item
+        {...itemConfig}
+        label={locale.titleFieldLabel}
+      >
+        <NameField
+          value={title}
+          onChange={onTitleChange}
+          placeholder={locale.titleFieldPlaceholder}
+        />
+      </Form.Item>
     </FieldContainer>
   );
 

--- a/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
+++ b/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
@@ -56,6 +56,7 @@ import {
   useGeoStylerLocale
 } from '../../../context/GeoStylerContext/GeoStylerContext';
 import FunctionUtil from '../../../Util/FunctionUtil';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 export interface ColorMapEntryRecord extends ColorMapEntry {
   key: number;
@@ -306,16 +307,20 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = (props) => {
     ? FunctionUtil.evaluateFunction(colorMap?.type) as ColorMapType
     : colorMap?.type;
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div className="gs-colormap-symbolizer-editor" >
       <div className="gs-colormap-header-row">
         <Form.Item
+          {...itemConfig}
         >
           <span>{locale.titleLabel}</span>
         </Form.Item>
         {
           colorMapTypeField?.visibility === false ? null : (
             <Form.Item
+              {...itemConfig}
               label={locale.typeLabel}
             >
               <ColorMapTypeField
@@ -328,6 +333,7 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = (props) => {
         {
           nrOfClassesField?.visibility === false ? null : (
             <Form.Item
+              {...itemConfig}
               label={locale.nrOfClassesLabel}
             >
               <InputNumber
@@ -344,6 +350,7 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = (props) => {
         {
           colorRampComboField?.visibility === false ? null : (
             <Form.Item
+              {...itemConfig}
               label={locale.colorRampLabel}
             >
               <ColorRampCombo
@@ -357,6 +364,7 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = (props) => {
         {
           extendedField?.visibility === false ? null : (
             <Form.Item
+              {...itemConfig}
               label={locale.extendedLabel}
             >
               <ExtendedField

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -55,6 +55,7 @@ import {
   useGeoStylerComposition,
   useGeoStylerLocale
 } from '../../../context/GeoStylerContext/GeoStylerContext';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 export interface EditorComposableProps {
   markEditor?: {
@@ -183,22 +184,21 @@ export const Editor: React.FC<EditorProps> = (props) => {
       return true;
     });
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div className="gs-symbolizer-editor" >
-      <Form
-        layout='vertical'
+      <Form.Item
+        {...itemConfig}
+        label={locale.kindFieldLabel}
       >
-        <Form.Item
-          label={locale.kindFieldLabel}
-        >
-          <KindField
-            kind={symbolizer.kind}
-            onChange={onKindFieldChange}
-            symbolizerKinds={filteredSymbolizerKinds}
-          />
-        </Form.Item>
-        {getUiForSymbolizer()}
-      </Form>
+        <KindField
+          kind={symbolizer.kind}
+          onChange={onKindFieldChange}
+          symbolizerKinds={filteredSymbolizerKinds}
+        />
+      </Form.Item>
+      {getUiForSymbolizer()}
     </div>
   );
 };

--- a/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
+++ b/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
@@ -44,6 +44,7 @@ import {
   useGeoStylerComposition,
   useGeoStylerLocale
 } from '../../../../context/GeoStylerContext/GeoStylerContext';
+import { getFormItemConfig } from '../../../../Util/FormItemUtil';
 
 export interface ChannelFieldComposableProps {
   sourceChannelNameField?: {
@@ -130,11 +131,14 @@ export const ChannelField: React.FC<ChannelFieldProps> = (props) => {
   const contrastEnhancementType = _get(channel, 'contrastEnhancement.enhancementType');
   const gamma = _get(channel, 'contrastEnhancement.gammaValue');
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div>
       {
         sourceChannelNameField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.sourceChannelNameLabel}
           >
             <SourceChannelNameField
@@ -148,6 +152,7 @@ export const ChannelField: React.FC<ChannelFieldProps> = (props) => {
       {
         contrastEnhancementField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.contrastEnhancementTypeLabel}
           >
             <ContrastEnhancementField
@@ -161,6 +166,7 @@ export const ChannelField: React.FC<ChannelFieldProps> = (props) => {
       {
         gammaValueField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.gammaValueLabel}
           >
             <GammaField

--- a/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.tsx
+++ b/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.tsx
@@ -38,6 +38,7 @@ import { ChannelSelection, GrayChannel } from 'geostyler-style';
 import _get from 'lodash/get';
 import _cloneDeep from 'lodash/cloneDeep';
 import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStylerContext';
+import { getFormItemConfig } from '../../../../Util/FormItemUtil';
 
 export interface GrayChannelFieldProps {
   sourceChannelNames?: string[];
@@ -74,9 +75,12 @@ export const GrayChannelField: React.FC<GrayChannelFieldProps> = ({
     }
   };
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div>
       <Form.Item
+        {...itemConfig}
         label={locale.grayLabel}
       >
         <SourceChannelNameField

--- a/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.tsx
+++ b/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.tsx
@@ -38,6 +38,7 @@ import { ChannelSelection, RGBChannel } from 'geostyler-style';
 import _get from 'lodash/get';
 import _cloneDeep from 'lodash/cloneDeep';
 import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStylerContext';
+import { getFormItemConfig } from '../../../../Util/FormItemUtil';
 
 export interface RgbChannelFieldProps {
   sourceChannelNames?: string[];
@@ -113,9 +114,12 @@ export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
     }
   };
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div>
       <Form.Item
+        {...itemConfig}
         label={locale.redLabel}
       >
         <SourceChannelNameField
@@ -125,6 +129,7 @@ export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.greenLabel}
       >
         <SourceChannelNameField
@@ -134,6 +139,7 @@ export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.blueLabel}
       >
         <SourceChannelNameField

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -58,6 +58,7 @@ import {
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
 import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 const Panel = Collapse.Panel;
 
@@ -192,6 +193,8 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
     visibility
   } = symbolizer;
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div className="gs-fill-symbolizer-editor" >
       <Collapse bordered={false} defaultActiveKey={['1']}>
@@ -199,6 +202,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
           {
             visibilityField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.visibilityLabel}
               >
                 <VisibilityField
@@ -211,6 +215,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
           {
             fillColorField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.fillColorLabel}
                 {...getFormItemSupportProps('color')}
               >
@@ -225,6 +230,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
           {
             fillOpacityField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.fillOpacityLabel}
                 {...getFormItemSupportProps('fillOpacity')}
               >
@@ -239,6 +245,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
           {
             opacityField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.opacityLabel}
                 {...getFormItemSupportProps('opacity')}
               >
@@ -253,6 +260,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
           {
             outlineOpacityField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.outlineOpacityLabel}
                 {...getFormItemSupportProps('outlineOpacity')}
               >
@@ -267,6 +275,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
           {
             outlineColorField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.outlineColorLabel}
                 {...getFormItemSupportProps('outlineColor')}
               >
@@ -281,6 +290,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
           {
             outlineWidthField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.outlineWidthLabel}
                 {...getFormItemSupportProps('outlineWidth')}
               >
@@ -295,6 +305,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
           {
             outlineDasharrayField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.outlineDasharrayLabel}
                 {...getFormItemSupportProps('outlineDasharray')}
               >

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -41,6 +41,7 @@ import { IconLibrary } from '../IconSelector/IconSelector';
 import { Form } from 'antd';
 
 import _get from 'lodash/get';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 export interface GraphicEditorDefaultProps {
   /** Label being used on TypeField */
@@ -107,9 +108,12 @@ export const GraphicEditor: React.FC<GraphicEditorProps> = ({
     }
   };
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div>
       <Form.Item
+        {...itemConfig}
         label={graphicTypeFieldLabel}
       >
         <GraphicTypeField

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -50,6 +50,7 @@ import {
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
 import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 export interface IconEditorComposableProps {
   // TODO add support for default values in ImageField
@@ -174,12 +175,14 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
   } = symbolizer;
 
   const imageSrc = !_isEmpty(image) ? image : locale.imagePlaceholder;
+  const itemConfig = getFormItemConfig();
 
   return (
     <div className="gs-icon-symbolizer-editor" >
       {
         visibilityField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.visibilityLabel}
           >
             <VisibilityField
@@ -192,6 +195,7 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
       {
         imageField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.imageLabel}
             {...getFormItemSupportProps('image')}
           >
@@ -207,6 +211,7 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
       {
         sizeField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.sizeLabel}
             {...getFormItemSupportProps('size')}
           >
@@ -220,6 +225,7 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
       {
         offsetXField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.offsetXLabel}
             {...getFormItemSupportProps('offset')}
           >
@@ -234,6 +240,7 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
       {
         offsetYField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.offsetYLabel}
             {...getFormItemSupportProps('offset')}
           >
@@ -248,6 +255,7 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
       {
         rotateField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.rotateLabel}
             {...getFormItemSupportProps('rotate')}
           >
@@ -262,6 +270,7 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
       {
         opacityField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.opacityLabel}
             {...getFormItemSupportProps('opacity')}
           >

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -62,6 +62,7 @@ import {
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
 import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 const Panel = Collapse.Panel;
 
@@ -226,6 +227,8 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
     visibility
   } = _cloneDeep(symbolizer);
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div className="gs-line-symbolizer-editor" >
       <Collapse bordered={false} defaultActiveKey={['1']}>
@@ -233,6 +236,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
           {
             visibilityField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.visibilityLabel}
               >
                 <VisibilityField
@@ -245,6 +249,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
           {
             colorField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.colorLabel}
                 {...getFormItemSupportProps('color')}
               >
@@ -259,6 +264,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
           {
             widthField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.widthLabel}
                 {...getFormItemSupportProps('width')}
               >
@@ -273,6 +279,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
           {
             perpendicularOffsetField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.perpendicularOffsetLabel}
                 {...getFormItemSupportProps('perpendicularOffset')}
               >
@@ -287,6 +294,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
           {
             opacityField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.opacityLabel}
                 {...getFormItemSupportProps('opacity')}
               >
@@ -301,6 +309,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
           {
             lineDashField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.dashLabel}
                 {...getFormItemSupportProps('dasharray')}
               >
@@ -314,6 +323,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
           {
             dashOffsetField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.dashOffsetLabel}
                 {...getFormItemSupportProps('dashOffset')}
               >
@@ -331,6 +341,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
           {
             capField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.capLabel}
                 {...getFormItemSupportProps('cap')}
               >
@@ -344,6 +355,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
           {
             joinField?.visibility === false ? null : (
               <Form.Item
+                {...itemConfig}
                 label={locale.joinLabel}
                 {...getFormItemSupportProps('join')}
               >

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -47,6 +47,7 @@ import {
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
 import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 export interface MarkEditorComposableProps {
   // TODO add wellKnownNames property that specifies the supported WKNs
@@ -99,11 +100,14 @@ export const MarkEditor: React.FC<MarkEditorProps> = (props) => {
     }
   };
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div className="gs-mark-symbolizer-editor" >
       {
         visibilityField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.visibilityLabel}
           >
             <VisibilityField
@@ -116,6 +120,7 @@ export const MarkEditor: React.FC<MarkEditorProps> = (props) => {
       {
         wellKnownNameField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.wellKnownNameFieldLabel}
             {...getFormItemSupportProps('wellKnownName')}
           >

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
@@ -48,6 +48,7 @@ import {WidthField} from '../Field/WidthField/WidthField';
 import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 import './PropTextEditor.less';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 export interface PropTextEditorProps {
   symbolizer: TextSymbolizer;
@@ -181,9 +182,12 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
     offsetY = offset[1];
   }
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div className="gs-text-symbolizer-prop-editor" >
       <Form.Item
+        {...itemConfig}
         label={locale.propFieldLabel}
       >
         <AttributeCombo
@@ -192,6 +196,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.colorLabel}
       >
         <ColorField
@@ -200,6 +205,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.fontLabel}
       >
         <FontPicker
@@ -208,6 +214,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.opacityLabel}
       >
         <OpacityField
@@ -216,6 +223,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.sizeLabel}
       >
         <WidthField
@@ -224,6 +232,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.offsetXLabel}
       >
         <OffsetField
@@ -232,6 +241,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.offsetYLabel}
       >
         <OffsetField
@@ -240,6 +250,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.rotateLabel}
       >
         <RotateField
@@ -248,6 +259,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.haloColorLabel}
       >
         <ColorField
@@ -256,6 +268,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         />
       </Form.Item>
       <Form.Item
+        {...itemConfig}
         label={locale.haloWidthLabel}
       >
         <WidthField

--- a/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
+++ b/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
@@ -52,6 +52,7 @@ import {
   useGeoStylerComposition,
   useGeoStylerLocale
 } from '../../../context/GeoStylerContext/GeoStylerContext';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 export interface RasterChannelEditorComposableProps {
   channelSelectionField?: InputConfig<'rgb' | 'gray'>;
@@ -144,15 +145,19 @@ export const RasterChannelEditor: React.FC<RasterChannelEditorProps> = (props) =
     grayChannel = channelSelection.grayChannel;
   }
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div>
       <Form.Item
+        {...itemConfig}
       >
         <span>{locale.titleLabel}</span>
       </Form.Item>
       {
         channelSelectionField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.channelSelectionLabel}
           >
             <Select

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -57,6 +57,7 @@ import {
   useGeoStylerUnsupportedProperties
 } from '../../../context/GeoStylerContext/GeoStylerContext';
 import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 export interface RasterEditorComposableProps {
   opacityField?: InputConfig<OpacityFieldProps['value']>;
@@ -192,6 +193,8 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
     wrapperCol: { span: 24 }
   };
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div className="gs-raster-symbolizer-editor" >
       {
@@ -200,6 +203,7 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
             {
               visibilityField?.visibility === false ? null : (
                 <Form.Item
+                  {...itemConfig}
                   label={locale.visibilityLabel}
                 >
                   <VisibilityField
@@ -212,6 +216,7 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
             {
               opacityField?.visibility === false ? null : (
                 <Form.Item
+                  {...itemConfig}
                   label={locale.opacityLabel}
                   {...getFormItemSupportProps('opacity')}
                 >
@@ -228,6 +233,7 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
             {
               contrastEnhancementField?.visibility === false ? null : (
                 <Form.Item
+                  {...itemConfig}
                   label={locale.contrastEnhancementLabel}
                   {...getFormItemSupportProps('contrastEnhancement')}
                 >
@@ -241,6 +247,7 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
             {
               gammaValueField?.visibility === false ? null : (
                 <Form.Item
+                  {...itemConfig}
                   label={locale.gammaValueLabel}
                   {...getFormItemSupportProps('contrastEnhancement')}
                 >
@@ -255,6 +262,7 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
             {
               colorMapEditor?.visibility === false ? null : (
                 <Form.Item
+                  {...itemConfig}
                   className="gs-raster-editor-view-toggle"
                   {...toggleViewButtonLayout}
                 >
@@ -267,6 +275,7 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
             {
               rasterChannelEditor?.visibility === false ? null : (
                 <Form.Item
+                  {...itemConfig}
                   className="gs-raster-editor-view-toggle"
                   {...toggleViewButtonLayout}
                 >

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -59,6 +59,7 @@ import {
 
 import './TextEditor.less';
 import VisibilityField, { VisibilityFieldProps } from '../Field/VisibilityField/VisibilityField';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 export interface TextEditorComposableProps {
   templateField?: InputConfig<string>;
@@ -236,12 +237,14 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
     offsetY = offset[1] as number;
   }
   const properties = data && data.schema ? Object.keys(data.schema.properties) : [];
+  const itemConfig = getFormItemConfig();
 
   return (
     <div className="gs-text-symbolizer-editor" >
       {
         visibilityField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.visibilityLabel}
           >
             <VisibilityField
@@ -254,6 +257,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
       {
         templateField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.templateFieldLabel}
             {...getFormItemSupportProps('label')}
           >
@@ -277,6 +281,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
       {
         colorField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.colorLabel}
             {...getFormItemSupportProps('color')}
           >
@@ -291,6 +296,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
       {
         fontField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.fontLabel}
             {...getFormItemSupportProps('font')}
           >
@@ -304,6 +310,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
       {
         opacityField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.opacityLabel}
             {...getFormItemSupportProps('opacity')}
           >
@@ -318,6 +325,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
       {
         sizeField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.sizeLabel}
             {...getFormItemSupportProps('size')}
           >
@@ -332,6 +340,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
       {
         offsetXField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.offsetXLabel}
             {...getFormItemSupportProps('offset')}
           >
@@ -346,6 +355,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
       {
         offsetYField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.offsetYLabel}
             {...getFormItemSupportProps('offset')}
           >
@@ -360,6 +370,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
       {
         rotateField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.rotateLabel}
             {...getFormItemSupportProps('rotate')}
           >
@@ -374,6 +385,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
       {
         haloColorField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.haloColorLabel}
             {...getFormItemSupportProps('haloColor')}
           >
@@ -388,6 +400,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
       {
         haloWidthField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.haloWidthLabel}
             {...getFormItemSupportProps('haloWidth')}
           >

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -47,6 +47,7 @@ import {
   useGeoStylerComposition,
   useGeoStylerLocale
 } from '../../../context/GeoStylerContext/GeoStylerContext';
+import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 export interface WellKnownNameEditorComposableProps {
   radiusField?: InputConfig<RadiusFieldProps['radius']>;
@@ -190,11 +191,14 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
     offset
   } = symbolizer;
 
+  const itemConfig = getFormItemConfig();
+
   return (
     <div>
       {
         radiusField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.radiusLabel}
           >
             <RadiusField
@@ -208,6 +212,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
       {
         offsetXField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.offsetXLabel}
           >
             <OffsetField
@@ -221,6 +226,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
       {
         offsetYField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.offsetYLabel}
           >
             <OffsetField
@@ -234,6 +240,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
       {
         fillColorField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.fillColorLabel}
           >
             <ColorField
@@ -247,6 +254,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
       {
         opacityField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.opacityLabel}
           >
             <OpacityField
@@ -260,6 +268,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
       {
         fillOpacityField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.fillOpacityLabel}
           >
             <OpacityField
@@ -273,6 +282,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
       {
         strokeColorField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.strokeColorLabel}
           >
             <ColorField
@@ -286,6 +296,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
       {
         strokeWidthField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.strokeWidthLabel}
           >
             <WidthField
@@ -299,6 +310,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
       {
         strokeOpacityField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.strokeOpacityLabel}
           >
             <OpacityField
@@ -312,6 +324,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
       {
         rotateField?.visibility === false ? null : (
           <Form.Item
+            {...itemConfig}
             label={locale.rotateLabel}
           >
             <RotateField

--- a/src/Util/FormItemUtil.spec.ts
+++ b/src/Util/FormItemUtil.spec.ts
@@ -1,0 +1,38 @@
+/* Released under the BSD 2-Clause License
+ *
+ * Copyright © 2023-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { getFormItemConfig } from './FormItemUtil';
+
+describe('FormItemUtil', () => {
+  describe('getFormItemConfig', () => {
+    it('returns the form item config', () => {
+      const itemConfig = getFormItemConfig();
+      expect(itemConfig).toBeDefined();
+    });
+  });
+});

--- a/src/Util/FormItemUtil.ts
+++ b/src/Util/FormItemUtil.ts
@@ -1,0 +1,40 @@
+/* Released under the BSD 2-Clause License
+ *
+ * Copyright © 2023-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * Get the config for form items.
+ * @returns The form item config.
+ */
+export const getFormItemConfig = () => {
+  return {
+    colon: false,
+    labelCol: {
+      span: 24
+    }
+  };
+};


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This wraps the form items in `<BulkEditor>` into a `<Form>` and sets its layout to `'vertical'` so that the form layout will be consistent with all the other forms. It also adjusts the layout of the symbol selection.

![image](https://github.com/geostyler/geostyler/assets/12186477/7524da6b-9ed8-425a-93d6-87829df4b60a)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

