### PR TITLE
chore: Pin chroma-js to 2.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/lodash": "^4.17.5",
         "@ungap/url-search-params": "^0.2.2",
         "antd": "^5.18.3",
-        "chroma-js": "^2.4.2",
+        "chroma-js": "2.4.2",
         "color": "^4.2.3",
         "csstype": "^3.1.3",
         "file-saver": "^2.0.5",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/lodash": "^4.17.5",
     "@ungap/url-search-params": "^0.2.2",
     "antd": "^5.18.3",
-    "chroma-js": "^2.4.2",
+    "chroma-js": "2.4.2",
     "color": "^4.2.3",
     "csstype": "^3.1.3",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

* chroma-js introduced breaking changes in newer versions after `2.4.2` which is currently specified in the package.json (^2.4.2).
* I reported the issue to chroma-js here: https://github.com/gka/chroma.js/issues/367 
* Projects depending on geostyler cannot be build currently as the `^` is allowing newer minor versions of chroma-js (despite using e.g. version resolution from yarn: https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/)
* Renovate had also issues with it: https://github.com/geostyler/geostyler/pull/2519

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

