### PR TITLE
fix: cleanup ol instance when destroying <OlRenderer>

### DIFF
--- a/src/Component/Renderer/OlRenderer/OlRenderer.tsx
+++ b/src/Component/Renderer/OlRenderer/OlRenderer.tsx
@@ -49,7 +49,6 @@ import 'ol/ol.css';
 
 import _isEqual from 'lodash/isEqual';
 import _get from 'lodash/get';
-import _uniqueId from 'lodash/uniqueId';
 import placeholder from './placeholder';
 import { InfoCircleTwoTone } from '@ant-design/icons';
 import { Tooltip } from 'antd';
@@ -72,8 +71,8 @@ export const OlRenderer: React.FC<OlRendererProps> = ({
 
   /** reference to the underlying OpenLayers map */
   const map = useRef<OlMap>();
+  const mapEl = useRef(null);
   const layer = useRef<OlLayerVector<any>>();
-  const [ mapId ] = useState(_uniqueId('map_'));
   const [containsFunctions, setContainsFunctions] = useState(false);
 
   const locale = useGeoStylerLocale('Renderer');
@@ -114,6 +113,10 @@ export const OlRenderer: React.FC<OlRendererProps> = ({
   }, [getSampleGeomFromSymbolizer]);
 
   useEffect(() => {
+    if (!mapEl.current) {
+      return undefined;
+    }
+
     layer.current = new OlLayerVector({
       source: new OlSourceVector<OlFeatureLike>()
     });
@@ -121,12 +124,18 @@ export const OlRenderer: React.FC<OlRendererProps> = ({
       layers: [layer.current],
       controls: [],
       interactions: [],
-      target: mapId,
+      target: mapEl.current,
       view: new OlView({
         projection: 'EPSG:4326'
       })
     });
-  }, [mapId]);
+
+    return () => {
+      if (map.current) {
+        map.current.setTarget(undefined);
+      }
+    };
+  }, [mapEl]);
 
   useEffect(() => {
     updateFeature();
@@ -223,7 +232,7 @@ export const OlRenderer: React.FC<OlRendererProps> = ({
 
   return (
     <div
-      id={mapId}
+      ref={mapEl}
       className="gs-symbolizer-olrenderer"
       role="presentation"
       onClick={(event) => {


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This cleans up the ol instance when destroying `<OlRenderer>`. This impurity became visible by using GeoStyler with react's StrictMode.

before:

![image](https://github.com/user-attachments/assets/c8690336-0c56-47ec-91f9-46d13eb2ac90)

after:

![image](https://github.com/user-attachments/assets/376c28a6-6377-4572-ad38-c4bdba79b36b)


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

