### PR TITLE
Updates `PreviewMap` to use spatialreference.org

### DIFF
--- a/src/Component/PreviewMap/PreviewMap.example.md
+++ b/src/Component/PreviewMap/PreviewMap.example.md
@@ -32,7 +32,20 @@ This demonstrates the usage of the `PreviewMap` component.
 
 ```jsx
 import React, { useState } from 'react';
-import { PreviewMap } from 'geostyler';
+import { GeoStylerContext, PreviewMap } from 'geostyler';
+
+import Map from 'ol/Map.js';
+import View from 'ol/View.js';
+import TileLayer from 'ol/layer/Tile.js';
+import OSM from 'ol/source/OSM.js';
+
+const map = new Map({
+  layers: [
+    new TileLayer({
+      source: new OSM(),
+    }),
+  ]
+});
 
 const PreviewMapExample = () => {
   const [style, setStyle] = useState({
@@ -51,47 +64,53 @@ const PreviewMapExample = () => {
           ]
         });
 
-  return (
-    <PreviewMap
-      style={style}
-      dataProjection="EPSG:32614"
-      data={{
-        schema: {
-          type: '',
-          properties: {}
-        },
-        exampleFeatures: {
-          type: 'FeatureCollection',
-          name: 'geojson32614',
-          features: [
-            {
-              type: 'Feature',
-              properties: { },
-              geometry: {
-                type: 'Point',
-                coordinates: [ 785433.013395566958934, 2032298.458539120620117 ]
-              }
-            },
-            {
-              type: 'Feature',
-              properties: { },
-              geometry: {
-                type: 'Point',
-                coordinates: [ 787905.450309246662073, 2030118.025881822220981 ]
-              }
-            },
-            {
-              type: 'Feature',
-              properties: { },
-              geometry: {
-                type: 'Point',
-                coordinates: [ 786123.196085085393861, 2028597.680797176202759 ]
-              }
+  const myContext = {
+    data: {
+      schema: {
+        type: '',
+        properties: {}
+      },
+      exampleFeatures: {
+        type: 'FeatureCollection',
+        name: 'geojson32614',
+        features: [
+          {
+            type: 'Feature',
+            properties: { },
+            geometry: {
+              type: 'Point',
+              coordinates: [ 785433.013395566958934, 2032298.458539120620117 ]
             }
-          ]
-        }
-      }}
-    />
+          },
+          {
+            type: 'Feature',
+            properties: { },
+            geometry: {
+              type: 'Point',
+              coordinates: [ 787905.450309246662073, 2030118.025881822220981 ]
+            }
+          },
+          {
+            type: 'Feature',
+            properties: { },
+            geometry: {
+              type: 'Point',
+              coordinates: [ 786123.196085085393861, 2028597.680797176202759 ]
+            }
+          }
+        ]
+      }
+    }
+  };
+
+  return (
+    <GeoStylerContext.Provider value={myContext}>
+      <PreviewMap
+        style={style}
+        map={map}
+        dataProjection="EPSG:32614"
+      />
+    </GeoStylerContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Description

This updates the `PreviewMap` to get the projection definition from spatialreference.org instead of epsg.io.

It also fixes the example by making use of the `GeoStylerContext` and adding a background layer.

This fixes #2535 

## Preview

![image](https://github.com/user-attachments/assets/a9122cfd-5824-46be-abed-a8bc3b1b8bd4)


## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

