### PR TITLE
Add browser build to package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 # production
 /dist
 /build
-/dist
 /browser
 
 # history

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "dist/index.d.ts",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "browser"
   ],
   "repository": {
     "type": "git",

--- a/vite.browser.config.ts
+++ b/vite.browser.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   build: {
+    outDir: 'browser',
     manifest: true,
     lib: {
       entry: './src/index.ts',


### PR DESCRIPTION
Include the browser build output directory in the package configuration and update the build settings accordingly.