### PR TITLE
fix: properly handle undefined in CardStyle else-rule

### DIFF
--- a/src/Component/Symbolizer/Field/ElseRuleField/ElseRuleField.tsx
+++ b/src/Component/Symbolizer/Field/ElseRuleField/ElseRuleField.tsx
@@ -56,7 +56,7 @@ export const ElseRuleField: React.FC<ElseRuleFieldProps> = ({
   return (
     <span className="editor-field gs-elserule-field">
       <Switch
-        checked={value === undefined ? true : value}
+        checked={value === undefined ? false : value}
         onChange={(checked) => {
           onChange?.(checked);
         }}


### PR DESCRIPTION
<!--
Thank you for considering giving code and/or documentation back to this project, you're awesome and we appreciate your work.
Please review the CONTRIBUTING.md and the CODE_OF_CONDUCT.md of this repository.
This makes it easy for you to give back and for us to accept your changes.

Comments in this file can be left untouched an will not appear in the Pull Request.
-->
## Description

This fixes the default value for the else-rule checkbox in the cardstyle. If else-rule was undefined, the checkbox was set to active, whereas it should have been inactive. Now, the checkbox is inactive, if else-rule is unset.

<!--
- Please give a short description of the changes you propose. Please use prose and try not to be too technical, if possible.
- Should I link an issue or a pull request? -> #
- Should I mention some people? -> @
-->

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

