### PR TITLE
fix: default cursor on non clickable renderers

### DIFF
--- a/src/Component/RuleTable/RuleTable.css
+++ b/src/Component/RuleTable/RuleTable.css
@@ -39,6 +39,7 @@
     .ant-input-number,
     .gs-symbolizer-olrenderer {
       border-radius: 0;
+      cursor: default;
     }
 
     .ant-input-search {

--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.css
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.css
@@ -33,5 +33,10 @@
   
   .gs-renderer {
     margin-bottom: 15px;
+    
+    .gs-symbolizer-olrenderer {
+      border-radius: 0;
+      cursor: default;
+    }
   }
 }


### PR DESCRIPTION
## Description

Put the default cursor on the symbolizer renderer when not clickable : 

* in the RuleTable
* in the Symbolizer Editor Window

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

