### PR TITLE
Add min-width to ColorPreview

### DIFF
--- a/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.css
+++ b/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.css
@@ -27,6 +27,7 @@
  */
 
 .colors-preview {
-  height: 30px;
+  min-height: 30px;
+  min-width: 100px;
   border-radius: 4px;
 }

--- a/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.tsx
+++ b/src/Component/RuleGenerator/ColorsPreview/ColorsPreview.tsx
@@ -50,6 +50,8 @@ export const ColorsPreview: React.FC<ColorsPreviewProps> = ({
     <div
       className="colors-preview"
       style={style}
-    />
+    >
+
+    </div>
   );
 };


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This fixes the broken ColorPreview #2739 by adding a min-width and min-height.


<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

