### PR TITLE
fix: code editor onchange string to mapbox style

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -69,6 +69,7 @@ import QGISStyleParser from 'geostyler-qgis-parser';
 import MapboxStyleParser from 'geostyler-mapbox-parser';
 import { useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
 import { isString } from 'lodash';
+import { MbStyle } from 'geostyler-mapbox-parser';
 
 // non default props
 export interface CodeEditorProps {
@@ -222,7 +223,12 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
     try {
       let parsedStyle;
       if (activeParser) {
-        const result = await activeParser.readStyle(v);
+        let result;
+        if (activeParser instanceof MapboxStyleParser) {
+          result = await activeParser.readStyle(JSON.parse(v) as MbStyle);
+        } else {
+          result = await activeParser.readStyle(v);
+        }
         setReadStyleResult(result);
         onStyleChange(result.output);
       } else {


### PR DESCRIPTION
## Description
Fixes reading mapbox style instead of string

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

