### PR TITLE
Remove unused props

### DIFF
--- a/src/Component/Rules/Rules.tsx
+++ b/src/Component/Rules/Rules.tsx
@@ -60,10 +60,6 @@ export interface RulesComposableProps {
 }
 
 export interface RulesInternalProps {
-  /** Display the number of features that match a rule */
-  showAmount?: boolean;
-  /** Display the number of features that match more than one rule */
-  showDuplicates?: boolean;
   /** List of rules to display in rule table */
   rules: GsRule[];
   /** The callback function that is triggered when the rules change */


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This removes the unused `showAmount` and `showDuplicates` props from the `Rules` component.
The visibility of these fields can be configured via `Rule` in the GeoStyler composition context.

This closes #2466 

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

