### PR TITLE
Refactor field props

### DIFF
--- a/src/Component/BulkEditor/BulkEditor.tsx
+++ b/src/Component/BulkEditor/BulkEditor.tsx
@@ -103,7 +103,7 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
         label={locale.radiusLabel}
       >
         <RadiusField
-          radius={radius}
+          value={radius}
           onChange={onRadiusChange}
         />
       </Form.Item>
@@ -122,14 +122,14 @@ export const BulkEditor: React.FC<BulkEditorProps> = ({
         className='gs-symbol-selection'
       >
         <KindField
-          kind={kind}
+          value={kind}
           onChange={setKind}
           symbolizerKinds={symbolizerKinds}
         />
         {
           kind === 'Mark' && (
             <WellKnownNameField
-              wellKnownName={wellKnownName}
+              value={wellKnownName}
               onChange={onWellKnownNameChange}
             />
           )

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -74,7 +74,6 @@ import { useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerCont
 import { isString } from 'lodash';
 import { MbStyle } from 'geostyler-mapbox-parser';
 
-// non default props
 export interface CodeEditorProps {
   /** Delay in ms until onStyleChange will be called */
   delay?: number;

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -32,27 +32,23 @@ import { ComparisonOperator } from 'geostyler-style';
 import { Select, Form } from 'antd';
 const Option = Select.Option;
 
-// default props
-interface OperatorComboDefaultProps {
+export interface OperatorComboProps {
   /** Label for this field */
-  label: string;
+  label?: string;
   /** Show title of selected item */
-  showTitles: boolean;
+  showTitles?: boolean;
   /** The default text to place into the empty field */
-  placeholder: string;
+  placeholder?: string;
   /** List of operators to show in this combo */
-  operators: ComparisonOperator[];
+  operators?: ComparisonOperator[];
   /** Mapping function for operator names in this combo */
-  operatorNameMappingFunction: (originalOperatorName: string) => string;
+  operatorNameMappingFunction?: (originalOperatorName: string) => string;
   /** Mapping function for operator title in this combo */
-  operatorTitleMappingFunction: (originalOperatorName: string) => string;
+  operatorTitleMappingFunction?: (originalOperatorName: string) => string;
   /** Validation status */
-  validateStatus: 'success' | 'warning' | 'error' | 'validating';
+  validateStatus?: 'success' | 'warning' | 'error' | 'validating';
   /** Element to show a help text */
-  help: React.ReactNode;
-}
-// non default props
-export interface OperatorComboProps extends Partial<OperatorComboDefaultProps> {
+  help?: React.ReactNode;
   /** Callback function for onChange */
   onOperatorChange?: ((newOperator: ComparisonOperator) => void);
   /** Initial value set to the field */

--- a/src/Component/NameField/NameField.tsx
+++ b/src/Component/NameField/NameField.tsx
@@ -33,13 +33,9 @@ import {
 
 import './NameField.less';
 
-// default props
-export interface NameFieldDefaultProps {
+export interface NameFieldProps {
   /** The placeholder text of the input field if no value was specified */
-  placeholder: string;
-}
-// non default props
-export interface NameFieldProps extends Partial<NameFieldDefaultProps> {
+  placeholder?: string;
   /** The value to display in input field */
   value?: string | undefined;
   /** The callback method that is triggered when the state changes */

--- a/src/Component/RemovableItem/RemovableItem.tsx
+++ b/src/Component/RemovableItem/RemovableItem.tsx
@@ -30,14 +30,9 @@ import { CloseCircleOutlined } from '@ant-design/icons';
 import React from 'react';
 import './RemovableItem.less';
 
-// default props
-export interface RemovableItemDefaultProps extends React.PropsWithChildren {
+export interface RemovableItemProps extends React.PropsWithChildren {
   /** The callback that is being called, when the item was clicked. */
-  onRemoveClick: () => void;
-}
-
-// non default props
-export interface RemovableItemProps extends Partial<RemovableItemDefaultProps> {
+  onRemoveClick?: () => void;
 }
 
 export const RemovableItem: React.FC<RemovableItemProps> = ({

--- a/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.tsx
+++ b/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.tsx
@@ -34,7 +34,6 @@ import RuleGeneratorUtil from '../../../Util/RuleGeneratorUtil';
 
 import _isEqual from 'lodash/isEqual';
 
-// non default props
 export interface ColorsPreviewProps {
   /** List of colors to preview */
   colors: string[];

--- a/src/Component/RuleGenerator/RuleGenerator.tsx
+++ b/src/Component/RuleGenerator/RuleGenerator.tsx
@@ -258,7 +258,7 @@ export const RuleGenerator: React.FC<RuleGeneratorProps> = (props) => {
           {...itemConfig}
         >
           <KindField
-            kind={symbolizerKind}
+            value={symbolizerKind}
             symbolizerKinds={[
               'Fill',
               'Mark',
@@ -272,7 +272,7 @@ export const RuleGenerator: React.FC<RuleGeneratorProps> = (props) => {
             {...itemConfig}
           >
             <WellKnownNameField
-              wellKnownName={wellKnownName}
+              value={wellKnownName}
               onChange={setWellKnownName}
             />
           </Form.Item>

--- a/src/Component/Selectable/Selectable.tsx
+++ b/src/Component/Selectable/Selectable.tsx
@@ -30,12 +30,7 @@ import React, { ReactNode, useState } from 'react';
 import './Selectable.less';
 import { SelectableItem } from './SelectableItem/SelectableItem';
 
-// default props
-export interface SelectableDefaultProps extends React.PropsWithChildren {
-}
-
-// non default props
-export interface SelectableProps extends Partial<SelectableDefaultProps> {
+export interface SelectableProps extends React.PropsWithChildren {
   /** The ids of the selected items. */
   selection?: number[];
   /** The change event that is triggered, when the selection changes. */

--- a/src/Component/Selectable/SelectableItem/SelectableItem.tsx
+++ b/src/Component/Selectable/SelectableItem/SelectableItem.tsx
@@ -30,16 +30,11 @@ import { CheckCircleOutlined } from '@ant-design/icons';
 import React from 'react';
 import './SelectableItem.less';
 
-// default props
-export interface SelectableItemDefaultProps extends React.PropsWithChildren {
+export interface SelectableItemProps extends React.PropsWithChildren {
   /** The callback that is being called, when the item was clicked. */
-  onItemClick: () => void;
+  onItemClick?: () => void;
   /** Whether the item is currently selected. */
-  selected: boolean;
-}
-
-// non default props
-export interface SelectableItemProps extends Partial<SelectableItemDefaultProps> {
+  selected?: boolean;
 }
 
 export const SelectableItem: React.FC<SelectableItemProps> = ({

--- a/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
+++ b/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
@@ -53,19 +53,14 @@ import './BulkEditModals.less';
 import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 
-// default props
-interface BulkEditModalsDefaultProps {
-  colorModalVisible: boolean;
-  sizeModalVisible: boolean;
-  opacityModalVisible: boolean;
-  symbolModalVisible: boolean;
-  style: GsStyle;
-  selectedRowKeys: number[];
-  modalsClosed: ModalProps['onCancel'];
-}
-
-// non default props
-export interface BulkEditModalsProps extends Partial<BulkEditModalsDefaultProps> {
+export interface BulkEditModalsProps {
+  colorModalVisible?: boolean;
+  sizeModalVisible?: boolean;
+  opacityModalVisible?: boolean;
+  symbolModalVisible?: boolean;
+  style?: GsStyle;
+  selectedRowKeys?: number[];
+  modalsClosed?: ModalProps['onCancel'];
   updateMultiColors?: (x: Expression<string>) => void;
   updateMultiSizes?: (x: Expression<number> | undefined) => void;
   updateMultiOpacities?: (x: Expression<number> | undefined) => void;

--- a/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
+++ b/src/Component/Symbolizer/BulkEditModals/BulkEditModals.tsx
@@ -153,7 +153,7 @@ export const BulkEditModals: React.FC<BulkEditModalsProps> = ({
       >
         {locale.radiusLabel}
         <RadiusField
-          radius={size}
+          value={size}
           onChange={updateMultiSizes}
         />
       </Modal>
@@ -179,13 +179,13 @@ export const BulkEditModals: React.FC<BulkEditModalsProps> = ({
       >
         <KindField
           symbolizerKinds={['Mark', 'Icon']}
-          kind={kind}
+          value={kind}
           onChange={setKind}
         />
         {
           kind === 'Mark' ? (
             <WellKnownNameField
-              wellKnownName={symbol}
+              value={symbol}
               onChange={(val) => {
                 updateMultiSymbols(val, kind);
               }}

--- a/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
+++ b/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
@@ -253,7 +253,7 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = (props) => {
     const input = (
       <OffsetField
         className="gs-colormap-quantity-input"
-        offset={record.quantity}
+        value={record.quantity}
         onChange={value => {
           setValueForColorMapEntry(record.key, 'quantity', value);
         }}
@@ -324,7 +324,7 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = (props) => {
               label={locale.typeLabel}
             >
               <ColorMapTypeField
-                colorMapType={colorMapType}
+                value={colorMapType}
                 onChange={onTypeChange}
               />
             </Form.Item>
@@ -368,7 +368,7 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = (props) => {
               label={locale.extendedLabel}
             >
               <ExtendedField
-                extended={colorMap?.extended as boolean}
+                value={colorMap?.extended as boolean}
                 onChange={onExtendedChange}
               />
             </Form.Item>

--- a/src/Component/Symbolizer/Editor/Editor.tsx
+++ b/src/Component/Symbolizer/Editor/Editor.tsx
@@ -193,7 +193,7 @@ export const Editor: React.FC<EditorProps> = (props) => {
         label={locale.kindFieldLabel}
       >
         <KindField
-          kind={symbolizer.kind}
+          value={symbolizer.kind}
           onChange={onKindFieldChange}
           symbolizerKinds={filteredSymbolizerKinds}
         />

--- a/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.tsx
+++ b/src/Component/Symbolizer/Field/BrightnessField/BrightnessField.tsx
@@ -35,7 +35,7 @@ import { Expression } from 'geostyler-style';
 type InputProps = NumberExpressionInputProps['inputProps'];
 
 export interface BrightnessFieldProps extends InputProps {
-  brightness?: number;
+  value?: number;
   onChange?: (newValue: Expression<number> | undefined) => void;
 }
 
@@ -45,7 +45,7 @@ export interface BrightnessFieldProps extends InputProps {
  */
 export const BrightnessField: React.FC<BrightnessFieldProps> = ({
   onChange,
-  brightness,
+  value,
   ...inputNumberProps
 }) => {
 
@@ -56,7 +56,7 @@ export const BrightnessField: React.FC<BrightnessFieldProps> = ({
   return (
     <NumberExpressionInput
       className="editor-field brightness-field"
-      value={brightness}
+      value={value}
       onChange={onChange}
       onCancel={onCancel}
       inputProps={{

--- a/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
+++ b/src/Component/Symbolizer/Field/ChannelField/ChannelField.tsx
@@ -54,7 +54,7 @@ export interface ChannelFieldComposableProps {
   contrastEnhancementField?: {
     visibility?: boolean;
   };
-  gammaValueField?: InputConfig<GammaFieldProps['gamma']>;
+  gammaValueField?: InputConfig<GammaFieldProps['value']>;
 }
 
 export interface ChannelFieldInternalProps {
@@ -143,7 +143,7 @@ export const ChannelField: React.FC<ChannelFieldProps> = (props) => {
           >
             <SourceChannelNameField
               onChange={onSourceChannelNameChange}
-              sourceChannelName={sourceChannelName as string}
+              value={sourceChannelName as string}
               sourceChannelNames={sourceChannelNames}
             />
           </Form.Item>
@@ -156,7 +156,7 @@ export const ChannelField: React.FC<ChannelFieldProps> = (props) => {
             label={locale.contrastEnhancementTypeLabel}
           >
             <ContrastEnhancementField
-              contrastEnhancement={contrastEnhancementType}
+              value={contrastEnhancementType}
               contrastEnhancementOptions={contrastEnhancementTypes}
               onChange={onContrastEnhancementChange}
             />
@@ -170,7 +170,7 @@ export const ChannelField: React.FC<ChannelFieldProps> = (props) => {
             label={locale.gammaValueLabel}
           >
             <GammaField
-              gamma={gamma as any}
+              value={gamma as any}
               defaultValue={gammaValueField?.default}
               onChange={onGammaChange}
             />

--- a/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.tsx
+++ b/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.tsx
@@ -40,7 +40,7 @@ import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStyl
 export interface ColorMapEntryFieldProps {
   labelPlaceholder?: string;
   onChange?: (colorMapEntry: ColorMapEntry) => void;
-  colorMapEntry?: ColorMapEntry;
+  value?: ColorMapEntry;
 }
 
 /**
@@ -49,14 +49,14 @@ export interface ColorMapEntryFieldProps {
 export const ColorMapEntryField: React.FC<ColorMapEntryFieldProps> = ({
   labelPlaceholder = 'Color Map Label',
   onChange,
-  colorMapEntry
+  value
 }) => {
 
   const locale = useGeoStylerLocale('ColorMapEntryField');
 
-  const updateColorMapEntry = (prop: string, value: any) => {
-    let updated: ColorMapEntry = {...colorMapEntry};
-    updated[prop as keyof ColorMapEntry] = value;
+  const updateColorMapEntry = (prop: string, newValue: any) => {
+    let updated: ColorMapEntry = {...newValue};
+    updated[prop as keyof ColorMapEntry] = newValue;
     if (onChange) {
       onChange(updated);
     }
@@ -84,7 +84,7 @@ export const ColorMapEntryField: React.FC<ColorMapEntryFieldProps> = ({
         label={locale.colorLabel}
       >
         <ColorField
-          value={_get(colorMapEntry, 'color') as string}
+          value={_get(value, 'color') as string}
           onChange={onColorChange}
         />
       </Form.Item>
@@ -92,7 +92,7 @@ export const ColorMapEntryField: React.FC<ColorMapEntryFieldProps> = ({
         label={locale.quantityLabel}
       >
         <OffsetField
-          offset={_get(colorMapEntry, 'quantity') as number}
+          value={_get(value, 'quantity') as number}
           onChange={onQuantityChange}
         />
       </Form.Item>
@@ -101,8 +101,8 @@ export const ColorMapEntryField: React.FC<ColorMapEntryFieldProps> = ({
       >
         <Input
           className="editor-field colormapentry-label-field"
-          defaultValue={_get(colorMapEntry, 'label') as string}
-          value={_get(colorMapEntry, 'label') as string}
+          defaultValue={_get(value, 'label') as string}
+          value={_get(value, 'label') as string}
           placeholder={labelPlaceholder}
           onChange={(evt: any) => {
             onLabelChange(evt.target.value);
@@ -113,7 +113,7 @@ export const ColorMapEntryField: React.FC<ColorMapEntryFieldProps> = ({
         label={locale.opacityLabel}
       >
         <OpacityField
-          value={colorMapEntry?.opacity}
+          value={value?.opacity}
           onChange={onOpacityChange}
         />
       </Form.Item>

--- a/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.tsx
+++ b/src/Component/Symbolizer/Field/ColorMapEntryField/ColorMapEntryField.tsx
@@ -55,7 +55,7 @@ export const ColorMapEntryField: React.FC<ColorMapEntryFieldProps> = ({
   const locale = useGeoStylerLocale('ColorMapEntryField');
 
   const updateColorMapEntry = (prop: string, newValue: any) => {
-    let updated: ColorMapEntry = {...newValue};
+    let updated: ColorMapEntry = {...value};
     updated[prop as keyof ColorMapEntry] = newValue;
     if (onChange) {
       onChange(updated);

--- a/src/Component/Symbolizer/Field/ColorMapTypeField/ColorMapTypeField.tsx
+++ b/src/Component/Symbolizer/Field/ColorMapTypeField/ColorMapTypeField.tsx
@@ -41,7 +41,7 @@ import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStyl
 export interface ColorMapTypeFieldProps {
   colorMapTypeOptions?: ColorMapType[];
   onChange?: (colorMapType: ColorMapType) => void;
-  colorMapType?: ColorMapType;
+  value?: ColorMapType;
 }
 
 /**
@@ -50,7 +50,7 @@ export interface ColorMapTypeFieldProps {
 export const ColorMapTypeField: React.FC<ColorMapTypeFieldProps> = ({
   colorMapTypeOptions = ['ramp', 'intervals', 'values'],
   onChange,
-  colorMapType
+  value
 }) => {
 
   const locale = useGeoStylerLocale('ColorMapTypeField');
@@ -69,7 +69,7 @@ export const ColorMapTypeField: React.FC<ColorMapTypeFieldProps> = ({
     }
   };
 
-  const mapType = colorMapType ? colorMapType : colorMapTypeOptions[0];
+  const mapType = value ? value : colorMapTypeOptions[0];
   return (
     <Radio.Group
       className="color-map-type-field"

--- a/src/Component/Symbolizer/Field/ContrastEnhancementField/ContrastEnhancementField.tsx
+++ b/src/Component/Symbolizer/Field/ContrastEnhancementField/ContrastEnhancementField.tsx
@@ -38,14 +38,9 @@ import {
 } from 'geostyler-style';
 import FunctionUtil from '../../../../Util/FunctionUtil';
 
-// default props
-interface ContrastEnhancementFieldDefaultProps {
-  contrastEnhancementOptions: ContrastEnhancement['enhancementType'][];
-}
-
-// non default props
-export interface ContrastEnhancementFieldProps extends Partial<ContrastEnhancementFieldDefaultProps> {
+export interface ContrastEnhancementFieldProps {
   onChange?: (contrastEnhancement: ContrastEnhancement['enhancementType']) => void;
+  contrastEnhancementOptions?: ContrastEnhancement['enhancementType'][];
   value?: ContrastEnhancement['enhancementType'];
 }
 

--- a/src/Component/Symbolizer/Field/ContrastEnhancementField/ContrastEnhancementField.tsx
+++ b/src/Component/Symbolizer/Field/ContrastEnhancementField/ContrastEnhancementField.tsx
@@ -46,7 +46,7 @@ interface ContrastEnhancementFieldDefaultProps {
 // non default props
 export interface ContrastEnhancementFieldProps extends Partial<ContrastEnhancementFieldDefaultProps> {
   onChange?: (contrastEnhancement: ContrastEnhancement['enhancementType']) => void;
-  contrastEnhancement?: ContrastEnhancement['enhancementType'];
+  value?: ContrastEnhancement['enhancementType'];
 }
 
 /**
@@ -55,7 +55,7 @@ export interface ContrastEnhancementFieldProps extends Partial<ContrastEnhanceme
 export const ContrastEnhancementField: React.FC<ContrastEnhancementFieldProps> = ({
   onChange,
   contrastEnhancementOptions = ['normalize', 'histogram'],
-  contrastEnhancement
+  value
 }) => {
 
   const getContrastEnhancementSelectOptions = () => {
@@ -78,7 +78,7 @@ export const ContrastEnhancementField: React.FC<ContrastEnhancementFieldProps> =
     <Select
       className="editor-field contrastEnhancement-field"
       allowClear={true}
-      value={contrastEnhancement}
+      value={value}
       onChange={onChange}
     >
       {getContrastEnhancementSelectOptions()}

--- a/src/Component/Symbolizer/Field/ContrastField/ContrastField.tsx
+++ b/src/Component/Symbolizer/Field/ContrastField/ContrastField.tsx
@@ -34,7 +34,7 @@ import { Expression } from 'geostyler-style';
 type InputProps = NumberExpressionInputProps['inputProps'];
 
 export interface ContrastFieldProps extends InputProps {
-  contrast?: Expression<number>;
+  value?: Expression<number>;
   onChange?: (newValue: Expression<number> | undefined) => void;
 }
 
@@ -43,7 +43,7 @@ export interface ContrastFieldProps extends InputProps {
  */
 export const ContrastField: React.FC<ContrastFieldProps> = ({
   onChange,
-  contrast,
+  value,
   ...inputNumberProps
 }) => {
 
@@ -55,7 +55,7 @@ export const ContrastField: React.FC<ContrastFieldProps> = ({
   return (
     <NumberExpressionInput
       className="editor-field contrast-field"
-      value={contrast}
+      value={value}
       onChange={onChange}
       onCancel={onCancel}
       inputProps={{

--- a/src/Component/Symbolizer/Field/ExtendedField/ExtendedField.tsx
+++ b/src/Component/Symbolizer/Field/ExtendedField/ExtendedField.tsx
@@ -35,7 +35,7 @@ import {
 // non default props
 export interface ExtendedFieldProps {
   onChange?: (extended: boolean) => void;
-  extended?: boolean;
+  value?: boolean;
 }
 
 /**
@@ -43,7 +43,7 @@ export interface ExtendedFieldProps {
  */
 export const ExtendedField: React.FC<ExtendedFieldProps> = ({
   onChange,
-  extended
+  value
 }) => {
 
   const onExtendedChange = (evt: any) => {
@@ -55,7 +55,7 @@ export const ExtendedField: React.FC<ExtendedFieldProps> = ({
   return (
     <Radio.Group
       className="extend-field"
-      defaultValue={extended === true ? extended : false}
+      defaultValue={value === true ? value : false}
       buttonStyle="solid"
       onChange={onExtendedChange}
       size="small"

--- a/src/Component/Symbolizer/Field/ExtendedField/ExtendedField.tsx
+++ b/src/Component/Symbolizer/Field/ExtendedField/ExtendedField.tsx
@@ -32,7 +32,6 @@ import {
   Radio
 } from 'antd';
 
-// non default props
 export interface ExtendedFieldProps {
   onChange?: (extended: boolean) => void;
   value?: boolean;

--- a/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.tsx
+++ b/src/Component/Symbolizer/Field/FadeDurationField/FadeDurationField.tsx
@@ -34,7 +34,7 @@ import { Expression } from 'geostyler-style';
 type InputProps = NumberExpressionInputProps['inputProps'];
 
 export interface FadeDurationFieldProps extends InputProps {
-  fadeDuration?: number;
+  value?: number;
   onChange?: (newValue: Expression<number> | undefined) => void;
 }
 
@@ -43,7 +43,7 @@ export interface FadeDurationFieldProps extends InputProps {
  */
 export const FadeDurationField: React.FC<FadeDurationFieldProps> = ({
   onChange,
-  fadeDuration,
+  value,
   ...inputNumberProps
 }) => {
 
@@ -54,7 +54,7 @@ export const FadeDurationField: React.FC<FadeDurationFieldProps> = ({
   return (
     <NumberExpressionInput
       className="editor-field fadeDuration-field"
-      value={fadeDuration}
+      value={value}
       onChange={onChange}
       onCancel={onCancel}
       inputProps={{

--- a/src/Component/Symbolizer/Field/GammaField/GammaField.tsx
+++ b/src/Component/Symbolizer/Field/GammaField/GammaField.tsx
@@ -34,7 +34,7 @@ import { Expression } from 'geostyler-style';
 type InputProps = NumberExpressionInputProps['inputProps'];
 
 export interface GammaFieldProps extends InputProps {
-  gamma?: number;
+  value?: number;
   onChange?: (newValue: Expression<number> | undefined) => void;
 }
 
@@ -43,7 +43,7 @@ export interface GammaFieldProps extends InputProps {
  */
 export const GammaField: React.FC<GammaFieldProps> = ({
   onChange,
-  gamma,
+  value,
   ...inputNumberProps
 }) => {
 
@@ -54,7 +54,7 @@ export const GammaField: React.FC<GammaFieldProps> = ({
   return (
     <NumberExpressionInput
       className="editor-field gamma-field"
-      value={gamma}
+      value={value}
       onChange={onChange}
       onCancel={onCancel}
       inputProps={{

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
@@ -35,14 +35,11 @@ import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStyl
 
 const Option = Select.Option;
 
-export interface GraphicTypeFieldDefaultProps {
+export interface GraphicTypeFieldProps {
   /** List of selectable GraphicTypes for Select */
-  graphicTypes: GraphicType[];
+  graphicTypes?: GraphicType[];
   /** If true GraphicTypeField can be cleared  */
-  clearable: boolean;
-}
-
-export interface GraphicTypeFieldProps extends Partial<GraphicTypeFieldDefaultProps> {
+  clearable?: boolean;
   /** Currently selected GraphicType */
   value?: GraphicType;
   /** Callback when selection changes */

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
@@ -44,7 +44,7 @@ export interface GraphicTypeFieldDefaultProps {
 
 export interface GraphicTypeFieldProps extends Partial<GraphicTypeFieldDefaultProps> {
   /** Currently selected GraphicType */
-  graphicType?: GraphicType;
+  value?: GraphicType;
   /** Callback when selection changes */
   onChange?: (type: GraphicType) => void;
 }
@@ -52,7 +52,7 @@ export interface GraphicTypeFieldProps extends Partial<GraphicTypeFieldDefaultPr
 /** GraphicTypeField to select between different GraphicTypes */
 export const GraphicTypeField: React.FC<GraphicTypeFieldProps> = ({
   onChange,
-  graphicType,
+  value,
   graphicTypes = ['Mark', 'Icon'],
   clearable = true,
   ...passThroughProps
@@ -75,7 +75,7 @@ export const GraphicTypeField: React.FC<GraphicTypeFieldProps> = ({
   return (
     <Select
       className="editor-field graphictype-field"
-      value={graphicType}
+      value={value}
       onChange={onChange}
       allowClear={clearable}
       {...passThroughProps}

--- a/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.tsx
+++ b/src/Component/Symbolizer/Field/GrayChannelField/GrayChannelField.tsx
@@ -43,7 +43,7 @@ import { getFormItemConfig } from '../../../../Util/FormItemUtil';
 export interface GrayChannelFieldProps {
   sourceChannelNames?: string[];
   onChange?: (channelSelection: ChannelSelection) => void;
-  channelSelection?: ChannelSelection;
+  value?: ChannelSelection;
 }
 
 /**
@@ -51,17 +51,17 @@ export interface GrayChannelFieldProps {
  */
 export const GrayChannelField: React.FC<GrayChannelFieldProps> = ({
   onChange,
-  channelSelection,
+  value,
   sourceChannelNames
 }) => {
 
   const locale = useGeoStylerLocale('GrayChannelField');
 
-  const onGrayChannelChange = (value: string) => {
-    const gray = value;
+  const onGrayChannelChange = (newValue: string) => {
+    const gray = newValue;
     let newChannelSelection: GrayChannel;
-    if (channelSelection && channelSelection.hasOwnProperty('grayChannel')) {
-      newChannelSelection = _cloneDeep(channelSelection) as GrayChannel;
+    if (newValue && newValue.hasOwnProperty('grayChannel')) {
+      newChannelSelection = _cloneDeep(value) as GrayChannel;
       newChannelSelection.grayChannel.sourceChannelName = gray;
     } else {
       newChannelSelection = {
@@ -86,7 +86,7 @@ export const GrayChannelField: React.FC<GrayChannelFieldProps> = ({
         <SourceChannelNameField
           sourceChannelNames={sourceChannelNames}
           onChange={onGrayChannelChange}
-          sourceChannelName={_get(channelSelection, 'grayChannel.sourceChannelName')}
+          value={_get(value, 'grayChannel.sourceChannelName')}
         />
       </Form.Item>
     </div>

--- a/src/Component/Symbolizer/Field/KindField/KindField.tsx
+++ b/src/Component/Symbolizer/Field/KindField/KindField.tsx
@@ -37,7 +37,7 @@ import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStyl
 const Option = Select.Option;
 
 export interface KindFieldProps {
-  kind?: SymbolizerKind;
+  value?: SymbolizerKind;
   symbolizerKinds?: SymbolizerKind[];
   onChange?: (kind: SymbolizerKind) => void;
 }
@@ -47,7 +47,7 @@ export interface KindFieldProps {
  */
 export const KindField: React.FC<KindFieldProps> = ({
   onChange,
-  kind = 'Mark',
+  value = 'Mark',
   symbolizerKinds = ['Mark', 'Fill', 'Icon', 'Line', 'Text', 'Raster']
 }) => {
 
@@ -65,7 +65,7 @@ export const KindField: React.FC<KindFieldProps> = ({
   return (
     <Select
       className="editor-field kind-field"
-      value={kind}
+      value={value}
       onChange={onChange}
     >
       {kindSelectOptions}

--- a/src/Component/Symbolizer/Field/LineDashField/LineDashField.spec.tsx
+++ b/src/Component/Symbolizer/Field/LineDashField/LineDashField.spec.tsx
@@ -47,7 +47,7 @@ describe('OffsetField', () => {
   describe('InputFields', () => {
     it('change handlers call the onChange prop method correctly', async() => {
       const onChangeMock = vi.fn();
-      const field = render(<LineDashField dashArray={dashArray} onChange={onChangeMock} />);
+      const field = render(<LineDashField value={dashArray} onChange={onChangeMock} />);
       const inputs = await field.findAllByRole('spinbutton');
 
       // const numberInputs = wrapper.find('InputNumber');
@@ -63,7 +63,7 @@ describe('OffsetField', () => {
   describe('onAddDash', () => {
     it('calls a passed onChange function with the new dashArray', async() => {
       const onChangeMock = vi.fn();
-      const field = render(<LineDashField dashArray={dashArray} onChange={onChangeMock} />);
+      const field = render(<LineDashField value={dashArray} onChange={onChangeMock} />);
       const addButton = field.container.querySelector('button.gs-add-dash-button');
       fireEvent.click(addButton as Element);
       let newDashArray = [...dashArray, 1];
@@ -74,7 +74,7 @@ describe('OffsetField', () => {
   describe('onRemoveDash', () => {
     it('calls a passed onChange function with the new dashArray', async() => {
       const onChangeMock = vi.fn();
-      const field = render(<LineDashField dashArray={dashArray} onChange={onChangeMock} />);
+      const field = render(<LineDashField value={dashArray} onChange={onChangeMock} />);
       const removeButton = field.container.querySelector('button.gs-rm-dash-button');
       fireEvent.click(removeButton as Element);
       let newDashArray = [...dashArray];

--- a/src/Component/Symbolizer/Field/LineDashField/LineDashField.tsx
+++ b/src/Component/Symbolizer/Field/LineDashField/LineDashField.tsx
@@ -36,14 +36,9 @@ import { MinusOutlined, PlusOutlined } from '@ant-design/icons';
 
 import './LineDashField.less';
 
-// default props
-interface LineDashFieldDefaultProps {
-  dashArray: number[];
-}
-
-// non default props
-export interface LineDashFieldProps extends Partial<LineDashFieldDefaultProps> {
+export interface LineDashFieldProps {
   onChange?: (dashArray: number[]) => void;
+  value?: number[];
 }
 
 /**
@@ -51,12 +46,12 @@ export interface LineDashFieldProps extends Partial<LineDashFieldDefaultProps> {
  */
 export const LineDashField: React.FC<LineDashFieldProps> = ({
   onChange,
-  dashArray = []
+  value = []
 }) => {
 
   const onAddDash = () => {
     // add a new dash (UI)
-    let newDashArray = [...dashArray];
+    let newDashArray = [...value];
     newDashArray.push(1);
     if (onChange) {
       onChange(newDashArray);
@@ -65,7 +60,7 @@ export const LineDashField: React.FC<LineDashFieldProps> = ({
 
   const onRemoveDash = () => {
     // remove last dash (UI)
-    let newDashArray = [...dashArray];
+    let newDashArray = [...value];
     newDashArray.splice(newDashArray.length - 1, 1);
     if (onChange) {
       onChange(newDashArray);
@@ -75,16 +70,16 @@ export const LineDashField: React.FC<LineDashFieldProps> = ({
   return (
     <div className="editor-field linedash-field">
       {
-        dashArray.map((dash, idx) => <InputNumber
+        value.map((dash, idx) => <InputNumber
           key={idx}
           value={dash}
           min={1}
           step={1}
           style={{ width: 55 }}
-          onChange={(value: number) => {
+          onChange={(newValue: number) => {
             // replace current dash value
-            let newDashArray = [...dashArray];
-            newDashArray[idx] = value;
+            let newDashArray = [...value];
+            newDashArray[idx] = newValue;
             if (onChange) {
               onChange(newDashArray);
             }

--- a/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
+++ b/src/Component/Symbolizer/Field/OffsetField/OffsetField.tsx
@@ -34,7 +34,7 @@ import { Expression } from 'geostyler-style';
 type InputProps = NumberExpressionInputProps['inputProps'];
 
 export interface OffsetFieldProps extends InputProps {
-  offset?: Expression<number>;
+  value?: Expression<number>;
   className?: string;
   onChange?: (newValue: Expression<number> | undefined) => void;
 }
@@ -43,7 +43,7 @@ export interface OffsetFieldProps extends InputProps {
  * OffsetField for map labels
  */
 export const OffsetField: React.FC<OffsetFieldProps> = ({
-  offset,
+  value,
   onChange,
   className,
   ...inputNumberProps
@@ -61,7 +61,7 @@ export const OffsetField: React.FC<OffsetFieldProps> = ({
   return (
     <NumberExpressionInput
       className={finalClassName}
-      value={offset}
+      value={value}
       onChange={onChange}
       onCancel={onCancel}
       inputProps={{

--- a/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
+++ b/src/Component/Symbolizer/Field/RadiusField/RadiusField.tsx
@@ -34,7 +34,7 @@ import { Expression } from 'geostyler-style';
 type InputProps = NumberExpressionInputProps['inputProps'];
 
 export interface RadiusFieldProps extends InputProps {
-  radius?: Expression<number>;
+  value?: Expression<number>;
   onChange?: (newValue: Expression<number> | undefined) => void;
 }
 
@@ -43,7 +43,7 @@ export interface RadiusFieldProps extends InputProps {
  */
 export const RadiusField: React.FC<RadiusFieldProps> = ({
   onChange,
-  radius,
+  value,
   ...inputNumberProps
 }) => {
 
@@ -54,7 +54,7 @@ export const RadiusField: React.FC<RadiusFieldProps> = ({
   return (
     <NumberExpressionInput
       className="editor-field radius-field"
-      value={radius}
+      value={value}
       onChange={onChange}
       onCancel={onCancel}
       inputProps={{

--- a/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.tsx
+++ b/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.tsx
@@ -38,15 +38,10 @@ import {
 } from 'geostyler-style';
 import FunctionUtil from '../../../../Util/FunctionUtil';
 
-// default props
-interface ResamplingFieldDefaultProps {
-  resamplingOptions: RasterSymbolizer['resampling'][];
-}
-
-// non default props
-export interface ResamplingFieldProps extends Partial<ResamplingFieldDefaultProps> {
+export interface ResamplingFieldProps {
   onChange?: (resamplings: RasterSymbolizer['resampling']) => void;
-  resampling?: RasterSymbolizer['resampling'];
+  value?: RasterSymbolizer['resampling'];
+  resamplingOptions?: RasterSymbolizer['resampling'][];
 }
 
 /**
@@ -55,7 +50,7 @@ export interface ResamplingFieldProps extends Partial<ResamplingFieldDefaultProp
 export const ResamplingField: React.FC<ResamplingFieldProps> = ({
   resamplingOptions =['linear', 'nearest'],
   onChange,
-  resampling
+  value
 }) => {
 
   const resamplingSelectOptions = resamplingOptions.map(resamplingOpt => {
@@ -76,7 +71,7 @@ export const ResamplingField: React.FC<ResamplingFieldProps> = ({
     <Select
       className="editor-field resampling-field"
       allowClear={true}
-      value={resampling}
+      value={value}
       onChange={onChange}
     >
       {resamplingSelectOptions}

--- a/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.tsx
+++ b/src/Component/Symbolizer/Field/RgbChannelField/RgbChannelField.tsx
@@ -43,7 +43,7 @@ import { getFormItemConfig } from '../../../../Util/FormItemUtil';
 export interface RgbChannelFieldProps {
   sourceChannelNames?: string[];
   onChange?: (channelSelection: ChannelSelection) => void;
-  channelSelection?: ChannelSelection;
+  value?: ChannelSelection;
 }
 
 /**
@@ -52,21 +52,21 @@ export interface RgbChannelFieldProps {
 export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
   sourceChannelNames,
   onChange,
-  channelSelection
+  value
 }) => {
 
   const locale = useGeoStylerLocale('RgbChannelField');
 
   const onRedChannelChange = (red: string) => {
     let rgb: RGBChannel;
-    if (!channelSelection || (channelSelection && channelSelection.hasOwnProperty('grayChannel'))) {
+    if (!value || (value && value.hasOwnProperty('grayChannel'))) {
       rgb = {
         redChannel: {
           sourceChannelName: red
         }
       } as RGBChannel;
     } else {
-      rgb = _cloneDeep(channelSelection as RGBChannel);
+      rgb = _cloneDeep(value as RGBChannel);
       rgb.redChannel = {
         sourceChannelName: red
       };
@@ -78,14 +78,14 @@ export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
 
   const onGreenChannelChange = (green: string) => {
     let rgb: RGBChannel;
-    if (!channelSelection || (channelSelection && channelSelection.hasOwnProperty('grayChannel'))) {
+    if (!value || (value && value.hasOwnProperty('grayChannel'))) {
       rgb = {
         greenChannel: {
           sourceChannelName: green
         }
       } as RGBChannel;
     } else {
-      rgb = _cloneDeep(channelSelection as RGBChannel);
+      rgb = _cloneDeep(value as RGBChannel);
       rgb.greenChannel = {
         sourceChannelName: green
       };
@@ -97,14 +97,14 @@ export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
 
   const onBlueChannelChange = (blue: string) => {
     let rgb: RGBChannel;
-    if (!channelSelection || (channelSelection && channelSelection.hasOwnProperty('grayChannel'))) {
+    if (!value || (value && value.hasOwnProperty('grayChannel'))) {
       rgb = {
         blueChannel: {
           sourceChannelName: blue
         }
       } as RGBChannel;
     } else {
-      rgb = _cloneDeep(channelSelection as RGBChannel);
+      rgb = _cloneDeep(value as RGBChannel);
       rgb.blueChannel = {
         sourceChannelName: blue
       };
@@ -125,7 +125,7 @@ export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
         <SourceChannelNameField
           sourceChannelNames={sourceChannelNames}
           onChange={onRedChannelChange}
-          sourceChannelName={_get(channelSelection, 'redChannel.sourceChannelName')}
+          value={_get(value, 'redChannel.sourceChannelName')}
         />
       </Form.Item>
       <Form.Item
@@ -135,7 +135,7 @@ export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
         <SourceChannelNameField
           sourceChannelNames={sourceChannelNames}
           onChange={onGreenChannelChange}
-          sourceChannelName={_get(channelSelection, 'greenChannel.sourceChannelName')}
+          value={_get(value, 'greenChannel.sourceChannelName')}
         />
       </Form.Item>
       <Form.Item
@@ -145,7 +145,7 @@ export const RgbChannelField: React.FC<RgbChannelFieldProps> = ({
         <SourceChannelNameField
           sourceChannelNames={sourceChannelNames}
           onChange={onBlueChannelChange}
-          sourceChannelName={_get(channelSelection, 'blueChannel.sourceChannelName')}
+          value={_get(value, 'blueChannel.sourceChannelName')}
         />
       </Form.Item>
     </div>

--- a/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
+++ b/src/Component/Symbolizer/Field/RotateField/RotateField.tsx
@@ -34,7 +34,7 @@ import { Expression } from 'geostyler-style';
 type InputProps = NumberExpressionInputProps['inputProps'];
 
 export interface RotateFieldProps extends InputProps {
-  rotate?: Expression<number>;
+  value?: Expression<number>;
   onChange?: (newValue: Expression<number> | undefined) => void;
 }
 
@@ -43,7 +43,7 @@ export interface RotateFieldProps extends InputProps {
  */
 export const RotateField: React.FC<RotateFieldProps> = ({
   onChange,
-  rotate,
+  value,
   ...inputNumberProps
 }) => {
 
@@ -54,7 +54,7 @@ export const RotateField: React.FC<RotateFieldProps> = ({
   return (
     <NumberExpressionInput
       className="editor-field rotate-field"
-      value={rotate}
+      value={value}
       onChange={onChange}
       onCancel={onCancel}
       inputProps={{

--- a/src/Component/Symbolizer/Field/SaturationField/SaturationField.tsx
+++ b/src/Component/Symbolizer/Field/SaturationField/SaturationField.tsx
@@ -34,7 +34,7 @@ import { Expression } from 'geostyler-style';
 type InputProps = NumberExpressionInputProps['inputProps'];
 
 export interface SaturationFieldProps extends InputProps {
-  saturation?: Expression<number>;
+  value?: Expression<number>;
   onChange?: (newValue: Expression<number> | undefined) => void;
 }
 
@@ -43,7 +43,7 @@ export interface SaturationFieldProps extends InputProps {
  */
 export const SaturationField: React.FC<SaturationFieldProps> = ({
   onChange,
-  saturation,
+  value,
   ...inputNumberProps
 }) => {
 
@@ -54,7 +54,7 @@ export const SaturationField: React.FC<SaturationFieldProps> = ({
   return (
     <NumberExpressionInput
       className="editor-field saturation-field"
-      value={saturation}
+      value={value}
       onChange={onChange}
       onCancel={onCancel}
       inputProps={{

--- a/src/Component/Symbolizer/Field/SourceChannelNameField/SourceChannelNameField.tsx
+++ b/src/Component/Symbolizer/Field/SourceChannelNameField/SourceChannelNameField.tsx
@@ -43,7 +43,7 @@ interface SourceChannelNameFieldDefaultProps {
 export interface SourceChannelNameFieldProps extends Partial<SourceChannelNameFieldDefaultProps> {
   sourceChannelNames?: string[];
   onChange?: (sourceChannelName: string) => void;
-  sourceChannelName?: string;
+  value?: string;
 }
 
 /**
@@ -52,7 +52,7 @@ export interface SourceChannelNameFieldProps extends Partial<SourceChannelNameFi
 export const SourceChannelNameField: React.FC<SourceChannelNameFieldProps> = ({
   sourceChannelNames,
   onChange,
-  sourceChannelName,
+  value,
   placeholder = 'Name of band'
 }) => {
 
@@ -76,7 +76,7 @@ export const SourceChannelNameField: React.FC<SourceChannelNameFieldProps> = ({
           (
             <Select
               className="editor-field sourceChannelName-field"
-              value={sourceChannelName}
+              value={value}
               onChange={onChange}
             >
               {getSourceChannelNameSelectOptions()}
@@ -84,8 +84,8 @@ export const SourceChannelNameField: React.FC<SourceChannelNameFieldProps> = ({
           ) : (
             <Input
               className="editor-field sourceChannelName-field"
-              defaultValue={sourceChannelName}
-              value={sourceChannelName}
+              defaultValue={value}
+              value={value}
               placeholder={placeholder}
               onChange={(evt: any) => {
                 if (onChange) {

--- a/src/Component/Symbolizer/Field/SourceChannelNameField/SourceChannelNameField.tsx
+++ b/src/Component/Symbolizer/Field/SourceChannelNameField/SourceChannelNameField.tsx
@@ -34,13 +34,8 @@ import {
 } from 'antd';
 const Option = Select.Option;
 
-// default props
-interface SourceChannelNameFieldDefaultProps {
-  placeholder: string;
-}
-
-// non default props
-export interface SourceChannelNameFieldProps extends Partial<SourceChannelNameFieldDefaultProps> {
+export interface SourceChannelNameFieldProps {
+  placeholder?: string;
   sourceChannelNames?: string[];
   onChange?: (sourceChannelName: string) => void;
   value?: string;

--- a/src/Component/Symbolizer/Field/VisibilityField/VisibilityField.tsx
+++ b/src/Component/Symbolizer/Field/VisibilityField/VisibilityField.tsx
@@ -36,8 +36,8 @@ import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStyl
 
 type InputProps = BooleanExpressionInputProps['switchProps'];
 
-export interface VisibilityFieldProps extends InputProps {
-  visibility?: Expression<boolean>;
+export interface VisibilityFieldProps extends Omit<InputProps, 'value'> {
+  value?: Expression<boolean>;
   onChange?: (newValue: Expression<boolean>) => void;
 }
 
@@ -46,7 +46,7 @@ export interface VisibilityFieldProps extends InputProps {
  */
 export const VisibilityField: React.FC<VisibilityFieldProps> = ({
   onChange,
-  visibility,
+  value,
   ...inputBooleanProps
 }) => {
 
@@ -59,7 +59,7 @@ export const VisibilityField: React.FC<VisibilityFieldProps> = ({
   return (
     <BooleanExpressionInput
       className="editor-field visibility-field"
-      value={visibility === undefined ? true : visibility}
+      value={value === undefined ? true : value}
       onChange={onChange}
       onCancel={onCancel}
       switchProps={{...inputBooleanProps}}

--- a/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
+++ b/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
@@ -37,13 +37,8 @@ import _get from 'lodash/get';
 import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStylerContext';
 const Option = Select.Option;
 
-// default props
-interface WellKnownNameFieldDefaultProps {
-}
-
-// non default props
-export interface WellKnownNameFieldProps extends Partial<WellKnownNameFieldDefaultProps> {
-  wellKnownName?: WellKnownName;
+export interface WellKnownNameFieldProps {
+  value?: WellKnownName;
   wellKnownNames?: WellKnownName[];
   onChange?: (wellKnownName: WellKnownName) => void;
 }
@@ -53,7 +48,7 @@ export interface WellKnownNameFieldProps extends Partial<WellKnownNameFieldDefau
  */
 export const WellKnownNameField: React.FC<WellKnownNameFieldProps> = ({
   onChange,
-  wellKnownName = 'circle',
+  value = 'circle',
   wellKnownNames = ['circle', 'square', 'triangle', 'star', 'cross', 'x',
     'shape://backslash', 'shape://carrow', 'shape://dot',
     'shape://horline', 'shape://oarrow', 'shape://plus',
@@ -80,7 +75,7 @@ export const WellKnownNameField: React.FC<WellKnownNameFieldProps> = ({
   return (
     <Select
       className="editor-field wellknownname-field"
-      value={wellKnownName}
+      value={value}
       onChange={onChange}
     >
       {getWKNSelectOptions()}

--- a/src/Component/Symbolizer/FillEditor/FillEditor.tsx
+++ b/src/Component/Symbolizer/FillEditor/FillEditor.tsx
@@ -74,7 +74,7 @@ export interface FillEditorComposableProps {
   };
   outlineWidthField?: InputConfig<WidthFieldProps['value']>;
   // TODO add support for default values in VisibilityField
-  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
+  visibilityField?: InputConfig<VisibilityFieldProps['value']>;
   // TODO add support for graphicFill
 }
 
@@ -206,7 +206,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
                 label={locale.visibilityLabel}
               >
                 <VisibilityField
-                  visibility={visibility}
+                  value={visibility}
                   onChange={onVisibilityChange}
                 />
               </Form.Item>
@@ -310,7 +310,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
                 {...getFormItemSupportProps('outlineDasharray')}
               >
                 <LineDashField
-                  dashArray={outlineDasharray as number[]}
+                  value={outlineDasharray as number[]}
                   onChange={onOutlineDasharrayChange}
                 />
               </Form.Item>
@@ -321,7 +321,7 @@ export const FillEditor: React.FC<FillEditorProps> = (props) => {
           {/* TODO: allow changing graphicFill via composition context */}
           <GraphicEditor
             graphicTypeFieldLabel={locale.graphicFillTypeLabel}
-            graphic={graphicFill}
+            value={graphicFill}
             graphicType={_get(graphicFill, 'kind') as GraphicType}
             onGraphicChange={onGraphicChange}
           />

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.spec.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.spec.tsx
@@ -48,7 +48,7 @@ describe('GraphicEditor', () => {
   const dummyGraphicIcon: IconSymbolizer = SymbolizerUtil.iconSymbolizer;
   const onGraphicChangeSpy = vi.fn();
   const props: GraphicEditorProps = {
-    graphic: dummyGraphicMark,
+    value: dummyGraphicMark,
     graphicType: dummyGraphicType,
     onGraphicChange: onGraphicChangeSpy
   };
@@ -64,13 +64,13 @@ describe('GraphicEditor', () => {
   });
 
   it('renders MarkEditor if graphic is Mark', () => {
-    const graphicEditor = render(<GraphicEditor {...props} graphic={dummyGraphicMark} />);
+    const graphicEditor = render(<GraphicEditor {...props} value={dummyGraphicMark} />);
     const markEditor = graphicEditor.container.querySelector('.gs-mark-symbolizer-editor');
     expect(markEditor).toBeInTheDocument();
   });
 
   it('renders IconEditor if graphic is Icon', () => {
-    const graphicEditor = render(<GraphicEditor {...props} graphic={dummyGraphicIcon} />);
+    const graphicEditor = render(<GraphicEditor {...props} value={dummyGraphicIcon} />);
     const iconEditor = graphicEditor.container.querySelector('.gs-icon-symbolizer-editor');
     expect(iconEditor).toBeInTheDocument();
   });
@@ -80,7 +80,7 @@ describe('GraphicEditor', () => {
     const graphic: any = {};
     const graphicEditor = render(<GraphicEditor
       graphicType={graphicType}
-      graphic={graphic}
+      value={graphic}
     />);
     const markEditor = graphicEditor.container.querySelector('.gs-mark-symbolizer-editor');
     const iconEditor = graphicEditor.container.querySelector('.gs-icon-symbolizer-editor');

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -51,7 +51,7 @@ export interface GraphicEditorDefaultProps {
 // non default props
 export interface GraphicEditorProps extends Partial<GraphicEditorDefaultProps> {
   /** PointSymbolizer that is being used as graphic */
-  graphic: PointSymbolizer;
+  value: PointSymbolizer;
   /** Currently selected GraphicType */
   graphicType: GraphicType;
   /** Gets called when changing a graphic */
@@ -66,7 +66,7 @@ export interface GraphicEditorProps extends Partial<GraphicEditorDefaultProps> {
 /** GraphicEditor to select between different graphic options */
 export const GraphicEditor: React.FC<GraphicEditorProps> = ({
   graphicTypeFieldLabel = 'Graphic-Type',
-  graphic,
+  value,
   graphicType,
   onGraphicChange,
   graphicTypeFieldProps,
@@ -75,15 +75,15 @@ export const GraphicEditor: React.FC<GraphicEditorProps> = ({
 }) => {
 
   let graphicsField: React.ReactNode;
-  if (graphic?.kind === 'Mark') {
-    let markGraphic: MarkSymbolizer = graphic as MarkSymbolizer;
+  if (value?.kind === 'Mark') {
+    let markGraphic: MarkSymbolizer = value as MarkSymbolizer;
     graphicsField = <MarkEditor
       symbolizer={markGraphic}
       onSymbolizerChange={onGraphicChange}
     />;
-  } else if (graphic?.kind === 'Icon') {
+  } else if (value?.kind === 'Icon') {
     graphicsField =  <IconEditor
-      symbolizer={graphic}
+      symbolizer={value}
       onSymbolizerChange={onGraphicChange}
       iconLibraries={iconLibraries}
       {...iconEditorProps}
@@ -117,7 +117,7 @@ export const GraphicEditor: React.FC<GraphicEditorProps> = ({
         label={graphicTypeFieldLabel}
       >
         <GraphicTypeField
-          graphicType={graphicType}
+          value={graphicType}
           onChange={onGraphicTypeChange}
           {...graphicTypeFieldProps}
         />

--- a/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
+++ b/src/Component/Symbolizer/GraphicEditor/GraphicEditor.tsx
@@ -43,13 +43,9 @@ import { Form } from 'antd';
 import _get from 'lodash/get';
 import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
-export interface GraphicEditorDefaultProps {
+export interface GraphicEditorProps {
   /** Label being used on TypeField */
-  graphicTypeFieldLabel: string;
-}
-
-// non default props
-export interface GraphicEditorProps extends Partial<GraphicEditorDefaultProps> {
+  graphicTypeFieldLabel?: string;
   /** PointSymbolizer that is being used as graphic */
   value: PointSymbolizer;
   /** Currently selected GraphicType */

--- a/src/Component/Symbolizer/IconEditor/IconEditor.tsx
+++ b/src/Component/Symbolizer/IconEditor/IconEditor.tsx
@@ -62,12 +62,12 @@ export interface IconEditorComposableProps {
   sizeField?: {
     visibility?: boolean;
   };
-  offsetXField?: InputConfig<OffsetFieldProps['offset']>;
-  offsetYField?: InputConfig<OffsetFieldProps['offset']>;
-  rotateField?: InputConfig<RotateFieldProps['rotate']>;
+  offsetXField?: InputConfig<OffsetFieldProps['value']>;
+  offsetYField?: InputConfig<OffsetFieldProps['value']>;
+  rotateField?: InputConfig<RotateFieldProps['value']>;
   opacityField?: InputConfig<OpacityFieldProps['value']>;
   // TODO add support for default values in VisibilityField
-  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
+  visibilityField?: InputConfig<VisibilityFieldProps['value']>;
   iconLibraries?: IconLibrary[];
 }
 
@@ -187,7 +187,7 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
             label={locale.visibilityLabel}
           >
             <VisibilityField
-              visibility={visibility}
+              value={visibility}
               onChange={onVisibilityChange}
             />
           </Form.Item>
@@ -233,7 +233,7 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
             {...getFormItemSupportProps('offset')}
           >
             <OffsetField
-              offset={offset?.[0]}
+              value={offset?.[0]}
               defaultValue={offsetXField?.default as number}
               onChange={onOffsetXChange}
             />
@@ -248,7 +248,7 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
             {...getFormItemSupportProps('offset')}
           >
             <OffsetField
-              offset={offset?.[1]}
+              value={offset?.[1]}
               defaultValue={offsetYField?.default as number}
               onChange={onOffsetYChange}
             />
@@ -263,7 +263,7 @@ export const IconEditor: React.FC<IconEditorProps> = (props) => {
             {...getFormItemSupportProps('rotate')}
           >
             <RotateField
-              rotate={rotate}
+              value={rotate}
               defaultValue={rotateField?.default as number}
               onChange={onRotateChange}
             />

--- a/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
+++ b/src/Component/Symbolizer/IconSelectorWindow/IconSelectorWindow.tsx
@@ -39,7 +39,6 @@ import _isEqual from 'lodash/isEqual';
 import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
 
 
-// non default props
 export interface IconSelectorWindowProps extends Partial<ModalProps> {
   iconLibraries: IconLibrary[];
   selectedIconSrc?: string;

--- a/src/Component/Symbolizer/LineEditor/LineEditor.tsx
+++ b/src/Component/Symbolizer/LineEditor/LineEditor.tsx
@@ -69,13 +69,13 @@ const Panel = Collapse.Panel;
 export interface LineEditorComposableProps {
   colorField?: InputConfig<ColorFieldProps['value']>;
   widthField?: InputConfig<WidthFieldProps['value']>;
-  perpendicularOffsetField?: InputConfig<OffsetFieldProps['offset']>;
+  perpendicularOffsetField?: InputConfig<OffsetFieldProps['value']>;
   opacityField?: InputConfig<OpacityFieldProps['value']>;
   // TODO add support for default values in LineDashField
   lineDashField?: {
     visibility?: boolean;
   };
-  dashOffsetField?: InputConfig<OffsetFieldProps['offset']>;
+  dashOffsetField?: InputConfig<OffsetFieldProps['value']>;
   // TODO add support for default values in LineCapField
   capField?: {
     visibility?: boolean;
@@ -83,11 +83,11 @@ export interface LineEditorComposableProps {
   // TODO add support for default values in LineJoinField
   joinField?: InputConfig<LineJoinFieldProps['value']>;
   // TODO add support for default values in GraphicEditor
-  graphicStrokeField?: InputConfig<GraphicEditorProps['graphic']>;
+  graphicStrokeField?: InputConfig<GraphicEditorProps['value']>;
   // TODO add support for default values in GraphicEditor
-  graphicFillField?: InputConfig<GraphicEditorProps['graphic']>;
+  graphicFillField?: InputConfig<GraphicEditorProps['value']>;
   // TODO add support for default values in VisibilityField
-  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
+  visibilityField?: InputConfig<VisibilityFieldProps['value']>;
 }
 
 export interface LineEditorInternalProps {
@@ -240,7 +240,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
                 label={locale.visibilityLabel}
               >
                 <VisibilityField
-                  visibility={visibility}
+                  value={visibility}
                   onChange={onVisibilityChange}
                 />
               </Form.Item>
@@ -284,7 +284,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
                 {...getFormItemSupportProps('perpendicularOffset')}
               >
                 <OffsetField
-                  offset={perpendicularOffset}
+                  value={perpendicularOffset}
                   defaultValue={perpendicularOffsetField?.default as number}
                   onChange={onPerpendicularOffsetChange}
                 />
@@ -314,7 +314,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
                 {...getFormItemSupportProps('dasharray')}
               >
                 <LineDashField
-                  dashArray={dasharray as number[]}
+                  value={dasharray as number[]}
                   onChange={onDasharrayChange}
                 />
               </Form.Item>
@@ -328,7 +328,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
                 {...getFormItemSupportProps('dashOffset')}
               >
                 <OffsetField
-                  offset={dashOffset}
+                  value={dashOffset}
                   defaultValue={dashOffsetField?.default as number}
                   onChange={onDashOffsetChange}
                   disabled={
@@ -371,7 +371,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
           graphicStrokeField?.visibility === false ? null : (
             <Panel header="Graphic Stroke" key="2">
               <GraphicEditor
-                graphic={graphicStroke}
+                value={graphicStroke}
                 onGraphicChange={onGraphicStrokeChange}
                 graphicTypeFieldLabel={locale.graphicStrokeTypeLabel}
                 graphicType={_get(graphicStroke, 'kind') as GraphicType}
@@ -383,7 +383,7 @@ export const LineEditor: React.FC<LineEditorProps> = (props) => {
           graphicFillField?.visibility === false ? null : (
             <Panel header="Graphic Fill" key="3">
               <GraphicEditor
-                graphic={graphicFill}
+                value={graphicFill}
                 onGraphicChange={onGraphicFillChange}
                 graphicTypeFieldLabel={locale.graphicFillTypeLabel}
                 graphicType={_get(graphicFill, 'kind') as GraphicType}

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.tsx
@@ -56,7 +56,7 @@ export interface MarkEditorComposableProps {
     visibility?: boolean;
   };
   // TODO add support for default values in VisibilityField
-  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
+  visibilityField?: InputConfig<VisibilityFieldProps['value']>;
 }
 
 export interface MarkEditorInternalProps {
@@ -111,7 +111,7 @@ export const MarkEditor: React.FC<MarkEditorProps> = (props) => {
             label={locale.visibilityLabel}
           >
             <VisibilityField
-              visibility={symbolizer.visibility}
+              value={symbolizer.visibility}
               onChange={onVisibilityChange}
             />
           </Form.Item>
@@ -125,7 +125,7 @@ export const MarkEditor: React.FC<MarkEditorProps> = (props) => {
             {...getFormItemSupportProps('wellKnownName')}
           >
             <WellKnownNameField
-              wellKnownName={symbolizer.wellKnownName}
+              value={symbolizer.wellKnownName}
               onChange={onWellKnownNameChange}
             />
           </Form.Item>

--- a/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
+++ b/src/Component/Symbolizer/PropTextEditor/PropTextEditor.tsx
@@ -236,7 +236,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         label={locale.offsetXLabel}
       >
         <OffsetField
-          offset={offsetX}
+          value={offsetX}
           onChange={onOffsetXChange}
         />
       </Form.Item>
@@ -245,7 +245,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         label={locale.offsetYLabel}
       >
         <OffsetField
-          offset={offsetY}
+          value={offsetY}
           onChange={onOffsetYChange}
         />
       </Form.Item>
@@ -254,7 +254,7 @@ export const PropTextEditor: React.FC<PropTextEditorProps> = ({
         label={locale.rotateLabel}
       >
         <RotateField
-          rotate={rotate}
+          value={rotate}
           onChange={onRotateChange}
         />
       </Form.Item>

--- a/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
+++ b/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
@@ -163,7 +163,7 @@ export const RasterChannelEditor: React.FC<RasterChannelEditorProps> = (props) =
             <Select
               className="editor-field rgb-or-gray-field"
               allowClear={true}
-              value={rgbOrGray as 'rgb' | 'gray'}
+              value={rgbOrGray}
               onChange={onSelectionChange}
             >
               <Option

--- a/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
+++ b/src/Component/Symbolizer/RasterEditor/RasterEditor.tsx
@@ -71,12 +71,12 @@ export interface RasterEditorComposableProps {
   rasterChannelEditor?: {
     visibility?: boolean;
   };
-  gammaValueField?: InputConfig<GammaFieldProps['gamma']>;
+  gammaValueField?: InputConfig<GammaFieldProps['value']>;
   colorRamps?: {
     [name: string]: string[];
   };
   // TODO add support for default values in VisibilityField
-  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
+  visibilityField?: InputConfig<VisibilityFieldProps['value']>;
 }
 
 export interface RasterEditorInternalProps {
@@ -207,7 +207,7 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
                   label={locale.visibilityLabel}
                 >
                   <VisibilityField
-                    visibility={visibility}
+                    value={visibility}
                     onChange={onVisibilityChange}
                   />
                 </Form.Item>
@@ -238,7 +238,7 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
                   {...getFormItemSupportProps('contrastEnhancement')}
                 >
                   <ContrastEnhancementField
-                    contrastEnhancement={_get(contrastEnhancement, 'enhancementType')}
+                    value={_get(contrastEnhancement, 'enhancementType')}
                     onChange={onContrastEnhancementChange}
                   />
                 </Form.Item>
@@ -252,7 +252,7 @@ export const RasterEditor: React.FC<RasterEditorProps> = (props) => {
                   {...getFormItemSupportProps('contrastEnhancement')}
                 >
                   <GammaField
-                    gamma={_get(contrastEnhancement, 'gammaValue') as number}
+                    value={_get(contrastEnhancement, 'gammaValue') as number}
                     defaultValue={gammaValueField?.default}
                     onChange={onGammaValueChange}
                   />

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.tsx
@@ -39,8 +39,6 @@ import { Modal, ModalProps } from 'antd';
 import _isEqual from 'lodash/isEqual';
 import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
 
-
-// non default props
 export interface SymbolizerEditorWindowProps extends Partial<ModalProps> {
   symbolizers: Symbolizer[];
   onClose?: () => void;

--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -70,13 +70,13 @@ export interface TextEditorComposableProps {
   };
   opacityField?: InputConfig<OpacityFieldProps['value']>;
   sizeField?: InputConfig<SizeFieldProps['value']>;
-  offsetXField?: InputConfig<OffsetFieldProps['offset']>;
-  offsetYField?: InputConfig<OffsetFieldProps['offset']>;
-  rotateField?: InputConfig<RotateFieldProps['rotate']>;
+  offsetXField?: InputConfig<OffsetFieldProps['value']>;
+  offsetYField?: InputConfig<OffsetFieldProps['value']>;
+  rotateField?: InputConfig<RotateFieldProps['value']>;
   haloColorField?: InputConfig<ColorFieldProps['value']>;
   haloWidthField?: InputConfig<WidthFieldProps['value']>;
   // TODO add support for default values in VisibilityField
-  visibilityField?: InputConfig<VisibilityFieldProps['visibility']>;
+  visibilityField?: InputConfig<VisibilityFieldProps['value']>;
 }
 
 export interface TextEditorInternalProps {
@@ -248,7 +248,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
             label={locale.visibilityLabel}
           >
             <VisibilityField
-              visibility={visibility}
+              value={visibility}
               onChange={onVisibilityChange}
             />
           </Form.Item>
@@ -345,7 +345,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
             {...getFormItemSupportProps('offset')}
           >
             <OffsetField
-              offset={offsetX}
+              value={offsetX}
               defaultValue={offsetXField?.default as number}
               onChange={onOffsetXChange}
             />
@@ -360,7 +360,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
             {...getFormItemSupportProps('offset')}
           >
             <OffsetField
-              offset={offsetY}
+              value={offsetY}
               defaultValue={offsetYField?.default as number}
               onChange={onOffsetYChange}
             />
@@ -375,7 +375,7 @@ export const TextEditor: React.FC<TextEditorProps> = (props) => {
             {...getFormItemSupportProps('rotate')}
           >
             <RotateField
-              rotate={rotate as number}
+              value={rotate as number}
               defaultValue={rotateField?.default as number}
               onChange={onRotateChange}
             />

--- a/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
+++ b/src/Component/Symbolizer/WellKnownNameEditor/WellKnownNameEditor.tsx
@@ -50,16 +50,16 @@ import {
 import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
 export interface WellKnownNameEditorComposableProps {
-  radiusField?: InputConfig<RadiusFieldProps['radius']>;
-  offsetXField?: InputConfig<OffsetFieldProps['offset']>;
-  offsetYField?: InputConfig<OffsetFieldProps['offset']>;
+  radiusField?: InputConfig<RadiusFieldProps['value']>;
+  offsetXField?: InputConfig<OffsetFieldProps['value']>;
+  offsetYField?: InputConfig<OffsetFieldProps['value']>;
   fillColorField?: InputConfig<ColorFieldProps['value']>;
   opacityField?: InputConfig<OpacityFieldProps['value']>;
   fillOpacityField?: InputConfig<OpacityFieldProps['value']>;
   strokeColorField?: InputConfig<ColorFieldProps['value']>;
   strokeWidthField?: InputConfig<WidthFieldProps['value']>;
   strokeOpacityField?: InputConfig<OpacityFieldProps['value']>;
-  rotateField?: InputConfig<RotateFieldProps['rotate']>;
+  rotateField?: InputConfig<RotateFieldProps['value']>;
 }
 
 export interface WellKnownNameEditorInternalProps {
@@ -202,7 +202,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
             label={locale.radiusLabel}
           >
             <RadiusField
-              radius={radius}
+              value={radius}
               defaultValue={radiusField?.default as number}
               onChange={onRadiusChange}
             />
@@ -216,7 +216,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
             label={locale.offsetXLabel}
           >
             <OffsetField
-              offset={offset?.[0]}
+              value={offset?.[0]}
               defaultValue={offsetXField?.default as number}
               onChange={onOffsetXChange}
             />
@@ -230,7 +230,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
             label={locale.offsetYLabel}
           >
             <OffsetField
-              offset={offset?.[1]}
+              value={offset?.[1]}
               defaultValue={offsetYField?.default as number}
               onChange={onOffsetYChange}
             />
@@ -328,7 +328,7 @@ export const WellKnownNameEditor: React.FC<WellKnownNameEditorProps> = (props) =
             label={locale.rotateLabel}
           >
             <RotateField
-              rotate={rotate}
+              value={rotate}
               defaultValue={rotateField?.default as number}
               onChange={onRotateChange}
             />


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This refactors the props of the editor fields.

Most of the fields already had props like this: 
```
{
  value: string;
  onChange: (newValue: string) => void;
}
```
but some of the fields used to name the value field according to the type of the field like "radius", "color", ... 

This PR unifies this diffrences so all fields now have `value` as prop.
This PR also updates and unifies the declaration of default props for components to enhance the overview and readability.

:warning: As this updates a lot of component props this is considered as a breaking change.

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [x] Yes
- [ ] No
- [ ] I am unsure (no worries, we'll find out)

