### PR TITLE
Improve props composition for FontPicker

### DIFF
--- a/src/Component/Symbolizer/Field/FontPicker/FontPicker.example.md
+++ b/src/Component/Symbolizer/Field/FontPicker/FontPicker.example.md
@@ -39,27 +39,26 @@ class FontPickerExample extends React.Component {
     super(props);
 
     this.state = {
-      font: ['arial']
+      value: ['arial']
     };
 
     this.onChange = this.onChange.bind(this);
   }
 
-  onChange(font) {
+  onChange(value) {
     this.setState({
-      font: font
+      value
     });
   }
 
   render() {
     const {
-      font
+      value
     } = this.state;
 
     return (
       <FontPicker
-        font={font}
-        fontOptions={['monospace', 'fantasy', 'serif', 'sans-serif']}
+        value={value}
         onChange={this.onChange}
       />
     );

--- a/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
+++ b/src/Component/Symbolizer/Field/FontPicker/FontPicker.tsx
@@ -29,36 +29,30 @@
 import React from 'react';
 
 import {
-  Select
+  Select,
+  SelectProps
 } from 'antd';
 
-// default props
-interface FontPickerDefaultProps {
-  fontOptions: string[];
-}
-
-// non default props
-export interface FontPickerProps extends Partial<FontPickerDefaultProps> {
-  onChange?: (fonts: string[]) => void;
-  font?: string[];
+export interface FontPickerProps extends Omit<SelectProps, 'options' | 'defaultValue'> {
+  fonts?: string[];
+  defaultValue?: string[];
 }
 
 /**
  * FontPicker to select font types / families
  */
 export const FontPicker: React.FC<FontPickerProps> = ({
-  onChange,
-  font,
-  fontOptions = [
+  fonts = [
     'Arial', 'Verdana', 'Sans-serif',
     'Courier New', 'Lucida Console', 'Monospace',
     'Times New Roman', 'Georgia', 'Serif'
-  ]
+  ],
+  ...restProps
 }) => {
 
   let options: {label: string; value: string}[];
-  if (fontOptions) {
-    options = fontOptions.map((fontOpt: string) => {
+  if (fonts) {
+    options = fonts.map((fontOpt: string) => {
       return {
         label: fontOpt,
         value: fontOpt
@@ -70,8 +64,7 @@ export const FontPicker: React.FC<FontPickerProps> = ({
     <Select
       className="editor-field font-picker"
       mode="tags"
-      value={font}
-      onChange={onChange}
+      {...restProps}
       options={options}
     />
   );

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
@@ -209,7 +209,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         label={locale.fontLabel}
       >
         <FontPicker
-          font={font as string[]}
+          value={font as string[]}
           onChange={onFontChange}
         />
       </Form.Item>

--- a/src/Component/Symbolizer/TextEditor/TextEditor.example.md
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.example.md
@@ -83,7 +83,9 @@ class TextEditorExample extends React.Component {
 <TextEditorExample />
 ```
 
-This demonstrates the usage of `TextEditor` with `GeoStylerContext`.
+This demonstrates the usage of `TextEditor` with `GeoStylerContext`. The visibility
+of each field can be toggled and a default value can be set. Also the fonts for the
+fontField can be specified.
 
 ```jsx
 import React, { useState } from 'react';
@@ -102,7 +104,14 @@ function TextEditorExample () {
           visibility: true
         },
         fontField: {
-          visibility: true
+          visibility: true,
+          default: ['Wingdings', 'Comic Sans MS'],
+          fonts: [
+            'Comic Sans MS',
+            'Wingdings',
+            'Arial',
+            'Verdana',
+          ]
         },
         opacityField: {
           visibility: true

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -44,7 +44,7 @@ import {
 import { ColorField, ColorFieldProps } from '../Field/ColorField/ColorField';
 import { OpacityField, OpacityFieldProps } from '../Field/OpacityField/OpacityField';
 import { WidthField, WidthFieldProps } from '../Field/WidthField/WidthField';
-import { FontPicker } from '../Field/FontPicker/FontPicker';
+import { FontPicker, FontPickerProps } from '../Field/FontPicker/FontPicker';
 import { OffsetField, OffsetFieldProps } from '../Field/OffsetField/OffsetField';
 import { RotateField, RotateFieldProps } from '../Field/RotateField/RotateField';
 import { SizeFieldProps } from '../Field/SizeField/SizeField';
@@ -64,10 +64,7 @@ import { getFormItemConfig } from '../../../Util/FormItemUtil';
 export interface TextEditorComposableProps {
   templateField?: InputConfig<string>;
   colorField?: InputConfig<ColorFieldProps['value']>;
-  // TODO add support for default values in FontPicker
-  fontField?: {
-    visibility?: boolean;
-  };
+  fontField?: InputConfig<FontPickerProps['value']> & { fonts?: FontPickerProps['fonts'] };
   opacityField?: InputConfig<OpacityFieldProps['value']>;
   sizeField?: InputConfig<SizeFieldProps['value']>;
   offsetXField?: InputConfig<OffsetFieldProps['offset']>;
@@ -301,8 +298,10 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
             {...getFormItemSupportProps('font')}
           >
             <FontPicker
-              font={font as string[]}
+              value={font as string[]}
+              defaultValue={fontField?.default as string[]}
               onChange={onFontChange}
+              fonts={fontField?.fonts}
             />
           </Form.Item>
         )


### PR DESCRIPTION
BREAKING CHANGE: The FontPickers value name changed from `font` to `value`

<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This improves the props of the `FontPicker` componet.

It is now possible to provide a `defaultValue` and list of `fonts` via GeoStyler context.
This closes #2405 

:warning: Strictly speaking, this is a breaking change because the props of a component have changed. Even if this component is certainly only used internally.

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

