### PR TITLE
Add support for between filter

### DIFF
--- a/src/Component/FilterOverview/FilterOverview.example.md
+++ b/src/Component/FilterOverview/FilterOverview.example.md
@@ -35,7 +35,13 @@ import React from "react";
 import { FilterOverview } from "geostyler";
 
 function FilterOverviewExample() {
-  const filter = ["&&", ["==", "foo", "bar"], ["!=", "faz", "baz"]];
+  const filter = [
+    "&&",
+    ["==", "state", "germany"],
+    ["<=x<=", "population", 100000, 200000],
+    ["||", [">=", "population", 100000], ["<", "population", 200000]],
+    ["!", ["==", "name", "Schalke"]],
+  ];
 
   return (
     <div>

--- a/src/Component/FilterOverview/FilterOverview.tsx
+++ b/src/Component/FilterOverview/FilterOverview.tsx
@@ -49,7 +49,7 @@ export interface FilterOverviewProps {
 
 export const FilterOverview: React.FC<FilterOverviewProps> = ({
   filter,
-  onEditFilterClick = () => {}
+  onEditFilterClick = () => { }
 }) => {
 
   const locale = useGeoStylerLocale('FilterOverview');
@@ -69,8 +69,7 @@ export const FilterOverview: React.FC<FilterOverviewProps> = ({
             treeData={treeData}
             defaultExpandAll
             selectable={false}
-            showLine={{showLeafIcon: false}}
-            switcherIcon={<div></div>}
+            showLine={{ showLeafIcon: false }}
             onClick={onEditFilterClick}
           />
         ) : (

--- a/src/Util/FilterUtil.spec.ts
+++ b/src/Util/FilterUtil.spec.ts
@@ -38,6 +38,233 @@ describe('FilterUtil', () => {
     filter = TestUtil.getDummyGsFilter();
   });
 
+  describe('handleSimpleFilter', () => {
+    const dummyData = TestUtil.getComplexGsDummyData();
+    const feature = dummyData.exampleFeatures.features[0];
+
+    describe('equality operator (==)', () => {
+      it('returns true when values are equal', () => {
+        feature.properties.name = 'Berlin';
+        const simpleFilter: Filter = ['==', 'name', 'Berlin'];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns false when values are not equal', () => {
+        feature.properties.name = 'Berlin';
+        const simpleFilter: Filter = ['==', 'name', 'Munich'];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+
+      it('works with numeric values', () => {
+        feature.properties.population = 100000;
+        const simpleFilter: Filter = ['==', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('inequality operator (!=)', () => {
+      it('returns true when values are not equal', () => {
+        feature.properties.name = 'Berlin';
+        const simpleFilter: Filter = ['!=', 'name', 'Munich'];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns false when values are equal', () => {
+        feature.properties.name = 'Berlin';
+        const simpleFilter: Filter = ['!=', 'name', 'Berlin'];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('contains operator (*=)', () => {
+      it('returns true when value contains substring', () => {
+        feature.properties.name = 'Berlin City';
+        const simpleFilter: Filter = ['*=', 'name', 'Berlin'];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns false when value does not contain substring', () => {
+        feature.properties.name = 'Munich';
+        const simpleFilter: Filter = ['*=', 'name', 'Berlin'];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+
+      it('returns false when substring is longer than value', () => {
+        feature.properties.name = 'Ber';
+        const simpleFilter: Filter = ['*=', 'name', 'Berlin'];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+
+      it('returns false when value is undefined', () => {
+        feature.properties.name = undefined;
+        const simpleFilter: Filter = ['*=', 'name', 'Berlin'];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('less than operator (<)', () => {
+      it('returns true when value is less than filter value', () => {
+        feature.properties.population = 50000;
+        const simpleFilter: Filter = ['<', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns false when value is equal to filter value', () => {
+        feature.properties.population = 100000;
+        const simpleFilter: Filter = ['<', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+
+      it('returns false when value is greater than filter value', () => {
+        feature.properties.population = 150000;
+        const simpleFilter: Filter = ['<', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('less than or equal operator (<=)', () => {
+      it('returns true when value is less than filter value', () => {
+        feature.properties.population = 50000;
+        const simpleFilter: Filter = ['<=', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns true when value equals filter value', () => {
+        feature.properties.population = 100000;
+        const simpleFilter: Filter = ['<=', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns false when value is greater than filter value', () => {
+        feature.properties.population = 150000;
+        const simpleFilter: Filter = ['<=', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('greater than operator (>)', () => {
+      it('returns true when value is greater than filter value', () => {
+        feature.properties.population = 150000;
+        const simpleFilter: Filter = ['>', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns false when value is equal to filter value', () => {
+        feature.properties.population = 100000;
+        const simpleFilter: Filter = ['>', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+
+      it('returns false when value is less than filter value', () => {
+        feature.properties.population = 50000;
+        const simpleFilter: Filter = ['>', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('greater than or equal operator (>=)', () => {
+      it('returns true when value is greater than filter value', () => {
+        feature.properties.population = 150000;
+        const simpleFilter: Filter = ['>=', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns true when value equals filter value', () => {
+        feature.properties.population = 100000;
+        const simpleFilter: Filter = ['>=', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns false when value is less than filter value', () => {
+        feature.properties.population = 50000;
+        const simpleFilter: Filter = ['>=', 'population', 100000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('between operator (<=x<=)', () => {
+      it('returns true when value is within range', () => {
+        feature.properties.population = 150000;
+        const simpleFilter: Filter = ['<=x<=', 'population', 100000, 200000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns true when value equals lower boundary', () => {
+        feature.properties.population = 100000;
+        const simpleFilter: Filter = ['<=x<=', 'population', 100000, 200000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns true when value equals upper boundary', () => {
+        feature.properties.population = 200000;
+        const simpleFilter: Filter = ['<=x<=', 'population', 100000, 200000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('returns false when value is below lower boundary', () => {
+        feature.properties.population = 50000;
+        const simpleFilter: Filter = ['<=x<=', 'population', 100000, 200000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+
+      it('returns false when value is above upper boundary', () => {
+        feature.properties.population = 300000;
+        const simpleFilter: Filter = ['<=x<=', 'population', 100000, 200000];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(false);
+      });
+
+      it('works with decimal values', () => {
+        feature.properties.temperature = 23.5;
+        const simpleFilter: Filter = ['<=x<=', 'temperature', 20.0, 25.0];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+
+      it('works with negative values', () => {
+        feature.properties.altitude = -5;
+        const simpleFilter: Filter = ['<=x<=', 'altitude', -10, 0];
+        const result = FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        expect(result).toBe(true);
+      });
+    });
+
+    describe('unknown operator', () => {
+      it('throws an error for unknown comparison operator', () => {
+        feature.properties.name = 'Berlin';
+        const simpleFilter: any = ['~=', 'name', 'Berlin'];
+        expect(() => {
+          FilterUtil.handleSimpleFilter(simpleFilter, feature);
+        }).toThrow('Cannot parse Filter. Unknown comparison operator.');
+      });
+    });
+  });
+
   describe('featureMatchesFilter', () => {
     it('returns true if a feature matches the filter', () => {
       const dummyData = TestUtil.getComplexGsDummyData();

--- a/src/Util/FilterUtil.ts
+++ b/src/Util/FilterUtil.ts
@@ -126,6 +126,8 @@ class FilterUtil {
         return (parseFloat(featureValue) > Number(filterValue));
       case '>=':
         return (parseFloat(featureValue) >= Number(filterValue));
+      case '<=x<=':
+        return (parseFloat(featureValue) >= Number(filter[2]) && parseFloat(featureValue) <= Number(filter[3]));
       default:
         throw new Error('Cannot parse Filter. Unknown comparison operator.');
     }
@@ -333,7 +335,7 @@ class FilterUtil {
    */
   static addFilter(rootFilter: Filter, position: string, type: string) {
 
-    let addedFilter: Filter ;
+    let addedFilter: Filter;
     let newFilter: Filter = structuredClone(rootFilter);
 
     switch (type) {
@@ -379,7 +381,7 @@ class FilterUtil {
 
     switch (type) {
       case 'and':
-        if (previousFilter && (previousFilter[0] === '&&' || previousFilter[0] === '||' )) {
+        if (previousFilter && (previousFilter[0] === '&&' || previousFilter[0] === '||')) {
           addedFilter = previousFilter;
           if (!Array.isArray(addedFilter)) {
             throw new Error('Cannot change filter. Filter is not an array.');
@@ -390,7 +392,7 @@ class FilterUtil {
         }
         break;
       case 'or':
-        if (previousFilter && (previousFilter[0] === '&&' || previousFilter[0] === '||' )) {
+        if (previousFilter && (previousFilter[0] === '&&' || previousFilter[0] === '||')) {
           addedFilter = previousFilter;
           if (!Array.isArray(addedFilter)) {
             throw new Error('Cannot change filter. Filter is not an array.');
@@ -461,7 +463,11 @@ class FilterUtil {
     const filterClone = structuredClone(filter);
     const operator = filterClone.shift();
     if (isComparisonOperator(operator)) {
-      tree.title = `${filterClone[0]} ${operator} ${filterClone[1]}`;
+      if (operator === '<=x<=') {
+        tree.title = `${filterClone[1]} <= ${filterClone[0]} <= ${filterClone[2]}`;
+      } else {
+        tree.title = `${filterClone[0]} ${operator} ${filterClone[1]}`;
+      }
     } else if (isCombinationOperator(operator)) {
       tree.title = operator;
       tree.children = filterClone.map((f: any) => {


### PR DESCRIPTION
Introduce support for the between filter in the filtering utility and update the FilterOverview example to demonstrate its usage.

## Preview

<img width="949" height="348" alt="image" src="https://github.com/user-attachments/assets/dd524f32-7c9a-4102-9da0-fac850c18ada" />


Fixes #2659

