### PR TITLE
Upgrade Ant Design to v6 and refactor components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "18.3.1",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@ant-design/icons": "^5.5.1",
+        "@ant-design/icons": "^6.1.0",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -20,7 +20,7 @@
         "@types/geojson": "^7946.0.14",
         "@types/lodash": "^4.17.5",
         "@ungap/url-search-params": "^0.2.2",
-        "antd": "^5.25.4",
+        "antd": "^6.3.0",
         "chroma-js": "3.2.0",
         "color": "^4.2.3",
         "csstype": "^3.1.3",
@@ -182,26 +182,26 @@
       "license": "MIT"
     },
     "node_modules/@ant-design/colors": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.2.1.tgz",
-      "integrity": "sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-8.0.1.tgz",
+      "integrity": "sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==",
       "license": "MIT",
       "dependencies": {
-        "@ant-design/fast-color": "^2.0.6"
+        "@ant-design/fast-color": "^3.0.0"
       }
     },
     "node_modules/@ant-design/cssinjs": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-1.23.0.tgz",
-      "integrity": "sha512-7GAg9bD/iC9ikWatU9ym+P9ugJhi/WbsTWzcKN6T4gU0aehsprtke1UAaaSxxkjjmkJb3llet/rbUSLPgwlY4w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs/-/cssinjs-2.1.0.tgz",
+      "integrity": "sha512-eZFrPCnrYrF3XtL7qA4L75P0qA3TtZta8H3Yggy7UYFh8gZgu5bSMNF+v4UVCzGxzYmx8ZvPdgOce0BJ6PsW9g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "@emotion/hash": "^0.8.0",
         "@emotion/unitless": "^0.7.5",
-        "classnames": "^2.3.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1",
         "csstype": "^3.1.3",
-        "rc-util": "^5.35.0",
         "stylis": "^4.3.4"
       },
       "peerDependencies": {
@@ -210,43 +210,48 @@
       }
     },
     "node_modules/@ant-design/cssinjs-utils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-1.1.3.tgz",
-      "integrity": "sha512-nOoQMLW1l+xR1Co8NFVYiP8pZp3VjIIzqV6D6ShYF2ljtdwWJn5WSsH+7kvCktXL/yhEtWURKOfH5Xz/gzlwsg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/cssinjs-utils/-/cssinjs-utils-2.1.1.tgz",
+      "integrity": "sha512-RKxkj5pGFB+FkPJ5NGhoX3DK3xsv0pMltha7Ei1AnY3tILeq38L7tuhaWDPQI/5nlPxOog44wvqpNyyGcUsNMg==",
       "license": "MIT",
       "dependencies": {
-        "@ant-design/cssinjs": "^1.21.0",
+        "@ant-design/cssinjs": "^2.1.0",
         "@babel/runtime": "^7.23.2",
-        "rc-util": "^5.38.0"
+        "@rc-component/util": "^1.4.0"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@ant-design/cssinjs/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@ant-design/fast-color": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-2.0.6.tgz",
-      "integrity": "sha512-y2217gk4NqL35giHl72o6Zzqji9O7vHh9YmhUVkPtAOpoTCH4uWxo/pr4VE8t0+ChEPs0qo4eJRC5Q1eXWo3vA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/fast-color/-/fast-color-3.0.1.tgz",
+      "integrity": "sha512-esKJegpW4nckh0o6kV3Tkb7NPIZYbPnnFxmQDUmL08ukXZAvV85TZBr70eGuke/CIArLaP6aw8lt9KILjnWuOw==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.7"
-      },
       "engines": {
         "node": ">=8.x"
       }
     },
     "node_modules/@ant-design/icons": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.6.1.tgz",
-      "integrity": "sha512-0/xS39c91WjPAZOWsvi1//zjx6kAp4kxWwctR6kuU6p133w8RU0D2dSCvZC19uQyharg/sAvYxGYWl01BbZZfg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-6.1.0.tgz",
+      "integrity": "sha512-KrWMu1fIg3w/1F2zfn+JlfNDU8dDqILfA5Tg85iqs1lf8ooyGlbkA+TkwfOKKgqpUmAiRY1PTFpuOU2DAIgSUg==",
       "license": "MIT",
       "dependencies": {
-        "@ant-design/colors": "^7.0.0",
+        "@ant-design/colors": "^8.0.0",
         "@ant-design/icons-svg": "^4.4.0",
-        "@babel/runtime": "^7.24.8",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.31.1"
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -262,20 +267,38 @@
       "integrity": "sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==",
       "license": "MIT"
     },
+    "node_modules/@ant-design/icons/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@ant-design/react-slick": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-1.1.2.tgz",
-      "integrity": "sha512-EzlvzE6xQUBrZuuhSAFTdsr4P2bBBHGZwKFemEfq8gIGyIQCxalYfZW/T2ORbtQx5rU69o+WycP3exY/7T1hGA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/react-slick/-/react-slick-2.0.0.tgz",
+      "integrity": "sha512-HMS9sRoEmZey8LsE/Yo6+klhlzU12PisjrVcydW3So7RdklyEd2qehyU6a7Yp+OYN72mgsYs3NFCyP2lCPFVqg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "classnames": "^2.2.5",
+        "@babel/runtime": "^7.28.4",
+        "clsx": "^2.1.1",
         "json2mq": "^0.2.0",
-        "resize-observer-polyfill": "^1.5.1",
         "throttle-debounce": "^5.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.9.0"
+        "react": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ant-design/react-slick/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -330,6 +353,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2644,6 +2668,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2667,6 +2692,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2688,6 +2714,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -4432,6 +4459,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4646,9 +4674,9 @@
       }
     },
     "node_modules/@rc-component/async-validator": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.0.4.tgz",
-      "integrity": "sha512-qgGdcVIF604M9EqjNF0hbUTz42bz/RDtxWdWuU5EQe3hi7M8ob54B6B35rOsvX5eSvIHIzT9iH1R3n+hk3CGfg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/async-validator/-/async-validator-5.1.0.tgz",
+      "integrity": "sha512-n4HcR5siNUXRX23nDizbZBQPO0ZM/5oTtmKZ6/eqL0L2bo747cklFdZGRN2f+c9qWGICwDzrhW0H7tE9PptdcA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.4"
@@ -4657,34 +4685,340 @@
         "node": ">=14.x"
       }
     },
-    "node_modules/@rc-component/color-picker": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-2.0.1.tgz",
-      "integrity": "sha512-WcZYwAThV/b2GISQ8F+7650r5ZZJ043E57aVBFkQ+kSY4C6wdofXgB0hBx+GPGpIU0Z81eETNoDUJMr7oy/P8Q==",
+    "node_modules/@rc-component/cascader": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/cascader/-/cascader-1.14.0.tgz",
+      "integrity": "sha512-Ip9356xwZUR2nbW5PRVGif4B/bDve4pLa/N+PGbvBaTnjbvmN4PFMBGQSmlDlzKP1ovxaYMvwF/dI9lXNLT4iQ==",
       "license": "MIT",
       "dependencies": {
-        "@ant-design/fast-color": "^2.0.6",
-        "@babel/runtime": "^7.23.6",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.38.1"
+        "@rc-component/select": "~1.6.0",
+        "@rc-component/tree": "~1.2.0",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/cascader/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/checkbox": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/checkbox/-/checkbox-2.0.0.tgz",
+      "integrity": "sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/@rc-component/context": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-1.4.0.tgz",
-      "integrity": "sha512-kFcNxg9oLRMoL3qki0OMxK+7g5mypjgaaJp/pkOis/6rVxma9nJBF/8kCIuTYHUQNr0ii7MxqE33wirPZLJQ2w==",
+    "node_modules/@rc-component/checkbox/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/collapse": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/collapse/-/collapse-1.2.0.tgz",
+      "integrity": "sha512-ZRYSKSS39qsFx93p26bde7JUZJshsUBEQRlRXPuJYlAiNX0vyYlF5TsAm8JZN3LcF8XvKikdzPbgAtXSbkLUkw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
-        "rc-util": "^5.27.0"
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/collapse/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/color-picker": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/color-picker/-/color-picker-3.1.0.tgz",
+      "integrity": "sha512-o7Vavj7yyfVxFmeynXf0fCHVlC0UTE9al74c6nYuLck+gjuVdQNWSVXR8Efq/mmWFy7891SCOsfaPq6Eqe1s/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ant-design/fast-color": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
       },
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/color-picker/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/context": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/context/-/context-2.0.1.tgz",
+      "integrity": "sha512-HyZbYm47s/YqtP6pKXNMjPEMaukyg7P0qVfgMLzr7YiFNMHbK2fKTAGzms9ykfGHSfyf75nBbgWw+hHkp+VImw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/dialog": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@rc-component/dialog/-/dialog-1.8.4.tgz",
+      "integrity": "sha512-Ay6PM7phkTkquplG8fWfUGFZ2GTLx9diTl4f0d8Eqxd7W1u1KjE9AQooFQHOHnhZf0Ya3z51+5EKCWHmt/dNEw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.3",
+        "@rc-component/portal": "^2.1.0",
+        "@rc-component/util": "^1.9.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/dialog/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/drawer": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/drawer/-/drawer-1.4.2.tgz",
+      "integrity": "sha512-1ib+fZEp6FBu+YvcIktm+nCQ+Q+qIpwpoaJH6opGr4ofh2QMq+qdr5DLC4oCf5qf3pcWX9lUWPYX652k4ini8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/portal": "^2.1.3",
+        "@rc-component/util": "^1.9.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/drawer/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/dropdown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/dropdown/-/dropdown-1.0.2.tgz",
+      "integrity": "sha512-6PY2ecUSYhDPhkNHHb4wfeAya04WhpmUSKzdR60G+kMNVUCX2vjT/AgTS0Lz0I/K6xrPMJ3enQbwVpeN3sHCgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.11.0",
+        "react-dom": ">=16.11.0"
+      }
+    },
+    "node_modules/@rc-component/dropdown/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/form": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/form/-/form-1.6.2.tgz",
+      "integrity": "sha512-OgIn2RAoaSBqaIgzJf/X6iflIa9LpTozci1lagLBdURDFhGA370v0+T0tXxOi8YShMjTha531sFhwtnrv+EJaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/async-validator": "^5.1.0",
+        "@rc-component/util": "^1.6.2",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/form/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/image": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/image/-/image-1.6.0.tgz",
+      "integrity": "sha512-tSfn2ZE/oP082g4QIOxeehkmgnXB7R+5AFj/lIFr4k7pEuxHBdyGIq9axoCY9qea8NN0DY6p4IB/F07tLqaT5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.0.0",
+        "@rc-component/portal": "^2.1.2",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/image/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/input": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/input/-/input-1.1.2.tgz",
+      "integrity": "sha512-Q61IMR47piUBudgixJ30CciKIy9b1H95qe7GgEKOmSJVJXvFRWJllJfQry9tif+MX2cWFXWJf/RXz4kaCeq/Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@rc-component/input-number": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/input-number/-/input-number-1.6.2.tgz",
+      "integrity": "sha512-Gjcq7meZlCOiWN1t1xCC+7/s85humHVokTBI7PJgTfoyw5OWF74y3e6P8PHX104g9+b54jsodFIzyaj6p8LI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/mini-decimal": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/input-number/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/input/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/mentions": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/mentions/-/mentions-1.6.0.tgz",
+      "integrity": "sha512-KIkQNP6habNuTsLhUv0UGEOwG67tlmE7KNIJoQZZNggEZl5lQJTytFDb69sl5CK3TDdISCTjKP3nGEBKgT61CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/input": "~1.1.0",
+        "@rc-component/menu": "~1.2.0",
+        "@rc-component/textarea": "~1.1.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/mentions/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/menu": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/menu/-/menu-1.2.0.tgz",
+      "integrity": "sha512-VWwDuhvYHSnTGj4n6bV3ISrLACcPAzdPOq3d0BzkeiM5cve8BEYfvkEhNoM0PLzv51jpcejeyrLXeMVIJ+QJlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/menu/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@rc-component/mini-decimal": {
@@ -4699,15 +5033,36 @@
         "node": ">=8.x"
       }
     },
-    "node_modules/@rc-component/mutate-observer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-1.1.0.tgz",
-      "integrity": "sha512-QjrOsDXQusNwGZPf4/qRQasg7UFEj06XiCJ8iuiq/Io7CrHrgVi6Uuetw60WAMG1799v+aM8kyc+1L/GBbHSlw==",
+    "node_modules/@rc-component/motion": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@rc-component/motion/-/motion-1.1.6.tgz",
+      "integrity": "sha512-aEQobs/YA0kqRvHIPjQvOytdtdRVyhf/uXAal4chBjxDu6odHckExJzjn2D+Ju1aKK6hx3pAs6BXdV9+86xkgQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.18.0",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.24.4"
+        "@rc-component/util": "^1.2.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/motion/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/mutate-observer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/mutate-observer/-/mutate-observer-2.0.1.tgz",
+      "integrity": "sha512-AyarjoLU5YlxuValRi+w8JRH2Z84TBbFO2RoGWz9d8bSu0FqT8DtugH3xC3BV7mUwlmROFauyWuXFuq4IFbH+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.0"
       },
       "engines": {
         "node": ">=8.x"
@@ -4717,15 +5072,15 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/@rc-component/portal": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
-      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+    "node_modules/@rc-component/notification": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/notification/-/notification-1.2.0.tgz",
+      "integrity": "sha512-OX3J+zVU7rvoJCikjrfW7qOUp7zlDeFBK2eA3SFbGSkDqo63Sl4Ss8A04kFP+fxHSxMDIS9jYVEZtU1FNCFuBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.18.0",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.24.4"
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
       },
       "engines": {
         "node": ">=8.x"
@@ -4733,6 +5088,159 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/notification/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/overflow": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/overflow/-/overflow-1.0.0.tgz",
+      "integrity": "sha512-GSlBeoE0XTBi5cf3zl8Qh7Uqhn7v8RrlJ8ajeVpEkNe94HWy5l5BQ0Mwn2TVUq9gdgbfEMUmTX7tJFAg7mz0Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@rc-component/resize-observer": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/overflow/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/pagination": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/pagination/-/pagination-1.2.0.tgz",
+      "integrity": "sha512-YcpUFE8dMLfSo6OARJlK6DbHHvrxz7pMGPGmC/caZSJJz6HRKHC1RPP001PRHCvG9Z/veD039uOQmazVuLJzlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/pagination/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/picker": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/picker/-/picker-1.9.0.tgz",
+      "integrity": "sha512-OLisdk8AWVCG9goBU1dWzuH5QlBQk8jktmQ6p0/IyBFwdKGwyIZOSjnBYo8hooHiTdl0lU+wGf/OfMtVBw02KQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/trigger": "^3.6.15",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "date-fns": ">= 2.x",
+        "dayjs": ">= 1.x",
+        "luxon": ">= 3.x",
+        "moment": ">= 2.x",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      },
+      "peerDependenciesMeta": {
+        "date-fns": {
+          "optional": true
+        },
+        "dayjs": {
+          "optional": true
+        },
+        "luxon": {
+          "optional": true
+        },
+        "moment": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rc-component/picker/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/portal": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-2.2.0.tgz",
+      "integrity": "sha512-oc6FlA+uXCMiwArHsJyHcIkX4q6uKyndrPol2eWX8YPkAnztHOPsFIRtmWG4BMlGE5h7YIRE3NiaJ5VS8Lb1QQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/portal/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/progress": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/progress/-/progress-1.0.2.tgz",
+      "integrity": "sha512-WZUnH9eGxH1+xodZKqdrHke59uyGZSWgj5HBM5Kwk5BrTMuAORO7VJ2IP5Qbm9aH3n9x3IcesqHHR0NWPBC7fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/progress/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@rc-component/qrcode": {
@@ -4751,17 +5259,14 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/@rc-component/tour": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-1.15.1.tgz",
-      "integrity": "sha512-Tr2t7J1DKZUpfJuDZWHxyxWpfmj8EZrqSgyMZ+BCdvKZ6r1UDsfU46M/iWAAFBy961Ssfom2kv5f3UcjIL2CmQ==",
+    "node_modules/@rc-component/rate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/rate/-/rate-1.0.1.tgz",
+      "integrity": "sha512-bkXxeBqDpl5IOC7yL7GcSYjQx9G8H+6kLYQnNZWeBYq2OYIv1MONd6mqKTjnnJYpV0cQIU2z3atdW0j1kttpTw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.18.0",
-        "@rc-component/portal": "^1.0.0-9",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.24.4"
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
       },
       "engines": {
         "node": ">=8.x"
@@ -4771,18 +5276,90 @@
         "react-dom": ">=16.9.0"
       }
     },
-    "node_modules/@rc-component/trigger": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-2.3.0.tgz",
-      "integrity": "sha512-iwaxZyzOuK0D7lS+0AQEtW52zUWxoGqTGkke3dRyb8pYiShmRpCjB/8TzPI4R6YySCH7Vm9BZj/31VPiiQTLBg==",
+    "node_modules/@rc-component/rate/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/resize-observer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/resize-observer/-/resize-observer-1.1.1.tgz",
+      "integrity": "sha512-NfXXMmiR+SmUuKE1NwJESzEUYUFWIDUn2uXpxCTOLwiRUUakd62DRNFjRJArgzyFW8S5rsL4aX5XlyIXyC/vRA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@rc-component/portal": "^1.1.0",
-        "classnames": "^2.3.2",
-        "rc-motion": "^2.0.0",
-        "rc-resize-observer": "^1.3.1",
-        "rc-util": "^5.44.0"
+        "@rc-component/util": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/segmented": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/segmented/-/segmented-1.3.0.tgz",
+      "integrity": "sha512-5J/bJ01mbDnoA6P/FW8SxUvKn+OgUSTZJPzCNnTBntG50tzoP7DydGhqxp7ggZXZls7me3mc2EQDXakU3iTVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@rc-component/segmented/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/select": {
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@rc-component/select/-/select-1.6.10.tgz",
+      "integrity": "sha512-y4+2LnyGZrAorIBwflk78PmFVUWcSc9pcljiH72oHj7K1YY/BFUmj224pD7P4o7J+tbIFES45Z7LIpjVmvYlNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/overflow": "^1.0.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.3.0",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/select/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/slider": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/slider/-/slider-1.0.1.tgz",
+      "integrity": "sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
       },
       "engines": {
         "node": ">=8.x"
@@ -4790,6 +5367,353 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/slider/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/steps": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/steps/-/steps-1.2.2.tgz",
+      "integrity": "sha512-/yVIZ00gDYYPHSY0JP+M+s3ZvuXLu2f9rEjQqiUDs7EcYsUYrpJ/1bLj9aI9R7MBR3fu/NGh6RM9u2qGfqp+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/steps/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/switch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/switch/-/switch-1.0.3.tgz",
+      "integrity": "sha512-Jgi+EbOBquje/XNdofr7xbJQZPYJP+BlPfR0h+WN4zFkdtB2EWqEfvkXJWeipflwjWip0/17rNbxEAqs8hVHfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/switch/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/table": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@rc-component/table/-/table-1.9.1.tgz",
+      "integrity": "sha512-FVI5ZS/GdB3BcgexfCYKi3iHhZS3Fr59EtsxORszYGrfpH1eWr33eDNSYkVfLI6tfJ7vftJDd9D5apfFWqkdJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/context": "^2.0.1",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/util": "^1.1.0",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/table/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/tabs": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tabs/-/tabs-1.7.0.tgz",
+      "integrity": "sha512-J48cs2iBi7Ho3nptBxxIqizEliUC+ExE23faspUQKGQ550vaBlv3aGF8Epv/UB1vFWeoJDTW/dNzgIU0Qj5i/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/dropdown": "~1.0.0",
+        "@rc-component/menu": "~1.2.0",
+        "@rc-component/motion": "^1.1.3",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tabs/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/textarea": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/textarea/-/textarea-1.1.2.tgz",
+      "integrity": "sha512-9rMUEODWZDMovfScIEHXWlVZuPljZ2pd1LKNjslJVitn4SldEzq5vO1CL3yy3Dnib6zZal2r2DPtjy84VVpF6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/input": "~1.1.0",
+        "@rc-component/resize-observer": "^1.0.0",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/textarea/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/tooltip": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tooltip/-/tooltip-1.4.0.tgz",
+      "integrity": "sha512-8Rx5DCctIlLI4raR0I0xHjVTf1aF48+gKCNeAAo5bmF5VoR5YED+A/XEqzXv9KKqrJDRcd3Wndpxh2hyzrTtSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/trigger": "^3.7.1",
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/tooltip/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/tour": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tour/-/tour-2.3.0.tgz",
+      "integrity": "sha512-K04K9r32kUC+auBSQfr+Fss4SpSIS9JGe56oq/ALAX0p+i2ylYOI1MgR83yBY7v96eO6ZFXcM/igCQmubps0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/portal": "^2.2.0",
+        "@rc-component/trigger": "^3.0.0",
+        "@rc-component/util": "^1.7.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/tour/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/tree": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rc-component/tree/-/tree-1.2.3.tgz",
+      "integrity": "sha512-mG8hF2ogQcKaEpfyxzPvMWqqkptofd7Sf+YiXOpPzuXLTLwNKfLDJtysc1/oybopbnzxNqWh2Vgwi+GYwNIb7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.0.0",
+        "@rc-component/util": "^1.8.1",
+        "@rc-component/virtual-list": "^1.0.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=10.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/tree-select": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/tree-select/-/tree-select-1.8.0.tgz",
+      "integrity": "sha512-iYsPq3nuLYvGqdvFAW+l+I9ASRIOVbMXyA8FGZg2lGym/GwkaWeJGzI4eJ7c9IOEhRj0oyfIN4S92Fl3J05mjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/select": "~1.6.0",
+        "@rc-component/tree": "~1.2.0",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/@rc-component/tree-select/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/tree/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/trigger": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-3.9.0.tgz",
+      "integrity": "sha512-X8btpwfrT27AgrZVOz4swclhEHTZcqaHeQMXXBgveagOiakTa36uObXbdwerXffgV8G9dH1fAAE0DHtVQs8EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/motion": "^1.1.4",
+        "@rc-component/portal": "^2.2.0",
+        "@rc-component/resize-observer": "^1.1.1",
+        "@rc-component/util": "^1.2.1",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/trigger/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/upload": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/upload/-/upload-1.1.0.tgz",
+      "integrity": "sha512-LIBV90mAnUE6VK5N4QvForoxZc4XqEYZimcp7fk+lkE4XwHHyJWxpIXQQwMU8hJM+YwBbsoZkGksL1sISWHQxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rc-component/util": "^1.3.0",
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/upload/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rc-component/util": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@rc-component/util/-/util-1.9.0.tgz",
+      "integrity": "sha512-5uW6AfhIigCWeEQDthTozlxiT4Prn6xYQWeO0xokjcaa186OtwPRHBZJ2o0T0FhbjGhZ3vXdbkv0sx3gAYW7Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-mobile": "^5.0.0",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/@rc-component/util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
+    "node_modules/@rc-component/virtual-list": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/virtual-list/-/virtual-list-1.0.2.tgz",
+      "integrity": "sha512-uvTol/mH74FYsn5loDGJxo+7kjkO4i+y4j87Re1pxJBs0FaeuMuLRzQRGaXwnMcV1CxpZLi2Z56Rerj2M00fjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.0",
+        "@rc-component/resize-observer": "^1.0.1",
+        "@rc-component/util": "^1.4.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/virtual-list/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -6256,6 +7180,7 @@
       "integrity": "sha512-CEigAk7eOLyHvdgmpZsKFwtiqS2wFwI1fn4j09IU9GmD4euFM4jEBAViWeCqaNLlbX2k2+A/Fq9cje4HQBXuJQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/utils": "^8.32.1",
         "eslint-visitor-keys": "^4.2.0",
@@ -6296,6 +7221,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6925,6 +7851,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6935,6 +7862,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -7076,6 +8004,7 @@
       "integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.52.0",
@@ -7115,6 +8044,7 @@
       "integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.52.0",
         "@typescript-eslint/types": "8.52.0",
@@ -7891,6 +8821,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7971,6 +8902,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -8087,58 +9019,57 @@
       }
     },
     "node_modules/antd": {
-      "version": "5.29.3",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.29.3.tgz",
-      "integrity": "sha512-3DdbGCa9tWAJGcCJ6rzR8EJFsv2CtyEbkVabZE14pfgUHfCicWCj0/QzQVLDYg8CPfQk9BH7fHCoTXHTy7MP/A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-6.3.0.tgz",
+      "integrity": "sha512-bbHJcASrRHp02wTpr940KtUHlTT6tvmaD4OAjqgOJXNmTQ/+qBDdBVWY/yeDV41p/WbWjTLlaqRGVbL3UEVpNw==",
       "license": "MIT",
       "dependencies": {
-        "@ant-design/colors": "^7.2.1",
-        "@ant-design/cssinjs": "^1.23.0",
-        "@ant-design/cssinjs-utils": "^1.1.3",
-        "@ant-design/fast-color": "^2.0.6",
-        "@ant-design/icons": "^5.6.1",
-        "@ant-design/react-slick": "~1.1.2",
-        "@babel/runtime": "^7.26.0",
-        "@rc-component/color-picker": "~2.0.1",
-        "@rc-component/mutate-observer": "^1.1.0",
-        "@rc-component/qrcode": "~1.1.0",
-        "@rc-component/tour": "~1.15.1",
-        "@rc-component/trigger": "^2.3.0",
-        "classnames": "^2.5.1",
-        "copy-to-clipboard": "^3.3.3",
+        "@ant-design/colors": "^8.0.1",
+        "@ant-design/cssinjs": "^2.1.0",
+        "@ant-design/cssinjs-utils": "^2.1.1",
+        "@ant-design/fast-color": "^3.0.1",
+        "@ant-design/icons": "^6.1.0",
+        "@ant-design/react-slick": "~2.0.0",
+        "@babel/runtime": "^7.28.4",
+        "@rc-component/cascader": "~1.14.0",
+        "@rc-component/checkbox": "~2.0.0",
+        "@rc-component/collapse": "~1.2.0",
+        "@rc-component/color-picker": "~3.1.0",
+        "@rc-component/dialog": "~1.8.4",
+        "@rc-component/drawer": "~1.4.2",
+        "@rc-component/dropdown": "~1.0.2",
+        "@rc-component/form": "~1.6.2",
+        "@rc-component/image": "~1.6.0",
+        "@rc-component/input": "~1.1.2",
+        "@rc-component/input-number": "~1.6.2",
+        "@rc-component/mentions": "~1.6.0",
+        "@rc-component/menu": "~1.2.0",
+        "@rc-component/motion": "~1.1.6",
+        "@rc-component/mutate-observer": "^2.0.1",
+        "@rc-component/notification": "~1.2.0",
+        "@rc-component/pagination": "~1.2.0",
+        "@rc-component/picker": "~1.9.0",
+        "@rc-component/progress": "~1.0.2",
+        "@rc-component/qrcode": "~1.1.1",
+        "@rc-component/rate": "~1.0.1",
+        "@rc-component/resize-observer": "^1.1.1",
+        "@rc-component/segmented": "~1.3.0",
+        "@rc-component/select": "~1.6.5",
+        "@rc-component/slider": "~1.0.1",
+        "@rc-component/steps": "~1.2.2",
+        "@rc-component/switch": "~1.0.3",
+        "@rc-component/table": "~1.9.1",
+        "@rc-component/tabs": "~1.7.0",
+        "@rc-component/textarea": "~1.1.2",
+        "@rc-component/tooltip": "~1.4.0",
+        "@rc-component/tour": "~2.3.0",
+        "@rc-component/tree": "~1.2.3",
+        "@rc-component/tree-select": "~1.8.0",
+        "@rc-component/trigger": "^3.9.0",
+        "@rc-component/upload": "~1.1.0",
+        "@rc-component/util": "^1.9.0",
+        "clsx": "^2.1.1",
         "dayjs": "^1.11.11",
-        "rc-cascader": "~3.34.0",
-        "rc-checkbox": "~3.5.0",
-        "rc-collapse": "~3.9.0",
-        "rc-dialog": "~9.6.0",
-        "rc-drawer": "~7.3.0",
-        "rc-dropdown": "~4.2.1",
-        "rc-field-form": "~2.7.1",
-        "rc-image": "~7.12.0",
-        "rc-input": "~1.8.0",
-        "rc-input-number": "~9.5.0",
-        "rc-mentions": "~2.20.0",
-        "rc-menu": "~9.16.1",
-        "rc-motion": "^2.9.5",
-        "rc-notification": "~5.6.4",
-        "rc-pagination": "~5.1.0",
-        "rc-picker": "~4.11.3",
-        "rc-progress": "~4.0.0",
-        "rc-rate": "~2.13.1",
-        "rc-resize-observer": "^1.4.3",
-        "rc-segmented": "~2.7.0",
-        "rc-select": "~14.16.8",
-        "rc-slider": "~11.1.9",
-        "rc-steps": "~6.0.1",
-        "rc-switch": "~4.1.0",
-        "rc-table": "~7.54.0",
-        "rc-tabs": "~15.7.0",
-        "rc-textarea": "~1.10.2",
-        "rc-tooltip": "~6.4.0",
-        "rc-tree": "~5.13.1",
-        "rc-tree-select": "~5.27.0",
-        "rc-upload": "~4.11.0",
-        "rc-util": "^5.44.4",
         "scroll-into-view-if-needed": "^3.1.0",
         "throttle-debounce": "^5.0.2"
       },
@@ -8147,8 +9078,17 @@
         "url": "https://opencollective.com/ant-design"
       },
       "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
+    },
+    "node_modules/antd/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/any-promise": {
@@ -8298,7 +9238,6 @@
       "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -8380,7 +9319,6 @@
       "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.7",
         "define-properties": "^1.2.1",
@@ -8884,6 +9822,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -8932,6 +9871,7 @@
       "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9619,12 +10559,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
-    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -10275,15 +11209,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/copy-to-clipboard": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
-      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
-      "license": "MIT",
-      "dependencies": {
-        "toggle-selection": "^1.0.6"
-      }
-    },
     "node_modules/copy-webpack-plugin": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
@@ -10436,6 +11361,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -10808,10 +11734,11 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
+      "version": "1.11.19",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
+      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -11735,7 +12662,6 @@
       "integrity": "sha512-uDn+FE1yrDzyC0pCo961B2IHbdM8y/ACZsKD4dG6WqrjV53BADjwa7D+1aom2rsNVfLyDgU/eigvlJGJ08OQ4w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -12002,6 +12928,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12156,7 +13083,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -12214,7 +13140,6 @@
       "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -15003,6 +15928,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-mobile": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
+      "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
+      "license": "MIT"
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -15467,7 +16398,6 @@
       "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-object-atoms": "^1.0.0",
@@ -17136,6 +18066,7 @@
       "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.0.1",
         "data-urls": "^5.0.0",
@@ -17374,7 +18305,6 @@
       "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.6",
         "array.prototype.flat": "^1.3.1",
@@ -17939,6 +18869,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -18404,7 +19335,8 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -20654,6 +21586,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -20866,7 +21799,6 @@
       "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.4",
@@ -20942,6 +21874,7 @@
       "resolved": "https://registry.npmjs.org/ol/-/ol-10.7.0.tgz",
       "integrity": "sha512-122U5gamPqNgLpLOkogFJhgpywvd/5en2kETIDW+Ubfi9lPnZ0G9HWRdG+CX0oP8od2d6u6ky3eewIYYlrVczw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@types/rbush": "4.0.0",
         "earcut": "^3.0.0",
@@ -21888,6 +22821,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -22380,618 +23314,6 @@
         "rc": "cli.js"
       }
     },
-    "node_modules/rc-cascader": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/rc-cascader/-/rc-cascader-3.34.0.tgz",
-      "integrity": "sha512-KpXypcvju9ptjW9FaN2NFcA2QH9E9LHKq169Y0eWtH4e/wHQ5Wh5qZakAgvb8EKZ736WZ3B0zLLOBsrsja5Dag==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "classnames": "^2.3.1",
-        "rc-select": "~14.16.2",
-        "rc-tree": "~5.13.0",
-        "rc-util": "^5.43.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-checkbox": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/rc-checkbox/-/rc-checkbox-3.5.0.tgz",
-      "integrity": "sha512-aOAQc3E98HteIIsSqm6Xk2FPKIER6+5vyEFMZfo73TqM+VVAIqOkHoPjgKLqSNtVLWScoaM7vY2ZrGEheI79yg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.25.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-collapse": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/rc-collapse/-/rc-collapse-3.9.0.tgz",
-      "integrity": "sha512-swDdz4QZ4dFTo4RAUMLL50qP0EY62N2kvmk2We5xYdRwcRn8WcYtuetCJpwpaCbUfUt5+huLpVxhvmnK+PHrkA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.3.4",
-        "rc-util": "^5.27.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-dialog": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-9.6.0.tgz",
-      "integrity": "sha512-ApoVi9Z8PaCQg6FsUzS8yvBEQy0ZL2PkuvAgrmohPkN3okps5WZ5WQWPc1RNuiOKaAYv8B97ACdsFU5LizzCqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/portal": "^1.0.0-8",
-        "classnames": "^2.2.6",
-        "rc-motion": "^2.3.0",
-        "rc-util": "^5.21.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-drawer": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/rc-drawer/-/rc-drawer-7.3.0.tgz",
-      "integrity": "sha512-DX6CIgiBWNpJIMGFO8BAISFkxiuKitoizooj4BDyee8/SnBn0zwO2FHrNDpqqepj0E/TFTDpmEBCyFuTgC7MOg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.9",
-        "@rc-component/portal": "^1.1.1",
-        "classnames": "^2.2.6",
-        "rc-motion": "^2.6.1",
-        "rc-util": "^5.38.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-dropdown": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-4.2.1.tgz",
-      "integrity": "sha512-YDAlXsPv3I1n42dv1JpdM7wJ+gSUBfeyPK59ZpBD9jQhK9jVuxpjj3NmWQHOBceA1zEPVX84T2wbdb2SD0UjmA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.44.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.11.0",
-        "react-dom": ">=16.11.0"
-      }
-    },
-    "node_modules/rc-field-form": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rc-field-form/-/rc-field-form-2.7.1.tgz",
-      "integrity": "sha512-vKeSifSJ6HoLaAB+B8aq/Qgm8a3dyxROzCtKNCsBQgiverpc4kWDQihoUwzUj+zNWJOykwSY4dNX3QrGwtVb9A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.0",
-        "@rc-component/async-validator": "^5.0.3",
-        "rc-util": "^5.32.2"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-image": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-7.12.0.tgz",
-      "integrity": "sha512-cZ3HTyyckPnNnUb9/DRqduqzLfrQRyi+CdHjdqgsyDpI3Ln5UX1kXnAhPBSJj9pVRzwRFgqkN7p9b6HBDjmu/Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "@rc-component/portal": "^1.0.2",
-        "classnames": "^2.2.6",
-        "rc-dialog": "~9.6.0",
-        "rc-motion": "^2.6.2",
-        "rc-util": "^5.34.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-input": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/rc-input/-/rc-input-1.8.0.tgz",
-      "integrity": "sha512-KXvaTbX+7ha8a/k+eg6SYRVERK0NddX8QX7a7AnRvUa/rEH0CNMlpcBzBkhI0wp2C8C4HlMoYl8TImSN+fuHKA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.18.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/rc-input-number": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-9.5.0.tgz",
-      "integrity": "sha512-bKaEvB5tHebUURAEXw35LDcnRZLq3x1k7GxfAqBMzmpHkDGzjAtnUL8y4y5N15rIFIg5IJgwr211jInl3cipag==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/mini-decimal": "^1.0.1",
-        "classnames": "^2.2.5",
-        "rc-input": "~1.8.0",
-        "rc-util": "^5.40.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-mentions": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/rc-mentions/-/rc-mentions-2.20.0.tgz",
-      "integrity": "sha512-w8HCMZEh3f0nR8ZEd466ATqmXFCMGMN5UFCzEUL0bM/nGw/wOS2GgRzKBcm19K++jDyuWCOJOdgcKGXU3fXfbQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.22.5",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.2.6",
-        "rc-input": "~1.8.0",
-        "rc-menu": "~9.16.0",
-        "rc-textarea": "~1.10.0",
-        "rc-util": "^5.34.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-menu": {
-      "version": "9.16.1",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-9.16.1.tgz",
-      "integrity": "sha512-ghHx6/6Dvp+fw8CJhDUHFHDJ84hJE3BXNCzSgLdmNiFErWSOaZNsihDAsKq9ByTALo/xkNIwtDFGIl6r+RPXBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "2.x",
-        "rc-motion": "^2.4.3",
-        "rc-overflow": "^1.3.1",
-        "rc-util": "^5.27.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-motion": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.5.tgz",
-      "integrity": "sha512-w+XTUrfh7ArbYEd2582uDrEhmBHwK1ZENJiSJVb7uRxdE7qJSYjbO2eksRXmndqyKqKoYPc9ClpPh5242mV1vA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.44.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-notification": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/rc-notification/-/rc-notification-5.6.4.tgz",
-      "integrity": "sha512-KcS4O6B4qzM3KH7lkwOB7ooLPZ4b6J+VMmQgT51VZCeEcmghdeR4IrMcFq0LG+RPdnbe/ArT086tGM8Snimgiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.9.0",
-        "rc-util": "^5.20.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-overflow": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/rc-overflow/-/rc-overflow-1.4.1.tgz",
-      "integrity": "sha512-3MoPQQPV1uKyOMVNd6SZfONi+f3st0r8PksexIdBTeIYbMX0Jr+k7pHEDvsXtR4BpCv90/Pv2MovVNhktKrwvw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.37.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-pagination": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-5.1.0.tgz",
-      "integrity": "sha512-8416Yip/+eclTFdHXLKTxZvn70duYVGTvUUWbckCCZoIl3jagqke3GLsFrMs0bsQBikiYpZLD9206Ej4SOdOXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.3.2",
-        "rc-util": "^5.38.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-picker": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-4.11.3.tgz",
-      "integrity": "sha512-MJ5teb7FlNE0NFHTncxXQ62Y5lytq6sh5nUw0iH8OkHL/TjARSEvSHpr940pWgjGANpjCwyMdvsEV55l5tYNSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.7",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.2.1",
-        "rc-overflow": "^1.3.2",
-        "rc-resize-observer": "^1.4.0",
-        "rc-util": "^5.43.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "date-fns": ">= 2.x",
-        "dayjs": ">= 1.x",
-        "luxon": ">= 3.x",
-        "moment": ">= 2.x",
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      },
-      "peerDependenciesMeta": {
-        "date-fns": {
-          "optional": true
-        },
-        "dayjs": {
-          "optional": true
-        },
-        "luxon": {
-          "optional": true
-        },
-        "moment": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/rc-progress": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-4.0.0.tgz",
-      "integrity": "sha512-oofVMMafOCokIUIBnZLNcOZFsABaUw8PPrf1/y0ZBvKZNpOiu5h4AO9vv11Sw0p4Hb3D0yGWuEattcQGtNJ/aw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.6",
-        "rc-util": "^5.16.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-rate": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/rc-rate/-/rc-rate-2.13.1.tgz",
-      "integrity": "sha512-QUhQ9ivQ8Gy7mtMZPAjLbxBt5y9GRp65VcUyGUMF3N3fhiftivPHdpuDIaWIMOTEprAjZPC08bls1dQB+I1F2Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-resize-observer": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.4.3.tgz",
-      "integrity": "sha512-YZLjUbyIWox8E9i9C3Tm7ia+W7euPItNWSPX5sCcQTYbnwDb5uNpnLHQCG1f22oZWUhLw4Mv2tFmeWe68CDQRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.7",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.44.1",
-        "resize-observer-polyfill": "^1.5.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-segmented": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/rc-segmented/-/rc-segmented-2.7.0.tgz",
-      "integrity": "sha512-liijAjXz+KnTRVnxxXG2sYDGd6iLL7VpGGdR8gwoxAXy2KglviKCxLWZdjKYJzYzGSUwKDSTdYk8brj54Bn5BA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.1",
-        "classnames": "^2.2.1",
-        "rc-motion": "^2.4.4",
-        "rc-util": "^5.17.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.0.0",
-        "react-dom": ">=16.0.0"
-      }
-    },
-    "node_modules/rc-select": {
-      "version": "14.16.8",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-14.16.8.tgz",
-      "integrity": "sha512-NOV5BZa1wZrsdkKaiK7LHRuo5ZjZYMDxPP6/1+09+FB4KoNi8jcG1ZqLE3AVCxEsYMBe65OBx71wFoHRTP3LRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/trigger": "^2.1.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-overflow": "^1.3.1",
-        "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.5.2"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/rc-slider": {
-      "version": "11.1.9",
-      "resolved": "https://registry.npmjs.org/rc-slider/-/rc-slider-11.1.9.tgz",
-      "integrity": "sha512-h8IknhzSh3FEM9u8ivkskh+Ef4Yo4JRIY2nj7MrH6GQmrwV6mcpJf5/4KgH5JaVI1H3E52yCdpOlVyGZIeph5A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.36.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-steps": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rc-steps/-/rc-steps-6.0.1.tgz",
-      "integrity": "sha512-lKHL+Sny0SeHkQKKDJlAjV5oZ8DwCdS2hFhAkIjuQt1/pB81M0cA0ErVFdHq9+jmPmFw1vJB2F5NBzFXLJxV+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.16.7",
-        "classnames": "^2.2.3",
-        "rc-util": "^5.16.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-switch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rc-switch/-/rc-switch-4.1.0.tgz",
-      "integrity": "sha512-TI8ufP2Az9oEbvyCeVE4+90PDSljGyuwix3fV58p7HV2o4wBnVToEyomJRVyTaZeqNPAp+vqeo4Wnj5u0ZZQBg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0",
-        "classnames": "^2.2.1",
-        "rc-util": "^5.30.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-table": {
-      "version": "7.54.0",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.54.0.tgz",
-      "integrity": "sha512-/wDTkki6wBTjwylwAGjpLKYklKo9YgjZwAU77+7ME5mBoS32Q4nAwoqhA2lSge6fobLW3Tap6uc5xfwaL2p0Sw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "@rc-component/context": "^1.4.0",
-        "classnames": "^2.2.5",
-        "rc-resize-observer": "^1.1.0",
-        "rc-util": "^5.44.3",
-        "rc-virtual-list": "^3.14.2"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tabs": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-15.7.0.tgz",
-      "integrity": "sha512-ZepiE+6fmozYdWf/9gVp7k56PKHB1YYoDsKeQA1CBlJ/POIhjkcYiv0AGP0w2Jhzftd3AVvZP/K+V+Lpi2ankA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "classnames": "2.x",
-        "rc-dropdown": "~4.2.0",
-        "rc-menu": "~9.16.0",
-        "rc-motion": "^2.6.2",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.34.1"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-textarea": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/rc-textarea/-/rc-textarea-1.10.2.tgz",
-      "integrity": "sha512-HfaeXiaSlpiSp0I/pvWpecFEHpVysZ9tpDLNkxQbMvMz6gsr7aVZ7FpWP9kt4t7DB+jJXesYS0us1uPZnlRnwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "^2.2.1",
-        "rc-input": "~1.8.0",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.27.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tooltip": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.4.0.tgz",
-      "integrity": "sha512-kqyivim5cp8I5RkHmpsp1Nn/Wk+1oeloMv9c7LXNgDxUpGm+RbXJGL+OPvDlcRnx9DBeOe4wyOIl4OKUERyH1g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.11.2",
-        "@rc-component/trigger": "^2.0.0",
-        "classnames": "^2.3.1",
-        "rc-util": "^5.44.3"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-tree": {
-      "version": "5.13.1",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.13.1.tgz",
-      "integrity": "sha512-FNhIefhftobCdUJshO7M8uZTA9F4OPGVXqGfZkkD/5soDeOhwO06T/aKTrg0WD8gRg/pyfq+ql3aMymLHCTC4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.10.1",
-        "classnames": "2.x",
-        "rc-motion": "^2.0.1",
-        "rc-util": "^5.16.1",
-        "rc-virtual-list": "^3.5.1"
-      },
-      "engines": {
-        "node": ">=10.x"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/rc-tree-select": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/rc-tree-select/-/rc-tree-select-5.27.0.tgz",
-      "integrity": "sha512-2qTBTzwIT7LRI1o7zLyrCzmo5tQanmyGbSaGTIf7sYimCklAToVVfpMC6OAldSKolcnjorBYPNSKQqJmN3TCww==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.7",
-        "classnames": "2.x",
-        "rc-select": "~14.16.2",
-        "rc-tree": "~5.13.0",
-        "rc-util": "^5.43.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/rc-upload": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-4.11.0.tgz",
-      "integrity": "sha512-ZUyT//2JAehfHzjWowqROcwYJKnZkIUGWaTE/VogVrepSl7AFNbQf4+zGfX4zl9Vrj/Jm8scLO0R6UlPDKK4wA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "classnames": "^2.2.5",
-        "rc-util": "^5.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-util": {
-      "version": "5.44.4",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.44.4.tgz",
-      "integrity": "sha512-resueRJzmHG9Q6rI/DfK6Kdv9/Lfls05vzMs1Sk3M2P+3cJa+MakaZyWY8IPfehVuhPJFKrIY1IK4GqbiaiY5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "react-is": "^18.2.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
-    "node_modules/rc-util/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "license": "MIT"
-    },
-    "node_modules/rc-virtual-list": {
-      "version": "3.18.6",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.18.6.tgz",
-      "integrity": "sha512-TQ5SsutL3McvWmmxqQtMIbfeoE3dGjJrRSfKekgby7WQMpPIFvv4ghytp5Z0s3D8Nik9i9YNOCqHBfk86AwgAA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.20.0",
-        "classnames": "^2.2.6",
-        "rc-resize-observer": "^1.0.0",
-        "rc-util": "^5.36.0"
-      },
-      "engines": {
-        "node": ">=8.x"
-      },
-      "peerDependencies": {
-        "react": ">=16.9.0",
-        "react-dom": ">=16.9.0"
-      }
-    },
     "node_modules/rc/node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
@@ -23014,6 +23336,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23060,6 +23383,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -23460,6 +23784,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -24164,12 +24489,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT"
-    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -24367,6 +24686,7 @@
       "integrity": "sha512-wdN2Kd3Twh8MAEOEJZsuxuLKCsBEo4PVNLK6tQWAn10VhsVewQLzcucMgLolRlhFybGxfclbPeEYBaP6RvUFGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.7"
       },
@@ -24607,6 +24927,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -24671,6 +24992,7 @@
       "integrity": "sha512-6qGjWccl5yoyugHt3jTgztJ9Y0JVzyH8/Voc/D8PlLat9pwxQYXz7W1Dpnq5h0/G5GCYGUaDSlYcyk3AMh5A6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -26022,7 +26344,6 @@
       "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.8",
         "call-bound": "^1.0.3",
@@ -26051,7 +26372,6 @@
       "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
@@ -26907,12 +27227,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
-      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -27839,6 +28153,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -27974,6 +28289,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -28160,6 +28476,7 @@
       "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ant-design/icons": "^5.5.1",
+    "@ant-design/icons": "^6.1.0",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -68,7 +68,7 @@
     "@types/geojson": "^7946.0.14",
     "@types/lodash": "^4.17.5",
     "@ungap/url-search-params": "^0.2.2",
-    "antd": "^5.25.4",
+    "antd": "^6.3.0",
     "chroma-js": "3.2.0",
     "color": "^4.2.3",
     "csstype": "^3.1.3",

--- a/src/Component/CodeEditor/CodeEditor.spec.tsx
+++ b/src/Component/CodeEditor/CodeEditor.spec.tsx
@@ -59,34 +59,4 @@ describe('CodeEditor', () => {
   //   });
   // });
 
-  // TODO fix this test, somehow the props lead to a rendering error
-  // describe('generates an option for every parser', () => {
-  //   it('returns a Select.Option for every passed parser', async () => {
-  //     onStyleChangeDummy = vi.fn();
-  //     const props: CodeEditorProps = {
-  //       style: dummyStyle,
-  //       onStyleChange: onStyleChangeDummy,
-  //       parsers: [
-  //         sldParser
-  //       ],
-  //       delay
-  //     };
-  //     const codeEditor = render(<CodeEditor {...props} />);
-
-  //     const combobox = await codeEditor.findByRole('combobox');
-
-  //     await act(async () => {
-  //       fireEvent.keyDown(combobox, { key: 'Enter' });
-  //     });
-
-  //     let entry = codeEditor.queryAllByText('GeoStyler Style');
-
-  //     expect(entry.length).toBeGreaterThanOrEqual(1);
-
-  //     entry = codeEditor.queryAllByText('SLD Style Parser');
-
-  //     expect(entry.length).toBeGreaterThanOrEqual(1);
-  //   });
-  // });
-
 });

--- a/src/Component/CodeEditor/CodeEditor.tsx
+++ b/src/Component/CodeEditor/CodeEditor.tsx
@@ -41,7 +41,7 @@ import {
 } from 'file-saver';
 
 import './CodeEditor.css';
-import { UploadOutlined , ExclamationCircleTwoTone, WarningTwoTone } from '@ant-design/icons';
+import { UploadOutlined, ExclamationCircleTwoTone, WarningTwoTone } from '@ant-design/icons';
 import type { UploadChangeParam } from 'antd/lib/upload/interface';
 
 import {
@@ -50,7 +50,6 @@ import {
   Select,
   Upload
 } from 'antd';
-const Option = Select.Option;
 
 import {
   ReadStyleResult,
@@ -68,7 +67,7 @@ import { SldStyleParser } from 'geostyler-sld-parser';
 import { SLDUnitsSelect } from '../Symbolizer/SLDUnitsSelect/SLDUnitsSelect';
 import { usePrevious } from '../../hook/UsePrevious';
 import ParserFeedback from '../ParserFeedback/ParserFeedback';
-import { MapboxStyleParser, MbStyle} from 'geostyler-mapbox-parser';
+import { MapboxStyleParser, MbStyle } from 'geostyler-mapbox-parser';
 import { useGeoStylerLocale } from '../../context/GeoStylerContext/GeoStylerContext';
 import { QGISStyleParser } from 'geostyler-qgis-parser';
 
@@ -94,7 +93,7 @@ export interface CodeEditorProps {
 }
 
 type EditorLanguage = 'xml' | 'json' | 'plaintext';
-type FileExtension = '.sld' | '.qml' | '.json' | '.txt' ;
+type FileExtension = '.sld' | '.qml' | '.json' | '.txt';
 type MimeType = 'application/json' | 'text/xml' | 'text/plain';
 
 type FileFormat = {
@@ -121,7 +120,7 @@ const getFileFormat = (parser: StyleParser): FileFormat => {
       language: 'xml',
       mimeType: 'text/xml',
     };
-  } else if (parser && parser.title === QGISStyleParser.title){
+  } else if (parser && parser.title === QGISStyleParser.title) {
     fileFormat = {
       extension: '.qml',
       language: 'xml',
@@ -133,7 +132,7 @@ const getFileFormat = (parser: StyleParser): FileFormat => {
       language: 'json',
       mimeType: 'application/json',
     };
-  } else if (parser === undefined ) {
+  } else if (parser === undefined) {
     // parser == undefined -> GeostylerStyle
     fileFormat = {
       extension: '.json',
@@ -216,7 +215,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   }, [activeParser]);
 
   useEffect(() => {
-    if (!_isEqual(previousStyle, style) || !_isEqual(previouseParser, activeParser) ) {
+    if (!_isEqual(previousStyle, style) || !_isEqual(previouseParser, activeParser)) {
       updateValueFromStyle(style);
     }
   }, [activeParser, style, updateValueFromStyle, previousStyle, previouseParser]);
@@ -225,7 +224,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
     return (<h1>An error occurred in the CodeEditor UI.</h1>);
   }
 
-  const onChange = async(v: string) => {
+  const onChange = async (v: string) => {
     setValue(v);
     setReadStyleResult(undefined);
     try {
@@ -275,11 +274,11 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   };
 
   let parserOptions = [
-    <Option key="GeoStyler Style" value="GeoStyler Style" >Geostyler Style</Option>
+    { label: 'GeoStyler Style', value: 'GeoStyler Style' }
   ];
   const additionalOptions = parsers.map((parser: any) => {
     const title = parser.title;
-    return <Option key={title} value={title}>{title}</Option>;
+    return { label: title, value: title };
   });
   parserOptions = [...parserOptions, ...additionalOptions];
 
@@ -299,7 +298,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
       fileName += fileFormat.extension;
 
       const type = `${fileFormat.mimeType};charset=utf-8`;
-      const blob = new Blob([value], {type});
+      const blob = new Blob([value], { type });
       saveAs(blob, fileName);
     }
   };
@@ -357,12 +356,11 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
           className="gs-code-editor-format-select"
           onSelect={onParserSelect}
           value={activeParser ? activeParser.title : 'GeoStyler Style'}
-        >
-          {parserOptions}
-        </Select>
+          options={parserOptions}
+        />
         {
           parserHasUnitSelect &&
-            <SLDUnitsSelect changeHandler={onUnitSelect} />
+          <SLDUnitsSelect changeHandler={onUnitSelect} />
         }
         {
           showUploadButton &&
@@ -384,7 +382,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         className="gs-code-editor-monaco"
         value={value}
         // activeParser === undefined -> GeostylerStyle
-        path={activeParser === undefined ? MODELPATH : undefined }
+        path={activeParser === undefined ? MODELPATH : undefined}
         language={getFileFormat(activeParser).language}
         onChange={handleOnChange}
       />
@@ -398,16 +396,16 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         }
         {
           (readStyleHasFeedback) &&
-            <div className='read-feedback'>
-              <span>{`${locale.readFeedback} ${activeParser?.title}`}</span>
-              <ParserFeedback feedback={readStyleResult} />
-            </div>
+          <div className='read-feedback'>
+            <span>{`${locale.readFeedback} ${activeParser?.title}`}</span>
+            <ParserFeedback feedback={readStyleResult} />
+          </div>
         }
       </div>
       <div className="gs-code-editor-bottombar">
         <div className='left-items'>
-          { hasAlerts && <WarningTwoTone twoToneColor="#ff4d4f" onClick={toggleFeedback} /> }
-          { hasWarnings && <ExclamationCircleTwoTone twoToneColor="#faad14" onClick={toggleFeedback} /> }
+          {hasAlerts && <WarningTwoTone twoToneColor="#ff4d4f" onClick={toggleFeedback} />}
+          {hasWarnings && <ExclamationCircleTwoTone twoToneColor="#faad14" onClick={toggleFeedback} />}
         </div>
         <div className='center-items'>
           {

--- a/src/Component/DataInput/DataLoader/DataLoader.tsx
+++ b/src/Component/DataInput/DataLoader/DataLoader.tsx
@@ -29,9 +29,6 @@
 import React from 'react';
 
 import { Select, Modal } from 'antd';
-import { UploadRequestOption } from 'rc-upload/lib/interface';
-
-const Option = Select.Option;
 
 import {
   VectorData,
@@ -66,7 +63,7 @@ export const DataLoader: React.FC<DataLoaderProps> = ({
   const [modalVisible, setModalVisible] = React.useState<boolean>(false);
   const [activeParser, setActitveParser] = React.useState<DataParser>();
 
-  const parseGeoJsonUploadData = (uploadObject: UploadRequestOption<any>) => {
+  const parseGeoJsonUploadData = (uploadObject: any) => {
     if (!activeParser) {
       return;
     }
@@ -88,7 +85,7 @@ export const DataLoader: React.FC<DataLoaderProps> = ({
     };
   };
 
-  const parseShapefileUploadData = (uploadObject: UploadRequestOption<any>) => {
+  const parseShapefileUploadData = (uploadObject: any) => {
     if (!activeParser) {
       return;
     }
@@ -122,9 +119,9 @@ export const DataLoader: React.FC<DataLoaderProps> = ({
       });
   };
 
-  const parserOptions = parsers.map((parser: any) =>
-    <Option key={parser.title} value={parser.title}>{parser.title}</Option>
-  );
+  const parserOptions = parsers.map((parser: any) => {
+    return { label: parser.title, value: parser.title };
+  });
 
   const onSelect = (selection: string) => {
     const newActiveParser = parsers.find(parser => parser.title === selection);
@@ -186,9 +183,8 @@ export const DataLoader: React.FC<DataLoaderProps> = ({
       <Select
         style={{ width: 300 }}
         onSelect={onSelect}
-      >
-        {parserOptions}
-      </Select>
+        options={parserOptions}
+      />
       {getInputFromParser()}
     </div>
   );

--- a/src/Component/DataInput/StyleLoader/StyleLoader.tsx
+++ b/src/Component/DataInput/StyleLoader/StyleLoader.tsx
@@ -29,8 +29,6 @@
 import React, { useState } from 'react';
 
 import { Select } from 'antd';
-import { UploadRequestOption } from 'rc-upload/lib/interface';
-const Option = Select.Option;
 
 import {
   Style,
@@ -51,13 +49,13 @@ export interface StyleLoaderProps {
 
 export const StyleLoader: React.FC<StyleLoaderProps> = ({
   parsers,
-  onStyleRead = () => {}
+  onStyleRead = () => { }
 }) => {
 
   const locale = useGeoStylerLocale('StyleLoader');
   const [activeParser, setActiveParser] = useState<StyleParser>();
 
-  const parseStyle = async(uploadObject: UploadRequestOption<any>) => {
+  const parseStyle = async (uploadObject: any) => {
     if (!activeParser) {
       return undefined;
     }
@@ -82,9 +80,9 @@ export const StyleLoader: React.FC<StyleLoaderProps> = ({
     }
   };
 
-  const parserOptions = parsers.map((parser: any) =>
-    <Option key={parser.title} value={parser.title}>{parser.title}</Option>
-  );
+  const parserOptions = parsers.map((parser: any) => {
+    return { label: parser.title, value: parser.title };
+  });
 
   const onSelect = (selection: string) => {
     const newActiveParser = parsers.find(parser => parser.title === selection);
@@ -99,9 +97,8 @@ export const StyleLoader: React.FC<StyleLoaderProps> = ({
       <Select
         style={{ width: 300 }}
         onSelect={onSelect}
-      >
-        {parserOptions}
-      </Select>
+        options={parserOptions}
+      />
       {
         activeParser ?
           <UploadButton

--- a/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
+++ b/src/Component/DataInput/WfsParserInput/WfsParserInput.tsx
@@ -38,7 +38,6 @@ import {
   Select,
   InputNumber
 } from 'antd';
-const Option = Select.Option;
 
 import './WfsParserInput.css';
 import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
@@ -210,13 +209,14 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
       >
         <Select
           className='wfs-version-input'
-          style={{width: '100%'}}
+          style={{ width: '100%' }}
           value={version}
           onChange={onVersionChange}
-        >
-          <Option value="1.1.0">1.1.0</Option>
-          <Option value="2.0.0">2.0.0</Option>
-        </Select>
+          options={[
+            { label: '1.1.0', value: '1.1.0' },
+            { label: '2.0.0', value: '2.0.0' }
+          ]}
+        />
       </Form.Item>
       <Form.Item
         {...itemConfig}
@@ -253,7 +253,7 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
       >
         <Select
           className='wfs-propertyname-input'
-          style={{width: '100%'}}
+          style={{ width: '100%' }}
           mode="tags"
           value={propertyName}
           onChange={onPropertyNameChange}
@@ -268,7 +268,7 @@ export const WfsParserInput: React.FC<WfsParserInputProps> = ({
       >
         <InputNumber
           className='wfs-maxfeatures-input'
-          style={{width: '100%'}}
+          style={{ width: '100%' }}
           min={0}
           value={maxFeatures}
           onChange={onMaxFeaturesChange}

--- a/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
+++ b/src/Component/Filter/AttributeCombo/AttributeCombo.tsx
@@ -35,8 +35,6 @@ import {
 } from '../../../context/GeoStylerContext/GeoStylerContext';
 import { getFormItemConfig } from '../../../Util/FormItemUtil';
 
-const Option = Select.Option;
-
 export interface AttributeComboProps {
   /** Set true to hide the attribute's type in the select options */
   hideAttributeType?: boolean;
@@ -98,14 +96,10 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
       // create an option per attribute
       return attrNames.filter(attributeNameFilter!).map(attrName => {
         const attrNameMapped = attributeNameMappingFunction(attrName);
-        return (
-          <Option
-            key={attrName}
-            value={attrName}
-          >
-            {hideAttributeType ? attrNameMapped : `${attrNameMapped} (${attrDefs[attrName].type})`}
-          </Option>
-        );
+        return {
+          label: hideAttributeType ? attrNameMapped : `${attrNameMapped} (${attrDefs[attrName].type})`,
+          value: attrName
+        };
       });
     }
     return [];
@@ -130,9 +124,8 @@ export const AttributeCombo: React.FC<AttributeComboProps> = ({
               onChange={onAttributeChange}
               placeholder={locale.placeholder}
               size={size}
-            >
-              {options}
-            </Select>
+              options={options}
+            />
             :
             <Input
               ref={inputRef}

--- a/src/Component/Filter/FilterTree/FilterTree.tsx
+++ b/src/Component/Filter/FilterTree/FilterTree.tsx
@@ -63,7 +63,6 @@ import {
 
 import FilterUtil from '../../../Util/FilterUtil';
 
-import { DataNode } from 'rc-tree/lib/interface';
 import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
 import _isBoolean from 'lodash-es/isBoolean.js';
 
@@ -141,7 +140,7 @@ export const FilterTree: React.FC<FilterTreeProps & Partial<TreeProps>> = ({
   /**
    * Creates a DataNode for a given filter at the given position.
    */
-  const getNodeByFilter = (filter: Filter | CombinationOperator, position = ''): DataNode => {
+  const getNodeByFilter: any = (filter: Filter | CombinationOperator, position = '') => {
     const onMenuClick = (e: any) => {
       const keyPath: string[] = e.keyPath;
       const reversedKeyPath = keyPath.reverse();
@@ -223,7 +222,7 @@ export const FilterTree: React.FC<FilterTreeProps & Partial<TreeProps>> = ({
     let extraClassName = '';
     let title;
     const isLeaf = !(isCombinationFilter(filter) || isNegationFilter(filter));
-    let children: DataNode[] = [];
+    let children = [];
 
     if (isCombinationFilter(filter)) {
       const text = filter[0] === '&&' ? locale.andFilterText : locale.orFilterText;
@@ -237,7 +236,7 @@ export const FilterTree: React.FC<FilterTreeProps & Partial<TreeProps>> = ({
       children = filter.slice(1).map((subFilter: Filter | CombinationOperator, index: number) => {
         const pos = `${position}[${index + 1}]`;
         return getNodeByFilter(subFilter, pos);
-      });
+      }) as any[];
     } else if (isNegationFilter(filter)) {
       extraClassName = 'not-filter';
       title = (

--- a/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
+++ b/src/Component/Filter/OperatorCombo/OperatorCombo.tsx
@@ -30,7 +30,6 @@ import React from 'react';
 
 import { ComparisonOperator } from 'geostyler-style';
 import { Select, Form } from 'antd';
-const Option = Select.Option;
 
 export interface OperatorComboProps {
   /** Label for this field */
@@ -79,15 +78,10 @@ export const OperatorCombo: React.FC<OperatorComboProps> = ({
       ? operatorTitleMappingFunction(operator)
       : ' ';
 
-    return (
-      <Option
-        key={operator}
-        value={operator}
-        title={title}
-      >
-        {operatorNameMappingFunction(operator)}
-      </Option>
-    );
+    return {
+      label: title,
+      value: operator
+    };
   });
 
   let helpText = validateStatus !== 'success' ? help : null;
@@ -109,9 +103,8 @@ export const OperatorCombo: React.FC<OperatorComboProps> = ({
           value={value}
           onChange={onOperatorChange}
           placeholder={placeholder}
-        >
-          {options}
-        </Select>
+          options={options}
+        />
 
       </Form.Item>
 

--- a/src/Component/Filter/TextFilterField/TextFilterField.tsx
+++ b/src/Component/Filter/TextFilterField/TextFilterField.tsx
@@ -124,12 +124,14 @@ export const TextFilterField: React.FC<TextFilterFieldProps> = ({
               value={value}
               onChange={onAutoCompleteChange}
               placeholder={locale.placeholder}
-              dataSource={sampleValues}
-              filterOption={(val: string|number, option: any) => {
-                if (typeof val !== 'string') {
-                  return false;
+              options={sampleValues}
+              showSearch={{
+                filterOption: (val: string | number, option: any) => {
+                  if (typeof val !== 'string') {
+                    return false;
+                  }
+                  return option.key.toLowerCase().includes(val.toLowerCase());
                 }
-                return option.key.toLowerCase().includes(val.toLowerCase());
               }}
             />
             :

--- a/src/Component/ParserFeedback/ParserFeedback.tsx
+++ b/src/Component/ParserFeedback/ParserFeedback.tsx
@@ -59,7 +59,7 @@ export const ParserFeedback: React.FC<ParserFeedbackProps> = ({
       showIcon
       key={`warning-${index}`}
       type='warning'
-      message={warning}
+      title={warning}
     />
   ));
 
@@ -68,7 +68,7 @@ export const ParserFeedback: React.FC<ParserFeedbackProps> = ({
       showIcon
       key={`error-${index}`}
       type='error'
-      message={error.message}
+      title={error.message}
     />
   ));
 
@@ -113,7 +113,7 @@ export const ParserFeedback: React.FC<ParserFeedbackProps> = ({
       showIcon
       key={`unsupportedProperty-${index}`}
       type='warning'
-      message={unsupportedProperty}
+      title={unsupportedProperty}
     />
   ));
 

--- a/src/Component/PreviewMap/PreviewMap.tsx
+++ b/src/Component/PreviewMap/PreviewMap.tsx
@@ -31,7 +31,8 @@ import OlMap from 'ol/Map';
 import OlLayerVector from 'ol/layer/Vector';
 import OlSourceVector from 'ol/source/Vector';
 import OlFormatGeoJSON from 'ol/format/GeoJSON';
-import { Projection, ProjectionLike ,
+import {
+  Projection, ProjectionLike,
   get as getProjection,
 } from 'ol/proj';
 import OlFeature, {
@@ -258,7 +259,7 @@ export const PreviewMap: React.FC<PreviewMapProps> = ({
     return (
       <Alert
         type='error'
-        message={locale.errorTitle}
+        title={locale.errorTitle}
         description={errorMsg}
       />
     );

--- a/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.tsx
+++ b/src/Component/RuleGenerator/ClassificationCombo/ClassificationCombo.tsx
@@ -56,25 +56,21 @@ export const ClassificationCombo: React.FC<ClassificationComboProps> = ({
   const locale = useGeoStylerLocale('ClassificationCombo');
 
   const classificationOptions = classifications.map((method: ClassificationMethod) => {
-    return (
-      <Select.Option
-        className="classification-option"
-        key={method}
-        value={method}
-      >
-        {locale[method] || method}
-      </Select.Option>
-    );
+    return {
+      label: locale[method] || method,
+      value: method
+    };
   });
 
   return (
     <Select
       className="classification-combo"
-      optionFilterProp="children"
+      showSearch={{
+        optionFilterProp: 'children'
+      }}
       value={classification}
       onChange={onChange}
-    >
-      {classificationOptions}
-    </Select>
+      options={classificationOptions}
+    />
   );
 };

--- a/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.css
+++ b/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.css
@@ -30,15 +30,8 @@
   border-radius: 4px;
   font-weight: bold;
 
-  .ant-select-selection {
-    font-weight: bold;
-    background-color: inherit;
-  }
-
-  &.ant-select.ant-select-single {
-    .ant-select-selector {
-      background-color: unset;
-    }
+  .ant-select-content-value {
+    background-image: unset !important;
   }
 
   li.gs-color-ramp-option {

--- a/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.tsx
+++ b/src/Component/RuleGenerator/ColorRampCombo/ColorRampCombo.tsx
@@ -62,22 +62,15 @@ export const ColorRampCombo: React.FC<ColorRampComboProps> = ({
 
   const locale = useGeoStylerLocale('ColorRampCombo');
 
-  const colorRampOptions = Object.keys(colorRamps)
-    .map((name: string) => {
-      const colors = colorRamps[name];
-      const style = RuleGeneratorUtil.generateBackgroundStyleFromColors(colors);
-      return (
-        <Select.Option
-          className="gs-color-ramp-option"
-          key={name}
-          value={name}
-          style={style}
-        >
-          {name}
-        </Select.Option>
-      );
-    });
-
+  const colorRampOptions = Object.keys(colorRamps).map((name: string) => {
+    const colors = colorRamps[name];
+    const style = RuleGeneratorUtil.generateBackgroundStyleFromColors(colors);
+    return {
+      label: name,
+      value: name,
+      style
+    };
+  });
 
   let colorRampStyle;
   if (colorRamp) {
@@ -90,11 +83,12 @@ export const ColorRampCombo: React.FC<ColorRampComboProps> = ({
       className="gs-color-ramp-select"
       style={colorRampStyle}
       placeholder={locale.colorRampPlaceholder}
-      optionFilterProp="children"
+      showSearch={{
+        optionFilterProp: 'children'
+      }}
+      options={colorRampOptions}
       value={colorRamp}
       onChange={onChange}
-    >
-      {colorRampOptions}
-    </Select>
+    />
   );
 };

--- a/src/Component/RuleGenerator/ColorSpaceCombo/ColorSpaceCombo.tsx
+++ b/src/Component/RuleGenerator/ColorSpaceCombo/ColorSpaceCombo.tsx
@@ -55,27 +55,22 @@ export const ColorSpaceCombo: React.FC<ColorSpaceComboProps> = ({
   const locale = useGeoStylerLocale('ColorSpaceCombo');
 
   const colorSpaceOptions = colorSpaces.map((cSpace: InterpolationMode) => {
-    return (
-      <Select.Option
-        className="color-space-option"
-        key={cSpace}
-        value={cSpace}
-      >
-        {cSpace.toUpperCase()}
-      </Select.Option>
-    );
+    return {
+      label: cSpace.toUpperCase(),
+      value: cSpace
+    };
   });
-
 
   return (
     <Select
       className="color-space-select"
       placeholder={locale.colorSpacePlaceholder}
-      optionFilterProp="children"
+      showSearch={{
+        optionFilterProp: 'children'
+      }}
+      options={colorSpaceOptions}
       value={colorSpace}
       onChange={onChange}
-    >
-      {colorSpaceOptions}
-    </Select>
+    />
   );
 };

--- a/src/Component/ScaleDenominator/InputScaleDenominator.tsx
+++ b/src/Component/ScaleDenominator/InputScaleDenominator.tsx
@@ -99,7 +99,7 @@ export const InputScaleDenominator: React.FC<InputScaleDenominatorProps> = ({
               name="min-scale-denominator"
             >
               <InputNumber
-                addonBefore={'1: '}
+                prefix="1: "
                 controls={false}
                 value={minValue}
                 min={0}
@@ -127,7 +127,7 @@ export const InputScaleDenominator: React.FC<InputScaleDenominatorProps> = ({
               ]}
             >
               <InputNumber
-                addonBefore={'1: '}
+                prefix="1: "
                 controls={false}
                 value={maxValue}
                 min={0}

--- a/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.spec.tsx
+++ b/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.spec.tsx
@@ -36,12 +36,8 @@ import { vi } from 'vitest';
 vi.mock('antd', async (importOriginal) => {
   const antd = await importOriginal();
 
-  const Select = ({ children, onChange }: {children: React.ReactElement; onChange: (value: any) => void}) => {
+  const Select = ({ children, onChange }: { children: React.ReactElement; onChange: (value: any) => void }) => {
     return <select onChange={e => onChange(e.target.value)}>{children}</select>;
-  };
-
-  Select.Option = ({ children, ...otherProps }: {children: React.ReactElement}) => {
-    return <option {...otherProps}>{children}</option>;
   };
 
   return {

--- a/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
+++ b/src/Component/Symbolizer/ColorMapEditor/ColorMapEditor.tsx
@@ -380,7 +380,7 @@ export const ColorMapEditor: React.FC<ColorMapEditorProps> = (props) => {
             columns={columns}
             dataSource={colorMapRecords}
             pagination={{
-              position: ['bottomCenter']
+              placement: ['bottomCenter']
             }}
             size="small"
           />

--- a/src/Component/Symbolizer/Field/ContrastEnhancementField/ContrastEnhancementField.tsx
+++ b/src/Component/Symbolizer/Field/ContrastEnhancementField/ContrastEnhancementField.tsx
@@ -31,7 +31,6 @@ import React from 'react';
 import {
   Select
 } from 'antd';
-const Option = Select.Option;
 
 import {
   ContrastEnhancement, isGeoStylerFunction
@@ -53,30 +52,23 @@ export const ContrastEnhancementField: React.FC<ContrastEnhancementFieldProps> =
   value
 }) => {
 
-  const getContrastEnhancementSelectOptions = () => {
-    return contrastEnhancementOptions.map(contrastEnhancementOpt => {
-      if (isGeoStylerFunction(contrastEnhancementOpt)) {
-        contrastEnhancementOpt = FunctionUtil.evaluateFunction(contrastEnhancementOpt) as ('normalize' | 'histogram');
-      }
-      return (
-        <Option
-          key={contrastEnhancementOpt}
-          value={contrastEnhancementOpt}
-        >
-          {contrastEnhancementOpt}
-        </Option>
-      );
-    });
-  };
+  const contrastSelectOptiopns = contrastEnhancementOptions.map(contrastEnhancementOpt => {
+    if (isGeoStylerFunction(contrastEnhancementOpt)) {
+      contrastEnhancementOpt = FunctionUtil.evaluateFunction(contrastEnhancementOpt) as ('normalize' | 'histogram');
+    }
+    return {
+      label: contrastEnhancementOpt,
+      value: contrastEnhancementOpt
+    };
+  });
 
   return (
     <Select
       className="editor-field contrastEnhancement-field"
       allowClear={true}
       value={value}
+      options={contrastSelectOptiopns}
       onChange={onChange}
-    >
-      {getContrastEnhancementSelectOptions()}
-    </Select>
+    />
   );
 };

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.css
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.css
@@ -1,0 +1,3 @@
+.graphictype-field {
+  min-width: 120px;
+}

--- a/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
+++ b/src/Component/Symbolizer/Field/GraphicTypeField/GraphicTypeField.tsx
@@ -33,7 +33,7 @@ import { GraphicType } from 'geostyler-style';
 
 import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStylerContext';
 
-const Option = Select.Option;
+import './GraphicTypeField.css';
 
 export interface GraphicTypeFieldProps {
   /** List of selectable GraphicTypes for Select */
@@ -59,14 +59,10 @@ export const GraphicTypeField: React.FC<GraphicTypeFieldProps> = ({
 
   const typeSelectOptions = graphicTypes.map((type: GraphicType) => {
     const loc = locale?.[type] || type;
-    return (
-      <Option
-        key={type}
-        value={type}
-      >
-        {loc}
-      </Option>
-    );
+    return {
+      label: loc,
+      value: type
+    };
   });
 
   return (
@@ -75,9 +71,8 @@ export const GraphicTypeField: React.FC<GraphicTypeFieldProps> = ({
       value={value}
       onChange={onChange}
       allowClear={clearable}
+      options={typeSelectOptions}
       {...passThroughProps}
-    >
-      {typeSelectOptions}
-    </Select>
+    />
   );
 };

--- a/src/Component/Symbolizer/Field/KindField/KindField.css
+++ b/src/Component/Symbolizer/Field/KindField/KindField.css
@@ -1,0 +1,3 @@
+.kind-field {
+  min-width: 120px;
+}

--- a/src/Component/Symbolizer/Field/KindField/KindField.example.md
+++ b/src/Component/Symbolizer/Field/KindField/KindField.example.md
@@ -31,40 +31,14 @@
 This demonstrates the use of `KindField`.
 
 ```jsx
-import React from 'react';
-import { KindField } from 'geostyler';
+import React from "react";
+import { KindField } from "geostyler";
 
-class KindFieldExample extends React.Component {
-  constructor(props) {
-    super(props);
+const KindFieldExample = () => {
+  const [value, setValue] = React.useState("Mark");
 
-    this.state = {
-      kind: 'Mark'
-    };
+  return <KindField value={value} onChange={setValue} />;
+};
 
-    this.onChange = this.onChange.bind(this);
-  }
-
-  onChange(kind) {
-    this.setState({
-      kind: kind
-    });
-  }
-
-  render() {
-    const {
-      kind
-    } = this.state;
-
-    return (
-      <KindField
-        kind={kind}
-        symbolizerKinds={['Mark', 'Fill', 'Line', 'Icon', 'Text']}
-        onChange={this.onChange}
-      />
-    );
-  }
-}
-
-<KindFieldExample />
+<KindFieldExample />;
 ```

--- a/src/Component/Symbolizer/Field/KindField/KindField.tsx
+++ b/src/Component/Symbolizer/Field/KindField/KindField.tsx
@@ -34,7 +34,7 @@ import {
 import { SymbolizerKind } from 'geostyler-style';
 import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStylerContext';
 
-const Option = Select.Option;
+import './KindField.css';
 
 export interface KindFieldProps {
   value?: SymbolizerKind;
@@ -53,22 +53,19 @@ export const KindField: React.FC<KindFieldProps> = ({
 
   const locale = useGeoStylerLocale('KindField');
 
-  const kindSelectOptions = symbolizerKinds.map(symbolizerKind =>
-    <Option
-      key={symbolizerKind}
-      value={symbolizerKind}
-    >
-      {locale.symbolizerKinds?.[symbolizerKind] || symbolizerKind}
-    </Option>
-  );
+  const kindSelectOptions = symbolizerKinds.map(symbolizerKind => {
+    return {
+      label: locale.symbolizerKinds?.[symbolizerKind] || symbolizerKind,
+      value: symbolizerKind
+    };
+  });
 
   return (
     <Select
       className="editor-field kind-field"
       value={value}
       onChange={onChange}
-    >
-      {kindSelectOptions}
-    </Select>
+      options={kindSelectOptions}
+    />
   );
 };

--- a/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.css
+++ b/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.css
@@ -1,0 +1,3 @@
+.resampling-field {
+  min-width: 120px;
+}

--- a/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.tsx
+++ b/src/Component/Symbolizer/Field/ResamplingField/ResamplingField.tsx
@@ -31,12 +31,13 @@ import React from 'react';
 import {
   Select
 } from 'antd';
-const Option = Select.Option;
 
 import {
   RasterSymbolizer, isGeoStylerFunction
 } from 'geostyler-style';
 import FunctionUtil from '../../../../Util/FunctionUtil';
+
+import './ResamplingField.css';
 
 export interface ResamplingFieldProps {
   onChange?: (resamplings: RasterSymbolizer['resampling']) => void;
@@ -48,7 +49,7 @@ export interface ResamplingFieldProps {
  * ResamplingField to select between different resampling options
  */
 export const ResamplingField: React.FC<ResamplingFieldProps> = ({
-  resamplingOptions =['linear', 'nearest'],
+  resamplingOptions = ['linear', 'nearest'],
   onChange,
   value
 }) => {
@@ -57,14 +58,10 @@ export const ResamplingField: React.FC<ResamplingFieldProps> = ({
     if (isGeoStylerFunction(resamplingOpt)) {
       resamplingOpt = FunctionUtil.evaluateFunction(resamplingOpt) as ('linear' | 'nearest');
     }
-    return (
-      <Option
-        key={resamplingOpt}
-        value={resamplingOpt}
-      >
-        {resamplingOpt}
-      </Option>
-    );
+    return {
+      label: resamplingOpt,
+      value: resamplingOpt
+    };
   });
 
   return (
@@ -73,8 +70,7 @@ export const ResamplingField: React.FC<ResamplingFieldProps> = ({
       allowClear={true}
       value={value}
       onChange={onChange}
-    >
-      {resamplingSelectOptions}
-    </Select>
+      options={resamplingSelectOptions}
+    />
   );
 };

--- a/src/Component/Symbolizer/Field/SourceChannelNameField/SourceChannelNameField.tsx
+++ b/src/Component/Symbolizer/Field/SourceChannelNameField/SourceChannelNameField.tsx
@@ -32,7 +32,6 @@ import {
   Input,
   Select
 } from 'antd';
-const Option = Select.Option;
 
 export interface SourceChannelNameFieldProps {
   placeholder?: string;
@@ -51,18 +50,12 @@ export const SourceChannelNameField: React.FC<SourceChannelNameFieldProps> = ({
   placeholder = 'Name of band'
 }) => {
 
-  const getSourceChannelNameSelectOptions = () => {
-    return sourceChannelNames.map(name => {
-      return (
-        <Option
-          key={name}
-          value={name}
-        >
-          {name}
-        </Option>
-      );
-    });
-  };
+  const sourceChannelNameOptions = sourceChannelNames.map(name => {
+    return {
+      label: name,
+      value: name
+    };
+  });
 
   return (
     <div>
@@ -73,9 +66,8 @@ export const SourceChannelNameField: React.FC<SourceChannelNameFieldProps> = ({
               className="editor-field sourceChannelName-field"
               value={value}
               onChange={onChange}
-            >
-              {getSourceChannelNameSelectOptions()}
-            </Select>
+              options={sourceChannelNameOptions}
+            />
           ) : (
             <Input
               className="editor-field sourceChannelName-field"

--- a/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
+++ b/src/Component/Symbolizer/Field/WellKnownNameField/WellKnownNameField.tsx
@@ -35,7 +35,6 @@ import { WellKnownName } from 'geostyler-style';
 
 import _get from 'lodash-es/get.js';
 import { useGeoStylerLocale } from '../../../../context/GeoStylerContext/GeoStylerContext';
-const Option = Select.Option;
 
 export interface WellKnownNameFieldProps {
   value?: WellKnownName;
@@ -57,28 +56,21 @@ export const WellKnownNameField: React.FC<WellKnownNameFieldProps> = ({
 
   const locale = useGeoStylerLocale('WellKnownNameField');
 
-  const getWKNSelectOptions = () => {
-    return wellKnownNames.map(name => {
-      // if locales are not available, set Option text to name value
-      const loc = _get(locale, 'wellKnownNames[' + name + ']') || name;
-      return (
-        <Option
-          key={name}
-          value={name}
-        >
-          {loc}
-        </Option>
-      );
-    });
-  };
+  const wknSelectOptions = wellKnownNames.map(name => {
+    // if locales are not available, set Option text to name value
+    const loc = _get(locale, 'wellKnownNames[' + name + ']') || name;
+    return {
+      label: loc,
+      value: name
+    };
+  });
 
   return (
     <Select
       className="editor-field wellknownname-field"
       value={value}
       onChange={onChange}
-    >
-      {getWKNSelectOptions()}
-    </Select>
+      options={wknSelectOptions}
+    />
   );
 };

--- a/src/Component/Symbolizer/IconSelector/IconSelector.tsx
+++ b/src/Component/Symbolizer/IconSelector/IconSelector.tsx
@@ -33,7 +33,6 @@ import {
   Card,
   Select
 } from 'antd';
-const Option = Select.Option;
 
 import './IconSelector.css';
 
@@ -61,7 +60,7 @@ export interface IconSelectorProps {
 export const IconSelector: React.FC<IconSelectorProps & Pick<IconEditorComposableProps, 'iconLibraries'>> = (props) => {
 
   const composition = useGeoStylerComposition('IconEditor');
-  const composed = {...props, ...composition};
+  const composed = { ...props, ...composition };
 
   const {
     iconLibraries = [],
@@ -147,6 +146,13 @@ export const IconSelector: React.FC<IconSelectorProps & Pick<IconEditorComposabl
     );
   };
 
+  const librarySelectOptions = iconLibraries.map((lib: IconLibrary, index: number) => {
+    return {
+      label: lib.name,
+      value: index
+    };
+  });
+
   return (
     <div className="gs-icon-selector">
       <div className="gs-lib-row">
@@ -156,15 +162,8 @@ export const IconSelector: React.FC<IconSelectorProps & Pick<IconEditorComposabl
           allowClear={false}
           defaultValue={selectedLibIndex}
           onChange={onLibChange}
-        >
-          {
-            iconLibraries.map((lib: IconLibrary, index: number) => {
-              return (
-                <Option value={index} key={index.toString()}>{lib.name}</Option>
-              );
-            })
-          }
-        </Select>
+          options={librarySelectOptions}
+        />
       </div>
       <Card className="gs-icon-selector-card">
         {

--- a/src/Component/Symbolizer/MarkEditor/MarkEditor.spec.tsx
+++ b/src/Component/Symbolizer/MarkEditor/MarkEditor.spec.tsx
@@ -35,12 +35,8 @@ import { vi } from 'vitest';
 vi.mock('antd', async (original) => {
   const antd = await original();
 
-  const Select = ({ children, onChange }: {children: React.ReactElement; onChange: (value: any) => void}) => {
+  const Select = ({ children, onChange }: { children: React.ReactElement; onChange: (value: any) => void }) => {
     return <select onChange={e => onChange(e.target.value)}>{children}</select>;
-  };
-
-  Select.Option = ({ children, ...otherProps }: {children: React.ReactElement}) => {
-    return <option {...otherProps}>{children}</option>;
   };
 
   return {
@@ -53,7 +49,7 @@ describe('MarkEditor', () => {
 
   const dummySymbolizer: MarkSymbolizer = SymbolizerUtil.generateSymbolizer('Mark') as MarkSymbolizer;
   const props: MarkEditorProps = {
-    symbolizer:dummySymbolizer,
+    symbolizer: dummySymbolizer,
     onSymbolizerChange: vi.fn(),
   };
 
@@ -69,10 +65,10 @@ describe('MarkEditor', () => {
   describe('onWellKnownNameChange', () => {
     it('calls the onSymbolizerChange prop with correct symbolizer ', async () => {
       const markEditor = render(<MarkEditor {...props} />);
-      const newSymbolizer = {...props.symbolizer};
+      const newSymbolizer = { ...props.symbolizer };
       newSymbolizer.wellKnownName = 'square';
       const input = markEditor.container.querySelector('select');
-      await act(async() => {
+      await act(async () => {
         fireEvent.change(input!, {
           target: { value: 'square' }
         });

--- a/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
+++ b/src/Component/Symbolizer/MultiEditor/MultiEditor.tsx
@@ -43,8 +43,6 @@ import { Editor } from '../Editor/Editor';
 import SymbolizerUtil from '../../../Util/SymbolizerUtil';
 import { IconLibrary } from '../IconSelector/IconSelector';
 
-import { Tab } from 'rc-tabs/lib/interface';
-
 export interface MultiEditorProps {
   editorProps?: any;
   symbolizers: Symbolizer[];
@@ -101,7 +99,7 @@ export const MultiEditor: React.FC<MultiEditorProps> = ({
     }
   };
 
-  const tabs: Tab[] = symbolizers.map((symbolizer: Symbolizer, idx: number) => {
+  const tabs = symbolizers.map((symbolizer: Symbolizer, idx: number) => {
     return {
       className: 'gs-symbolizer-multi-editor-tab',
       key: idx.toString(),

--- a/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
+++ b/src/Component/Symbolizer/RasterChannelEditor/RasterChannelEditor.tsx
@@ -33,7 +33,6 @@ import {
   Select,
   Tabs
 } from 'antd';
-const Option = Select.Option;
 
 import {
   ChannelSelection,
@@ -163,16 +162,11 @@ export const RasterChannelEditor: React.FC<RasterChannelEditorProps> = (props) =
               allowClear={true}
               value={rgbOrGray}
               onChange={onSelectionChange}
-            >
-              <Option
-                key="rgb"
-                value="rgb"
-              >{locale.channelSelectionRgbLabel}</Option>
-              <Option
-                key="gray"
-                value="gray"
-              >{locale.channelSelectionGrayLabel}</Option>
-            </Select>
+              options={[
+                { label: locale.channelSelectionRgbLabel, value: 'rgb' },
+                { label: locale.channelSelectionGrayLabel, value: 'gray' }
+              ]}
+            />
           </Form.Item>
         )
       }

--- a/src/Component/Symbolizer/SLDUnitsSelect/SLDUnitsSelect.tsx
+++ b/src/Component/Symbolizer/SLDUnitsSelect/SLDUnitsSelect.tsx
@@ -27,7 +27,6 @@
  */
 
 import { Select } from 'antd';
-const Option = Select.Option;
 import React, { useState } from 'react';
 
 import './SLDUnitsSelect.css';
@@ -65,11 +64,12 @@ export const SLDUnitsSelect: React.FC<SLDUnitsSelectProps> = ({
         style={{ width: 100 }}
         onSelect={unitsChanged}
         value={symbolizerUnit}
-      >
-        <Option value="pixel">{locale.symbolizerUnitsPixel}</Option>
-        <Option value="metre">{locale.symbolizerUnitsMeter}</Option>
-        <Option value="foot">{locale.symbolizerUnitsFoot}</Option>
-      </Select>
+        options={[
+          { label: locale.symbolizerUnitsPixel, value: 'pixel' },
+          { label: locale.symbolizerUnitsMeter, value: 'metre' },
+          { label: locale.symbolizerUnitsFoot, value: 'foot' }
+        ]}
+      />
     </>
   );
 };


### PR DESCRIPTION
Update Ant Design to version 6 and refactor deprecated components according to the official migration guide. Adjustments include changes to component properties and styles to align with the new version. No breaking changes introduced.

