### PR TITLE
Explicitly remove outputFormat parameter from DescribeFeatureType request

### DIFF
--- a/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
+++ b/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
@@ -150,7 +150,10 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
         maxFeatures,
         featureID,
         propertyName,
-        srsName
+        srsName,
+        // this forces the app to send no outputFormat parameter in the request
+        // this is required to get a correct XML DescribeFeatureType response from GeoServer
+        outputFormat: null,
       };
     } else {
       requestParams = {
@@ -159,12 +162,16 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
         count: maxFeatures,
         featureID,
         propertyName,
-        srsName
+        srsName,
+        // this forces the app to send no outputFormat parameter in the request
+        // this is required to get a correct XML DescribeFeatureType response from GeoServer
+        outputFormat: null,
       };
     }
     onClickProp({
       url,
-      requestParams
+      requestParams,
+      // fetchParams: {headers: {'accept': 'application/xml'}},
     });
   };
 


### PR DESCRIPTION
A Geostyler server will not integrate correctly with a standalone instance of geoserver.

This is because by default geoserver will return a json style description which cannot be parser by geostyler.

Via this fix, no output format is requested explicitly, then geoserver responds with valid XML

<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] I am unsure (no worries, we'll find out)

