### PR TITLE
Adds postbuild script to add file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
   ],
   "homepage": "https://github.com/geostyler/geostyler",
   "scripts": {
+    "build": "npm run build-package && npm run build-styleguide",
     "build-package": "npm run build-browser && tsc && npm run build-dist",
-    "build-dist": "tsc -p ./ && copyfiles \"./src/**/*.css\" dist --up 1",
+    "build-dist": "tsc -p ./ && copyfiles \"./src/**/*.css\" dist --up 1 && node scripts/add-extensions.js",
     "build-styleguide": "styleguidist build --config styleguide.config.cjs",
     "build-browser": "vite build",
     "browser-sample": "npx http-server . -o /public/browser.html",
@@ -51,8 +52,7 @@
     "test-ci": "NODE_OPTIONS=--import=extensionless/register vitest --coverage",
     "test-watch": "NODE_OPTIONS=--import=extensionless/register vitest",
     "start-dev": "vite -c vite.dev.config.ts",
-    "preview": "vite preview",
-    "build": "npm run build-package && npm run build-styleguide"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@ant-design/icons": "^5.5.1",

--- a/scripts/add-extensions.js
+++ b/scripts/add-extensions.js
@@ -1,0 +1,90 @@
+/* Released under the BSD 2-Clause License
+ *
+ * Copyright © 2018-present, terrestris GmbH & Co. KG and GeoStyler contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice,
+ *   this list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This script adds .js extensions to all local imports in the compiled JavaScript files.
+ * It is used as a post-build step to ensure proper module resolution in ESM environments.
+ *
+ * The script:
+ * 1. Recursively finds all .js files in the dist directory
+ * 2. For each file, it looks for import/export statements with relative paths
+ * 3. Adds .js extension to these paths if they don't already have it
+ * 4. Preserves the original file if no changes are needed
+ */
+import { readdir, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const distDir = join(__dirname, '..', 'dist');
+
+async function* getFiles(dir) {
+  const dirents = await readdir(dir, { withFileTypes: true });
+  for (const dirent of dirents) {
+    const res = join(dir, dirent.name);
+    if (dirent.isDirectory()) {
+      yield* getFiles(res);
+    } else if (dirent.name.endsWith('.js')) {
+      yield res;
+    }
+  }
+}
+
+async function addExtensions() {
+  for await (const filePath of getFiles(distDir)) {
+    let content = await readFile(filePath, 'utf8');
+
+    const exportMatches = content.matchAll(/export\s*{[^}]+}\s*from\s*['"]([^'"]+)['"]/g);
+    for (const match of Array.from(exportMatches)) {
+      const [fullMatch, importPath] = match;
+      if (importPath.startsWith('.') && !importPath.endsWith('.js')) {
+        content = content.replace(fullMatch, fullMatch.replace(importPath, `${importPath}.js`));
+      }
+    }
+
+    const importMatches = content.matchAll(/import\s*{[^}]+}\s*from\s*['"]([^'"]+)['"]/g);
+    for (const match of Array.from(importMatches)) {
+      const [fullMatch, importPath] = match;
+      if (importPath.startsWith('.') && !importPath.endsWith('.js')) {
+        content = content.replace(fullMatch, fullMatch.replace(importPath, `${importPath}.js`));
+      }
+    }
+
+    const singleExportMatches = content.matchAll(/export\s*{\s*(\w+)\s*}\s*from\s*['"]([^'"]+)['"]/g);
+    for (const match of Array.from(singleExportMatches)) {
+      const [fullMatch, , importPath] = match;
+      if (importPath.startsWith('.') && !importPath.endsWith('.js')) {
+        content = content.replace(fullMatch, fullMatch.replace(importPath, `${importPath}.js`));
+      }
+    }
+
+    await writeFile(filePath, content);
+  }
+}
+
+addExtensions().catch(console.error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "inlineSources": true,
     "allowJs": false,
     "jsx": "react",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "bundler",
     "rootDir": "src",
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This adds a postbuild script that adds file extensions to the import pathes in the build output. Unfortunately there is no option in TypeScript where you can have imports without file extensions in the source code, but with file extensions in the build output.

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

