### PR TITLE
fix: use monaco-editor as npm package

### DIFF
--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -34,7 +34,8 @@ import React, {
   useState
 } from 'react';
 
-import { Editor, useMonaco } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+import { loader, Editor, useMonaco } from '@monaco-editor/react';
 
 import {
   saveAs
@@ -102,6 +103,8 @@ type FileFormat = {
   extension: FileExtension;
   mimeType: MimeType;
 };
+
+loader.config({ monaco });
 
 const MODELPATH = 'geostyler.json'; // associate with our model
 const SCHEMAURI = schema.$id;


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This uses the monaco-editor as an npm-package instead of loading it from a CDN, which is the default behaviour.

This fixes https://github.com/geostyler/geostyler/issues/2345

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

