### PR TITLE
Allow autoselect fields for numeric properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,51 @@
       );
       preview.render(gsPreview);
     };
-    const geostylerContext = {};
+    const geostylerContext = {
+      data: {
+        schema: {
+          title: 'DummyData',
+          type: 'object',
+          properties: {
+            value: {
+              type: 'number',
+              minimum: -100000,
+              maximum: 100000
+            },
+            name: {
+              type: 'string',
+            }
+          }
+        },
+        exampleFeatures: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              properties: {
+                name: 'Feature 1',
+                value: 1234
+              },
+              geometry: {
+                type: 'Point',
+                coordinates: [0, 0]
+              }
+            },
+            {
+              type: 'Feature',
+              properties: {
+                name: 'Feature 2',
+                value: 5678
+              },
+              geometry: {
+                type: 'Point',
+                coordinates: [1, 1]
+              }
+            }
+          ]
+        }
+      }
+    };
     const geostyler = React.createElement(
       GeoStylerContext.Provider,
       { value: geostylerContext },

--- a/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
+++ b/src/Component/Filter/ComparisonFilter/ComparisonFilter.tsx
@@ -283,6 +283,7 @@ export const ComparisonFilter: React.FC<ComparisonFilterProps> = (props) => {
       value={val}
       onValueChange={(newValue) => onValueChange(newValue, filterIndex)}
       validateStatus={validateStatus.value}
+      selectedAttribute={attribute}
     />;
   }
 

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.css
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.css
@@ -1,0 +1,5 @@
+.gs-number-filter-field {
+  .ant-select {
+    min-width: 10rem;
+  }
+}

--- a/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
+++ b/src/Component/Filter/NumberFilterField/NumberFilterField.tsx
@@ -27,8 +27,12 @@
  */
 
 import React from 'react';
-import { InputNumber, Form } from 'antd';
-import { useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
+import { InputNumber, Form, AutoComplete } from 'antd';
+import { useGeoStylerData, useGeoStylerLocale } from '../../../context/GeoStylerContext/GeoStylerContext';
+import { Feature } from 'geojson';
+import _get from 'lodash-es/get.js';
+
+import './NumberFilterField.css';
 
 export interface NumberFilterFieldProps {
   /** Initial value set to the field */
@@ -38,6 +42,8 @@ export interface NumberFilterFieldProps {
   /** Callback for onChange */
   onValueChange?: ((newValue: number) => void);
   size?: 'large' | 'middle' | 'small';
+  /** The selected attribute name */
+  selectedAttribute?: string;
 }
 
 /**
@@ -47,12 +53,31 @@ export const NumberFilterField: React.FC<NumberFilterFieldProps> = ({
   value,
   validateStatus = 'success',
   onValueChange,
-  size
+  size,
+  selectedAttribute
 }) => {
+  const data = useGeoStylerData();
 
   const locale = useGeoStylerLocale('NumberFilterField');
 
   const helpTxt = validateStatus !== 'success' ? locale.help : null;
+
+  const onAutoCompleteChange = (text: string) => {
+    if (onValueChange) {
+      onValueChange(Number(text));
+    }
+  };
+
+  const sampleValues: string[] = [];
+  if (data && 'exampleFeatures' in data) {
+    const features = data?.exampleFeatures?.features;
+    features.forEach((feature: Feature) => {
+      const sampleValue = _get(feature, `properties[${selectedAttribute}]`);
+      if (sampleValue && sampleValues.indexOf(sampleValue) === -1) {
+        sampleValues.push(`${sampleValue}`);
+      }
+    });
+  }
 
   return (
     <div
@@ -67,13 +92,24 @@ export const NumberFilterField: React.FC<NumberFilterFieldProps> = ({
         help={helpTxt}
         hasFeedback={true}
       >
-        <InputNumber
-          size={size}
-          defaultValue={value}
-          value={value}
-          onChange={onValueChange}
-          placeholder={locale.placeholder}
-        />
+        {
+          sampleValues.length > 0 ?
+            <AutoComplete
+              size={size}
+              value={`${value || ''}`}
+              onChange={onAutoCompleteChange}
+              placeholder={locale.placeholder}
+              options={sampleValues.map((val) => ({ value: val }))}
+            />
+            :
+            <InputNumber
+              size={size}
+              defaultValue={value}
+              value={value}
+              onChange={onValueChange}
+              placeholder={locale.placeholder}
+            />
+        }
       </Form.Item>
     </div>
   );


### PR DESCRIPTION
## Description

On first glance, the autoselect feature does not make sense for numberic fields. However, often numeric codes are used with codelists for eg. categories etc., where this could be a useful feature.

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

