### PR TITLE
feat: add option to disable name #2618

### DIFF
--- a/src/Component/NameField/NameField.tsx
+++ b/src/Component/NameField/NameField.tsx
@@ -38,8 +38,6 @@ export interface NameFieldProps {
   placeholder?: string;
   /** The value to display in input field */
   value?: string | undefined;
-  /** Is it disabled or not */
-  disabled?: boolean;
   /** The callback method that is triggered when the state changes */
   onChange?: (newValue: string) => void;
 }

--- a/src/Component/NameField/NameField.tsx
+++ b/src/Component/NameField/NameField.tsx
@@ -49,7 +49,6 @@ export interface NameFieldProps {
  */
 export const NameField: React.FC<NameFieldProps> = ({
   value,
-  disabled = false,
   placeholder = 'Enter Name',
   onChange: onChangeProp
 }) => {
@@ -67,7 +66,6 @@ export const NameField: React.FC<NameFieldProps> = ({
   return (
     <Input
       className="gs-namefield"
-      disabled={disabled}
       value={value}
       onChange={onChange}
       placeholder={placeholder}

--- a/src/Component/NameField/NameField.tsx
+++ b/src/Component/NameField/NameField.tsx
@@ -38,6 +38,8 @@ export interface NameFieldProps {
   placeholder?: string;
   /** The value to display in input field */
   value?: string | undefined;
+  /** Is it disabled or not */
+  disabled?: boolean;
   /** The callback method that is triggered when the state changes */
   onChange?: (newValue: string) => void;
 }
@@ -47,6 +49,7 @@ export interface NameFieldProps {
  */
 export const NameField: React.FC<NameFieldProps> = ({
   value,
+  disabled = false,
   placeholder = 'Enter Name',
   onChange: onChangeProp
 }) => {
@@ -64,6 +67,7 @@ export const NameField: React.FC<NameFieldProps> = ({
   return (
     <Input
       className="gs-namefield"
+      disabled={disabled}
       value={value}
       onChange={onChange}
       placeholder={placeholder}

--- a/src/Component/Style/Style.example.md
+++ b/src/Component/Style/Style.example.md
@@ -105,6 +105,66 @@ class StyleExample extends React.Component {
 <StyleExample />
 ```
 
+This demonstrates the use of `Style` with name disabled.
+
+```jsx
+import React from 'react';
+import { Style } from 'geostyler';
+
+import { Switch } from 'antd';
+
+class StyleExample extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      style: {
+        "name": "Demo Style",
+        "rules": [
+          {
+            "name": "Rule 1",
+            "symbolizers": [
+              {
+                "kind": "Mark",
+                "wellKnownName": "circle"
+              }
+            ]
+          }
+        ]
+      }
+    };
+
+    this.onStyleChange = this.onStyleChange.bind(this);
+  }
+
+  onStyleChange(style) {
+    this.setState({
+      style: style
+    });
+  }
+
+  render() {
+    const {
+      style
+    } = this.state;
+
+    return (
+      <div>
+        <hr/>
+        <Style
+          style={style}
+          disableName={true}
+          onStyleChange={this.onStyleChange}
+        />
+      </div>
+    );
+  }
+
+}
+
+<StyleExample />
+```
+
 This demonstrates the use of `Style`, customized using `GeoStylerContext` (multi edit disabled).
 
 ```jsx
@@ -154,7 +214,6 @@ function StyleExample() {
     </GeoStylerContext.Provider>
   );
 }
-
 
 <StyleExample />
 ```

--- a/src/Component/Style/Style.example.md
+++ b/src/Component/Style/Style.example.md
@@ -105,7 +105,7 @@ class StyleExample extends React.Component {
 <StyleExample />
 ```
 
-This demonstrates the use of `Style` with name disabled.
+This demonstrates the use of `Style`, customized using `GeoStylerContext` (name disabled).
 
 ```jsx
 import React from 'react';

--- a/src/Component/Style/Style.example.md
+++ b/src/Component/Style/Style.example.md
@@ -105,61 +105,45 @@ class StyleExample extends React.Component {
 <StyleExample />
 ```
 
-This demonstrates the use of `Style`, customized using `GeoStylerContext` (name disabled).
+This demonstrates the use of `Style`, customized using `GeoStylerContext` (name not visible).
 
 ```jsx
-import React from 'react';
-import { Style } from 'geostyler';
+import { GeoStylerContext, Style } from 'geostyler';
+import { Style as GsStyle } from 'geostyler-style';
 
-import { Switch } from 'antd';
+function StyleExample() {
+  const myContext = {
+    composition: {
+      Style: {
+        nameField: {
+          visibility: false
+        }
+      }
+    }
+  };
 
-class StyleExample extends React.Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      style: {
-        "name": "Demo Style",
-        "rules": [
+  const style = {
+    'name': 'Demo Style',
+    'rules': [
+      {
+        'name': 'Rule 1',
+        'symbolizers': [
           {
-            "name": "Rule 1",
-            "symbolizers": [
-              {
-                "kind": "Mark",
-                "wellKnownName": "circle"
-              }
-            ]
+            'kind': 'Mark',
+            'wellKnownName': 'circle'
           }
         ]
       }
-    };
+    ]
+  };
 
-    this.onStyleChange = this.onStyleChange.bind(this);
-  }
-
-  onStyleChange(style) {
-    this.setState({
-      style: style
-    });
-  }
-
-  render() {
-    const {
-      style
-    } = this.state;
-
-    return (
-      <div>
-        <hr/>
-        <Style
-          style={style}
-          disableName={true}
-          onStyleChange={this.onStyleChange}
-        />
-      </div>
-    );
-  }
-
+  return (
+    <GeoStylerContext.Provider value={myContext}>
+      <Style
+        style={style}
+      />
+    </GeoStylerContext.Provider>
+  );
 }
 
 <StyleExample />

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -63,6 +63,7 @@ import './Style.css';
 import { ItemType } from 'antd/es/menu/interface';
 
 export interface StyleComposableProps {
+  // TODO add support for default values in nameField
   nameField?: {
     visibility?: boolean;
   };

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -63,10 +63,12 @@ import './Style.css';
 import { ItemType } from 'antd/es/menu/interface';
 
 export interface StyleComposableProps {
+  nameField?: {
+    visibility?: boolean;
+  };
   /** Should the classification be disabled */
   disableClassification?: boolean;
   disableMultiEdit?: boolean;
-  disableName?: boolean;
 }
 
 export interface StyleInternalProps {
@@ -85,9 +87,9 @@ export const Style: React.FC<StyleProps> = (props) => {
   const composition = useGeoStylerComposition('Style');
   const composed = { ...props, ...composition };
   const {
+    nameField,
     disableClassification = false,
     disableMultiEdit = false,
-    disableName = false,
     style: styleProp = {
       name: 'My Style',
       rules: []
@@ -379,16 +381,19 @@ export const Style: React.FC<StyleProps> = (props) => {
   return (
     <div className="gs-style" >
       <div className="gs-style-name-classification-row">
-        <Form.Item
-          label={locale.nameFieldLabel}
-        >
-          <NameField
-            value={style.name}
-            disabled={disableName}
-            onChange={onNameChange}
-            placeholder={locale.nameFieldPlaceholder}
-          />
-        </Form.Item>
+        {
+          nameField?.visibility === false ? null : (
+            <Form.Item
+              label={locale.nameFieldLabel}
+            >
+              <NameField
+                value={style.name}
+                onChange={onNameChange}
+                placeholder={locale.nameFieldPlaceholder}
+              />
+            </Form.Item>
+          )
+        }
         {
           // TODO: Rule GeneratorWindow should only be available if data is VectorData
           !disableClassification &&

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -64,6 +64,7 @@ import { ItemType } from 'antd/es/menu/interface';
 
 export interface StyleComposableProps {
   // TODO add support for default values in nameField
+  // TODO add support for default values in nameField
   nameField?: {
     visibility?: boolean;
   };

--- a/src/Component/Style/Style.tsx
+++ b/src/Component/Style/Style.tsx
@@ -65,7 +65,8 @@ import { ItemType } from 'antd/es/menu/interface';
 export interface StyleComposableProps {
   /** Should the classification be disabled */
   disableClassification?: boolean;
-  disableMultiEdit: boolean;
+  disableMultiEdit?: boolean;
+  disableName?: boolean;
 }
 
 export interface StyleInternalProps {
@@ -86,6 +87,7 @@ export const Style: React.FC<StyleProps> = (props) => {
   const {
     disableClassification = false,
     disableMultiEdit = false,
+    disableName = false,
     style: styleProp = {
       name: 'My Style',
       rules: []
@@ -382,6 +384,7 @@ export const Style: React.FC<StyleProps> = (props) => {
         >
           <NameField
             value={style.name}
+            disabled={disableName}
             onChange={onNameChange}
             placeholder={locale.nameFieldPlaceholder}
           />


### PR DESCRIPTION
## Description

We have an use case where we don't want to let the user change the name of the style and handle it ourselves (because the name of the style must correspond to the name of the data). 
I've added disableName (optional) in StyleComposableProps, false by default in Style
This option disable or not the name input of the style.

## No breaking change

