### PR TITLE
fix: height renderer in symbolizer editor

### DIFF
--- a/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.css
+++ b/src/Component/Symbolizer/SymbolizerEditorWindow/SymbolizerEditorWindow.css
@@ -37,6 +37,7 @@
     .gs-symbolizer-olrenderer {
       border-radius: 0;
       cursor: default;
+      height: 100px;
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description
correction of the height of renderer in symbolizer editor
<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

