### PR TITLE
Update browser build configuration

### DIFF
--- a/vite.browser.config.ts
+++ b/vite.browser.config.ts
@@ -13,10 +13,24 @@ export default defineConfig({
       formats: ['iife'],
       fileName: 'geostyler',
     },
-    sourcemap: true,
+    // Sourcemaps are not needed for the browser build
+    sourcemap: false,
+    rollupOptions: {
+      external: [
+        'react',
+        'react-dom'
+      ],
+      output: {
+        globals: {
+          react: 'React',
+          'react-dom': 'ReactDOM'
+        }
+      }
+    }
   },
   define: {
-    appName: 'GeoStyler'
+    appName: 'GeoStyler',
+    "process.env.NODE_ENV": '"production"'
   },
   server: {
     host: '0.0.0.0'


### PR DESCRIPTION
Adjust the browser build configuration to disable sourcemaps and define react and react-dom as external dependencies. Set the production environment variable for the application.