### PR TITLE
Fix color picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "15.0.0-beta.5",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@ant-design/icons": "^5.3.7",
+        "@ant-design/icons": "^5.5.1",
         "@babel/polyfill": "^7.12.1",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "build": "npm run build-package && npm run build-styleguide"
   },
   "dependencies": {
-    "@ant-design/icons": "^5.3.7",
+    "@ant-design/icons": "^5.5.1",
     "@babel/polyfill": "^7.12.1",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.example.md
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.example.md
@@ -36,12 +36,11 @@ import { ColorField } from 'geostyler';
 
 const ColorFieldExample = () => {
 
-  const [value, setValue] = useState();
+  const [value, setValue] = useState("#013370");
 
   return (
     <ColorField
       value={value}
-      defaultValue="#013370"
       label="Color"
       onChange={setValue}
     />

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.less
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.less
@@ -33,12 +33,6 @@
       align-self: end;
     }
   }
-
-  .ant-color-picker-slider-alpha,
-  .ant-color-picker-alpha-input,
-  .ant-color-picker-format-select {
-    display: none;
-  }
 }
 
 .gs-color-field {

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.spec.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.spec.tsx
@@ -27,8 +27,10 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { ColorField } from './ColorField';
+import { vi } from 'vitest';
 
 describe('ColorField', () => {
 
@@ -39,6 +41,22 @@ describe('ColorField', () => {
   it('renders correctly', () => {
     const field = render(<ColorField />);
     expect(field.container).toBeInTheDocument();
+  });
+
+  it('change handler returns a hex code string', async () => {
+    const onChangeMock = vi.fn();
+    const field = render(<ColorField
+      onChange={onChangeMock}
+      format='rgb'
+      value='#000000'
+    />);
+    const colorPickerButton = field.container.querySelector('.color-picker-trigger');
+    await userEvent.click(colorPickerButton!);
+    const inputs = await screen.findAllByRole('spinbutton');
+    expect(inputs).toHaveLength(3);
+
+    fireEvent.change(inputs[1], { target: { value: 255 } });
+    expect(onChangeMock).toHaveBeenCalledWith('#00ff00');
   });
 
 });

--- a/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
+++ b/src/Component/Symbolizer/Field/ColorField/ColorField.tsx
@@ -44,6 +44,7 @@ import {
 } from 'geostyler-style';
 import { FunctionUI } from '../../../FunctionUI/FunctionUI';
 import { FunctionOutlined } from '@ant-design/icons';
+import { AggregationColor } from 'antd/es/color-picker/color';
 
 export interface ColorFieldProps extends Omit<ColorPickerProps, 'onChange' | 'value' | 'defaultValue'> {
   value?: Expression<string>;
@@ -63,13 +64,13 @@ export const ColorField: React.FC<ColorFieldProps> = ({
 
   const locale = useGeoStylerLocale('ColorField');
 
-  const onColorPickerChange = useCallback((_: any, hex: string) => {
-    // contains 0% opacity --> should only happen when clear is clicked
-    if (hex?.length === 9) {
+  const onColorPickerChange = useCallback((color?: AggregationColor) => {
+    if (!color) {
       onChange(undefined);
-    } else {
-      onChange(hex);
+      return;
     }
+    const hex = color.toHexString();
+    onChange(hex);
   }, [onChange]);
 
   function onCancel() {
@@ -91,7 +92,7 @@ export const ColorField: React.FC<ColorFieldProps> = ({
 
   let textColor;
   try {
-    textColor = Color(value || defaultValue).negate().grayscale().string();
+    textColor = Color(value || defaultValue).isLight() ? '#000000' : '#FFFFFF';
   } catch (error) {
     textColor = '#000000';
   }
@@ -110,9 +111,10 @@ export const ColorField: React.FC<ColorFieldProps> = ({
     <span className="editor-field gs-color-field">
       <ColorPicker
         allowClear
-        format='hex'
         {...passThroughProps}
+        disabledAlpha={true}
         onChange={onColorPickerChange}
+        onClear={() => onColorPickerChange()}
         value={colorString}
       >
         <Button style={btnStyle} className="color-picker-trigger">


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description
This fixes some issues with the ColorPicker: Compare #2501 

- allow RGB/HSB mode
- hide alpha inputs via API not via CSS
- ensure value of onChange is always in hex format

It also updates @ant-design/icons

### Preview

![geostyler_colorfield](https://github.com/user-attachments/assets/bca66a81-e914-436a-8c08-788b7b42b126)

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->
Fixes #2501 

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

