### PR TITLE
Update geostyler-sld-parser to version 8.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "geostyler-mapbox-parser": "^6.1.1",
         "geostyler-openlayers-parser": "^5.1.2",
         "geostyler-qgis-parser": "^4.0.2",
-        "geostyler-sld-parser": "^8.0.1",
+        "geostyler-sld-parser": "^8.1.0",
         "geostyler-style": "^10.3.0",
         "geostyler-wfs-parser": "^3.0.1",
         "lodash-es": "^4.17.21",
@@ -13212,13 +13212,13 @@
       }
     },
     "node_modules/geostyler-sld-parser": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/geostyler-sld-parser/-/geostyler-sld-parser-8.0.1.tgz",
-      "integrity": "sha512-sSNWCTgNTE/9Ce4JLtN+B4aVdDqAPmnyXncBT9TVZfaSIzrAyCdQVsyiHjEYKsBeT8K9NqMpch9ytUY/NLV7mA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/geostyler-sld-parser/-/geostyler-sld-parser-8.1.0.tgz",
+      "integrity": "sha512-9iDxWAR2nkkhMgBcAe+XgbmDdw36OdTEyGfXZcac5d7XbK8/KGZbxcKiQRiE9/+gPtFGIoc5+PSjjgWoJHMaaw==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "fast-xml-parser": "^5.2.3",
-        "geostyler-style": "^10.2.0",
+        "geostyler-style": "^10.3.0",
         "lodash": "^4.17.21"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "geostyler-mapbox-parser": "^6.1.1",
     "geostyler-openlayers-parser": "^5.1.2",
     "geostyler-qgis-parser": "^4.0.2",
-    "geostyler-sld-parser": "^8.0.1",
+    "geostyler-sld-parser": "^8.1.0",
     "geostyler-style": "^10.3.0",
     "geostyler-wfs-parser": "^3.0.1",
     "lodash-es": "^4.17.21",


### PR DESCRIPTION
Upgrade the geostyler-sld-parser dependency to version 8.1.0 to incorporate the latest features and improvements.